### PR TITLE
add option to only simulate em or had showers

### DIFF
--- a/NuRadioMC/SignalGen/askaryan.py
+++ b/NuRadioMC/SignalGen/askaryan.py
@@ -63,6 +63,8 @@ def get_time_trace(energy, theta, N, dt, shower_type, n_index, R, model, interp_
         the complex amplitudes for the given frequencies
 
     """
+    if(energy == 0):
+        return np.zeros(N)
     if model in par.get_parametrizations():
         return par.get_time_trace(energy, theta, N, dt, shower_type, n_index, R, model)
     elif(model == 'HCRB2017'):

--- a/NuRadioMC/SignalGen/parametrizations.py
+++ b/NuRadioMC/SignalGen/parametrizations.py
@@ -103,6 +103,8 @@ def get_time_trace(energy, theta, N, dt, shower_type, n_index, R, model):
                 k_E_bar = k_E_0 * np.tanh( (np.log10(E_0/units.eV)-log10_E_E)/k_E_1 )
             elif (shower_type == 'EM'):
                 k_E_bar = 4.65e-16 * units.V / units.cm / units.MHz**2
+            else:
+                raise NotImplementedError("shower type {} is not implemented in Alvarez2009 model.".format(shower_type))
 
             return k_E_bar * E_0/E_C * X_0/rho * np.sin(theta) * freq
 
@@ -134,6 +136,8 @@ def get_time_trace(energy, theta, N, dt, shower_type, n_index, R, model):
                     log10_k_L_bar = log10_k_0 + gamma_1 * ( log10_E_0 - log10_E_LPM )
 
                 k_L = 10**np.random.normal(log10_k_L_bar, sigma_k_L)
+            else:
+                raise NotImplementedError("shower type {} is not implemented in Alvarez2009 model.".format(shower_type))
 
             nu_L = rho/k_L/X_0
 
@@ -151,6 +155,8 @@ def get_time_trace(energy, theta, N, dt, shower_type, n_index, R, model):
                 beta = 2.57
             elif (shower_type == "EM"):
                 beta = 2.74
+            else:
+                raise NotImplementedError("shower type {} is not implemented in Alvarez2009 model.".format(shower_type))
 
             return 1/(1+(freq/nu_L(E_0, theta))**beta)
 
@@ -163,6 +169,8 @@ def get_time_trace(energy, theta, N, dt, shower_type, n_index, R, model):
                 k_R_bar = k_R_0 + np.tanh( (log10_E_R-np.log10(E_0/units.eV))/k_R_1 )
             elif (shower_type == "EM"):
                 k_R_bar = 1.54
+            else:
+                raise NotImplementedError("shower type {} is not implemented in Alvarez2009 model.".format(shower_type))
             nu_R = rho/k_R_bar/R_M * c/np.sqrt(n_index**2-1)
 
             alpha = 1.27

--- a/NuRadioMC/simulation/config_default.yaml
+++ b/NuRadioMC/simulation/config_default.yaml
@@ -23,6 +23,7 @@ signal:
   zerosignal: False  # if True, the signal is set to zero. This is useful to study 'noise' only simulations
   polarization: auto # can be either 'auto' or 'custom'
   ePhi: 0.  # only used if 'polarization = custom', fraction of ePhi component, the eTheta component is eTheta = (1 - ePhi**2)**0.5
+  shower_type: null # optional argument to only simulate certain shower types. Arguments can be "had" or "em". 
 
 trigger:
   noise_temperature: 300  # in Kelvin

--- a/NuRadioMC/simulation/simulation2.py
+++ b/NuRadioMC/simulation/simulation2.py
@@ -172,6 +172,15 @@ class simulation():
             if not self._is_in_fiducial_volume():
                 logger.debug("event is not in fiducial volume, skipping simulation")
                 continue
+            
+            # for special cases where only EM showers are simulated, skip all events where not EM is present
+            # i.e. all first interactions that are not nu_e CC
+            if(self._cfg['signal']['shower_type'] == "em"):
+                if(self._inttype == "nc"):  # skip all neutral current interactions
+                    continue
+                else:
+                    if(self._inttype == "cc" and np.abs(self._flavor) != 12): # skip all cc interaction that are not electron neutrinos
+                        continue 
 
             # calculate weight
             # if we have a second interaction, the weight needs to be calculated from the initial neutrino
@@ -735,6 +744,12 @@ class simulation():
                 fhad = inelasticity
         else:
             raise AttributeError("interaction type {} with flavor {} is not implemented".format(inttype, flavor))
+        
+        if(self._cfg['signal']['shower_type'] is not None):
+            if(self._cfg['signal']['shower_type'] == "em"):
+                fhad = 0
+            if(self._cfg['signal']['shower_type'] == "had"):
+                fem = 0
         return fem, fhad
 
     # TODO verify that calculation of polarization vector is correct!


### PR DESCRIPTION
via an optional config argument, NuRadioMC can be forced to only simulate EM or HAD showers. The logic is the following:
if "em" is selected, hadronic showers are disabled, i.e. the hadronic shower energy is set to zero
if "had" is selected, em showers are disabled, i.e. the em shower energy is set to zero