### PR TITLE
new test for effective volume

### DIFF
--- a/NuRadioMC/EvtGen/generator.py
+++ b/NuRadioMC/EvtGen/generator.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 import numpy as np
+import NuRadioMC
 from NuRadioMC.utilities import units
 from NuRadioMC.utilities import inelasticities
+from NuRadioMC.utilities import version
 from six import iterkeys, iteritems
 from scipy import constants
 from scipy.integrate import quad
@@ -692,6 +694,12 @@ def generate_eventlist_cylinder(filename, n_events, Emin, Emax,
     """
     attributes = {}
     n_events = int(n_events)
+    
+    # save current NuRadioMC version as attribute
+    # save NuRadioMC and NuRadioReco versions
+    attributes['NuRadioMC_EvtGen_version'] = NuRadioMC.__version__
+    attributes['NuRadioMC_EvtGen_version_hash'] = version.get_NuRadioMC_commit_hash()
+    
     attributes['n_events'] = n_events
     attributes['start_event_id'] = start_event_id
 
@@ -741,8 +749,9 @@ def generate_eventlist_cylinder(filename, n_events, Emin, Emax,
     data_sets["zeniths"] = np.arccos(u)  # generates distribution that is uniform in cos(theta)
 
     rr_full = np.random.triangular(full_rmin, full_rmax, full_rmax, n_events)
-    data_sets["xx"] = rr_full * np.cos(data_sets["azimuths"])
-    data_sets["yy"] = rr_full * np.sin(data_sets["azimuths"])
+    phiphi = np.random.uniform(0, 2 * np.pi, n_events)
+    data_sets["xx"] = rr_full * np.cos(phiphi)
+    data_sets["yy"] = rr_full * np.sin(phiphi)
     data_sets["zz"] = np.random.uniform(full_zmin, full_zmax, n_events)
     fmask = (rr_full >= fiducial_rmin) & (rr_full <= fiducial_rmax) & (data_sets["zz"] >= fiducial_zmin) & (data_sets["zz"] <= fiducial_zmax)  # fiducial volume mask
 

--- a/NuRadioMC/simulation/simulation2.py
+++ b/NuRadioMC/simulation/simulation2.py
@@ -29,6 +29,20 @@ import os
 # import confuse
 logger = logging.getLogger("sim")
 
+def pretty_time_delta(seconds):
+    seconds = int(seconds)
+    days, seconds = divmod(seconds, 86400)
+    hours, seconds = divmod(seconds, 3600)
+    minutes, seconds = divmod(seconds, 60)
+    if days > 0:
+        return '%dd%dh%dm%ds' % (days, hours, minutes, seconds)
+    elif hours > 0:
+        return '%dh%dm%ds' % (hours, minutes, seconds)
+    elif minutes > 0:
+        return '%dm%ds' % (minutes, seconds)
+    else:
+        return '%ds' % (seconds,)
+
 
 def merge_config(user, default):
     if isinstance(user, dict) and isinstance(default, dict):
@@ -155,7 +169,7 @@ class simulation():
         for self._iE in range(self._n_events):
             t1 = time.time()
             if(self._iE > 0 and self._iE % max(1, int(self._n_events / 100.)) == 0):
-                eta = datetime.timedelta(seconds=(time.time() - t_start) * (self._n_events - self._iE) / self._iE)
+                eta = pretty_time_delta((time.time() - t_start) * (self._n_events - self._iE) / self._iE)
                 total_time = inputTime + rayTracingTime + detSimTime + outputTime
                 logger.warning("processing event {}/{} = {:.1f}%, ETA {}, time consumption: ray tracing = {:.0f}% (att. length {:.0f}%), askaryan = {:.0f}%, detector simulation = {:.0f}% reading input = {:.0f}%".format(
                     self._iE, self._n_events, 100. * self._iE / self._n_events, eta, 100. * (rayTracingTime - askaryan_time) / total_time,
@@ -407,12 +421,14 @@ class simulation():
             logger.error("error in calculating effective volume")
 
         t_total = time.time() - t_start
-        logger.warning("{:d} events processed in {:.0f} seconds = {:.2f}ms/event".format(self._n_events,
-                                                                                         t_total, 1.e3 * t_total / self._n_events))
-
         outputTime = time.time() - t5
-        print("inputTime = " + str(inputTime) + "\nrayTracingTime = " + str(rayTracingTime) +
-              "\ndetSimTime = " + str(detSimTime) + "\noutputTime = " + str(outputTime))
+        logger.warning("{:d} events processed in {} = {:.2f}ms/event ({:.1f}% input, {:.1f}% ray tracing, {:.1f}%, {:.1f}% askaryan, detector simulation, {:.1f}% output)".format(self._n_events,
+                                                                                         pretty_time_delta(t_total), 1.e3 * t_total / self._n_events,
+                                                                                         100 * inputTime/t_total,
+                                                                                         100 * rayTracingTime/t_total,
+                                                                                         100 *askaryan_time/t_total,
+                                                                                         100 * detSimTime/t_total,
+                                                                                         100 * outputTime/t_total))
 
     def _is_in_fiducial_volume(self):
         """

--- a/NuRadioMC/test/Veff/1e18eV/.gitignore
+++ b/NuRadioMC/test/Veff/1e18eV/.gitignore
@@ -1,0 +1,6 @@
+output.hdf5
+1e18_full.hdf5
+veff_scatter.png
+veff.txt
+T04evaluate_scatter.py
+plots

--- a/NuRadioMC/test/Veff/1e18eV/T01generate_event_list.py
+++ b/NuRadioMC/test/Veff/1e18eV/T01generate_event_list.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+from __future__ import absolute_import, division, print_function
+from NuRadioMC.utilities import units
+from NuRadioMC.EvtGen.generator import generate_eventlist_cylinder
+
+# define simulation volume
+zmin = -2.7 * units.km  # the ice sheet at South Pole is 2.7km deep
+zmax = 0 * units.km
+rmin = 0 * units.km
+rmax = 4 * units.km
+
+# generate one event list at 1e18 eV with 10000 neutrinos
+generate_eventlist_cylinder('1e18_full.hdf5', 5e4, 1e18 * units.eV, 1e18 * units.eV, rmin, rmax, zmin, zmax,
+                            full_rmin=rmin, full_rmax=rmax, full_zmin=zmin, full_zmax=zmax)

--- a/NuRadioMC/test/Veff/1e18eV/T02RunSimulation.py
+++ b/NuRadioMC/test/Veff/1e18eV/T02RunSimulation.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+from __future__ import absolute_import, division, print_function
+import argparse
+# import detector simulation modules
+import NuRadioReco.modules.efieldToVoltageConverter
+import NuRadioReco.modules.trigger.highLowThreshold
+import NuRadioReco.modules.trigger.simpleThreshold
+import NuRadioReco.modules.channelResampler
+import NuRadioReco.modules.channelBandPassFilter
+import NuRadioReco.modules.channelGenericNoiseAdder
+from NuRadioReco.utilities import units
+from NuRadioMC.simulation import simulation2 as simulation
+import logging
+logging.basicConfig(level=logging.WARNING)
+logger = logging.getLogger("runstrawman")
+
+# initialize detector sim modules
+efieldToVoltageConverter = NuRadioReco.modules.efieldToVoltageConverter.efieldToVoltageConverter()
+efieldToVoltageConverter.begin()
+triggerSimulatorHighLow = NuRadioReco.modules.trigger.highLowThreshold.triggerSimulator()
+triggerSimulatorSimple = NuRadioReco.modules.trigger.simpleThreshold.triggerSimulator()
+channelResampler = NuRadioReco.modules.channelResampler.channelResampler()
+channelBandPassFilter = NuRadioReco.modules.channelBandPassFilter.channelBandPassFilter()
+channelGenericNoiseAdder = NuRadioReco.modules.channelGenericNoiseAdder.channelGenericNoiseAdder()
+
+class mySimulation(simulation.simulation):
+
+
+    def _detector_simulation(self):
+        # start detector simulation
+        if(bool(self._cfg['signal']['zerosignal'])):
+            self._increase_signal(None, 0)
+
+        efieldToVoltageConverter.run(self._evt, self._station, self._det)  # convolve efield with antenna pattern
+        # downsample trace to internal simulation sampling rate (the efieldToVoltageConverter upsamples the trace to
+        # 20 GHz by default to achive a good time resolution when the two signals from the two signal paths are added)
+        channelResampler.run(self._evt, self._station, self._det, sampling_rate=1. / self._dt)
+
+        if bool(self._cfg['noise']):
+            Vrms = self._Vrms / (self._bandwidth /( 2.5 * units.GHz))** 0.5  # normalize noise level to the bandwidth its generated for
+            channelGenericNoiseAdder.run(self._evt, self._station, self._det, amplitude=Vrms, min_freq=0 * units.MHz,
+                                         max_freq=2.5 * units.GHz, type='rayleigh')
+
+        # bandpass filter trace, the upper bound is higher then the sampling rate which makes it just a highpass filter
+        channelBandPassFilter.run(self._evt, self._station, self._det, passband=[80 * units.MHz, 1000 * units.GHz],
+                                  filter_type='butter', order=2)
+        channelBandPassFilter.run(self._evt, self._station, self._det, passband=[0, 500 * units.MHz],
+                                  filter_type='butter', order=10)
+
+        # run a high/low trigger on the 4 downward pointing LPDAs
+        triggerSimulatorHighLow.run(self._evt, self._station, self._det,
+                                    threshold_high=2 * self._Vrms,
+                                    threshold_low=-2 * self._Vrms,
+                                    triggered_channels=None,  # select the LPDA channels
+                                    number_concidences=1,  # 2/4 majority logic
+                                    trigger_name='highlow_2sigma')
+
+        # downsample trace back to detector sampling rate
+#         channelResampler.run(self._evt, self._station, self._det, sampling_rate=self._sampling_rate_detector)
+
+
+parser = argparse.ArgumentParser(description='Run NuRadioMC simulation')
+parser.add_argument('inputfilename', type=str,
+                    help='path to NuRadioMC input event list')
+parser.add_argument('detectordescription', type=str,
+                    help='path to file containing the detector description')
+parser.add_argument('config', type=str,
+                    help='NuRadioMC yaml config file')
+parser.add_argument('outputfilename', type=str,
+                    help='hdf5 output filename')
+parser.add_argument('outputfilenameNuRadioReco', type=str, nargs='?', default=None,
+                    help='outputfilename of NuRadioReco detector sim file')
+args = parser.parse_args()
+
+sim = mySimulation(eventlist=args.inputfilename,
+                            outputfilename=args.outputfilename,
+                            detectorfile=args.detectordescription,
+                            outputfilenameNuRadioReco=args.outputfilenameNuRadioReco,
+                            config_file=args.config)
+sim.run()
+

--- a/NuRadioMC/test/Veff/1e18eV/T03check_output.py
+++ b/NuRadioMC/test/Veff/1e18eV/T03check_output.py
@@ -1,0 +1,35 @@
+import numpy as np
+import h5py
+from NuRadioMC.utilities import units
+import sys
+
+fin = h5py.File("output.hdf5", 'r')
+weights = np.array(fin['weights'])
+n_events = fin.attrs['n_events']
+
+###########################
+# calculate effective volume
+###########################
+density_ice = 0.9167 * units.g / units.cm ** 3
+density_water = 997 * units.kg / units.m ** 3
+
+n_triggered = np.sum(weights)
+
+V = None
+rmin = fin.attrs['rmin']
+rmax = fin.attrs['rmax']
+dZ = fin.attrs['zmax'] - fin.attrs['zmin']
+V = np.pi * (rmax ** 2 - rmin ** 2) * dZ
+Veff = V * density_ice / density_water * 4 * np.pi * np.sum(weights) / n_events
+print('fraction of triggered events = {:.0f}/{:.0f} = {:.3f} -> {:.6g} km^3 sr'.format(n_triggered, n_events, n_triggered / n_events, Veff / units.km ** 3))
+
+Veff_mean = 4.74
+Veff_sigma = 0.43
+
+delta = (Veff / units.km ** 3 - Veff_mean) / Veff_sigma
+rdelta = (Veff / units.km ** 3 - Veff_mean) / Veff_mean
+print("effective volume deviates {:.1f} sigma ({:.0f}%) from the mean".format(delta, 100 * rdelta))
+
+if(np.abs(Veff / units.km ** 3 - Veff_mean) > 2 * Veff_sigma):
+    print("deviation is more than 2 sigma -> this should only happen in 5\% of the tests. Rerun the test and see if the error persists.")
+    sys.exit(-1)     

--- a/NuRadioMC/test/Veff/1e18eV/run.sh
+++ b/NuRadioMC/test/Veff/1e18eV/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+python T01generate_event_list.py
+python T02RunSimulation.py 1e18_full.hdf5  ../dipole_100m.json ../config.yaml output.hdf5
+python T03check_output.py

--- a/NuRadioMC/test/Veff/config.yaml
+++ b/NuRadioMC/test/Veff/config.yaml
@@ -1,0 +1,18 @@
+noise: False  # specify if simulation should be run with or without noise
+sampling_rate: 2.  # sampling rate in GHz used internally in the simulation.
+speedup:
+  minimum_weight_cut: 1.e-5
+  delta_C_cut: 0.698  # 40 degree
+  redo_raytracing: True  # redo ray tracing even if previous calculated ray tracing solutions are present
+propagation:
+  ice_model: southpole_2015
+signal:
+  model: Alvarez2009
+trigger:
+  noise_temperature: 300  # in Kelvin
+  bandwidth: 0.42  # effective bandwidth in GHz 
+weights:
+  weight_mode: core_mantle_crust # core_mantle_crust: use the three
+  #layer earth model, which considers the different densities of the
+  #core, mantle and crust. simple: use the simple earth model, which
+  #apply a constant earth density

--- a/NuRadioMC/test/Veff/dipole_100m.json
+++ b/NuRadioMC/test/Veff/dipole_100m.json
@@ -1,0 +1,55 @@
+{
+    "_default": {},
+    "channels": {
+        
+        "1": {
+            "adc_id": null,
+            "adc_n_samples": 256,
+            "adc_nbits": null,
+            "adc_sampling_frequency": 1.0,
+            "adc_time_delay": null,
+            "amp_reference_measurement": null,
+            "amp_type": "300",
+            "ant_comment": "South Pole Station channel1",
+            "ant_orientation_phi": 0.0,
+            "ant_orientation_theta": 0.0,
+            "ant_position_x": 0.0,
+            "ant_position_y": 0.0,
+            "ant_position_z": -100.0,
+            "ant_rotation_phi": 90.0,
+            "ant_rotation_theta": 90.0,
+            "ant_type": "XFDTD_Vpol_CrossFeed_150mmHole_n1.78",
+            "cab_id": "17-09",
+            "cab_length": 5.0,
+            "cab_reference_measurement": null,
+            "cab_time_delay": 19.8,
+            "cab_type": "LMR_400",
+            "channel_id": 0,
+            "commission_time": "{TinyDate}:2017-11-01T00:00:00",
+            "decommission_time": "{TinyDate}:2038-01-01T00:00:00",
+            "station_id": 101
+        }
+    },
+    "comment": {
+        "1": "a surface station with 4 downward facing LPDAs and 4 dipoles with 1GHz sampling, i.e., the bandwidth is 0-500MHz"
+    },
+    "positions": {},
+    "stations": {
+        "1": {
+            "MAC_address": "0002F7F2E7B9",
+            "MBED_type": "v1",
+            "board_number": 203,
+            "commission_time": "{TinyDate}:2017-11-04T00:00:00",
+            "decommission_time": "{TinyDate}:2038-01-01T00:00:00",
+            "pos_altitude": 0,
+            "pos_easting": 0,
+            "pos_northing": 0,
+            "pos_measurement_time": null,
+            "pos_position": "SP1",
+            "pos_site": "southpole",
+            "position": "SP1",
+            "station_id": 101,
+            "station_type": null
+        }
+    }
+}

--- a/NuRadioMC/test/config.yaml
+++ b/NuRadioMC/test/config.yaml
@@ -4,6 +4,7 @@ speedup:
   minimum_weight_cut: 1.e-5
   delta_C_cut: 0.698  # 40 degree
   redo_raytracing: True  # redo ray tracing even if previous calculated ray tracing solutions are present
+  min_efield_amplitude: 2
 propagation:
   ice_model: ARAsim_southpole
 signal:


### PR DESCRIPTION
This test performs a full Veff simulation and verifies that the Veff prediction remains the same. All steps are tested. 

Due to the MC nature, there is a certain scatter. Simulating 50,000 events in a 4km radius zylinder at SP at 1e18 leads to the following scatter in the Veff prediction of about 10%.
![veff_scatter](https://user-images.githubusercontent.com/31775679/61067711-0f28f680-a3bd-11e9-894a-4c10a2bc2330.png)

I implemented the verification such that the deviation is not allowed to be larger than 2 sigma which should cover 95% of the test runs. In case we get a larger deviation, the test just needs to be rerun. Do you think this is a feasible solution? 

The simulation takes ~4min on my laptop. We could simulate more events to decrease the scatter? 

@anelles we need to C++ ray tracer to work on the built bot. Can you try fixing that? It seems that the inclusion path is not set correctly, probably some googling on how to set up GSL on ubuntu will help. 

Addresses #106 


