### PR TITLE
Adjustment to timing changes

### DIFF
--- a/NuRadioMC/examples/01_Veff_simulation/T02RunSimulation.py
+++ b/NuRadioMC/examples/01_Veff_simulation/T02RunSimulation.py
@@ -58,7 +58,6 @@ class mySimulation(simulation.simulation):
                                     threshold_low=-4 * self._Vrms,
                                     triggered_channels=[0, 1, 2, 3],  # select the LPDA channels
                                     number_concidences=2,  # 2/4 majority logic
-                                    cut_trace=False,
                                     trigger_name='LPDA_2of4_4.1sigma',
                                     set_not_triggered=(not self._station.has_triggered("simple_threshold"))) # calculate more time consuming ARIANNA trigger only if station passes simple trigger
         
@@ -68,7 +67,6 @@ class mySimulation(simulation.simulation):
                                     threshold_low=-3 * self._Vrms,
                                     triggered_channels=[4, 5, 6, 7], # select the bicone channels
                                     number_concidences=4, # 4/4 majority logic
-                                    cut_trace=False,
                                     trigger_name='surface_dipoles_4of4_3sigma',
                                     set_not_triggered=(not self._station.has_triggered("simple_threshold"))) # calculate more time consuming ARIANNA trigger only if station passes simple trigger
         

--- a/NuRadioMC/simulation/simulation2.py
+++ b/NuRadioMC/simulation/simulation2.py
@@ -110,6 +110,7 @@ class simulation():
         # read in detector positions
         logger.warning("Detectorfile {}".format(os.path.abspath(self._detectorfile)))
         self._det = detector.Detector(json_filename=self._detectorfile)
+        self._det.update(evt_time)
 
         self._station_ids = self._det.get_station_ids()
 
@@ -348,7 +349,7 @@ class simulation():
                             fig.subplots_adjust(top=0.9)
                             plt.show()
 
-                        electric_field = NuRadioReco.framework.electric_field.ElectricField([channel_id])
+                        electric_field = NuRadioReco.framework.electric_field.ElectricField([channel_id], self._det.get_relative_position(self._sim_station.get_id(), channel_id))
                         electric_field.set_frequency_spectrum(np.array([eR, eTheta, ePhi]), 1. / self._dt)
                         electric_field.set_trace_start_time(T)
                         electric_field[efp.azimuth] = azimuth


### PR DESCRIPTION
Changes necessary to work with the changes done to the timing in NuRadioReco:
- Sets the E-field positions to the positions of the channels they were simulated for
- Removes the cut_trace parameter in the trigger simulation calls from the example
- Sets the detector time to the event time (This should probably already have been done. I guess it worked before because the detector initialized to datetime.now() by default)