### PR TITLE
Auto compile raytracer

### DIFF
--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -23,16 +23,16 @@ try:
     print("using CPP version of ray tracer")
 except:
     print("trying to compile the CPP extension on-the-fly")
-    import subprocess
-    import os
-    subprocess.call(os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                                 "install.sh"))
     try:
+        import subprocess
+        import os
+        subprocess.call(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                 "install.sh"))
         from NuRadioMC.SignalProp.CPPAnalyticRayTracing import wrapper
         cpp_available = True
-        print("using CPP version of ray tracer")
+        print("compilation was sucessful, using CPP version of ray tracer")
     except:
-        print("using python version of ray tracer")
+        print("compilation was not sucessful, using python version of ray tracer")
         cpp_available = False
 
 """

--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -22,8 +22,18 @@ try:
     cpp_available = True
     print("using CPP version of ray tracer")
 except:
-    print("using python version of ray tracer")
-    cpp_available = False
+    print("trying to compile the CPP extension on-the-fly")
+    import subprocess
+    import os
+    subprocess.call(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                 "install.sh"))
+    try:
+        from NuRadioMC.SignalProp.CPPAnalyticRayTracing import wrapper
+        cpp_available = True
+        print("using CPP version of ray tracer")
+    except:
+        print("using python version of ray tracer")
+        cpp_available = False
 
 """
 analytic ray tracing solution

--- a/NuRadioMC/SignalProp/install.sh
+++ b/NuRadioMC/SignalProp/install.sh
@@ -1,0 +1,8 @@
+cd CPPAnalyticRayTracing
+rm wrapper.so  # first delete already existing module
+if [[ -z "${GSLDIR}" ]]; then
+	echo "GSLDIR environment variable undefined" 
+	echo "setting GSLDIR to " $(gsl-config --prefix)
+	export GSLDIR=$(gsl-config --prefix)
+fi
+python setup.py build_ext --inplace

--- a/NuRadioMC/SignalProp/install.sh
+++ b/NuRadioMC/SignalProp/install.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+cd "$(dirname "$0")"
 cd CPPAnalyticRayTracing
 rm wrapper.so  # first delete already existing module
 if [[ -z "${GSLDIR}" ]]; then


### PR DESCRIPTION
I added a install script that should simplify the installation of the Cpp ray tracer extension. 

I also coded that this script is executed everytime the ray tracer is loaded and the cpp version can't be found. I don't know if this is really what we want. If will certainly make things easier if it runs out-of-the box. But it might be annoying if for some reason we want to use the python version or if the compilation fails (then the user will get an error message everytime he loads the ray tracer). 

The user can still deactivate the cpp version via
```python
from NuRadioMC.SignalProp import analyticraytracing
analyticraytracing.cpp_available = False
```
but this is secret developer knowledge ;-) what do you think? 