### PR TITLE
Unit test fix

### DIFF
--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -123,7 +123,7 @@ class simulation():
         self._mout = collections.OrderedDict()
         self._mout_groups = collections.OrderedDict()
         self._mout_attrs = collections.OrderedDict()
-        
+
         # read in detector positions
         logger.warning("Detectorfile {}".format(os.path.abspath(self._detectorfile)))
         self._det = None
@@ -271,7 +271,7 @@ class simulation():
                                        sg_pre['ray_tracing_solution_type'][self._iE][channel_id], temp_reflection, temp_reflection_case)
                     else:
                         r.find_solutions()
-                        
+
                     if(not r.has_solution()):
                         logger.debug("event {} and station {}, channel {} does not have any ray tracing solution ({} to {})".format(
                             self._event_id, self._station_id, channel_id, x1, x2))
@@ -381,12 +381,12 @@ class simulation():
                                     zenith_reflection, n_2=1., n_1=self._ice.get_index_of_refraction([x2[0], x2[1], -1 * units.cm]))
                                 r_phi = geo_utl.get_fresnel_r_s(
                                     zenith_reflection, n_2=1., n_1=self._ice.get_index_of_refraction([x2[0], x2[1], -1 * units.cm]))
-    
+
                                 eTheta *= r_theta
                                 ePhi *= r_phi
                                 logger.debug("ray hits the surface at an angle {:.2f}deg -> reflection coefficient is r_theta = {:.2f}, r_phi = {:.2f}".format(zenith_reflection/units.deg,
                                     r_theta, r_phi))
-                                
+
                         if(self._n_reflections > 0):  # take into account possible bottom reflections
                             # each reflection lowers the amplitude by the reflection coefficient and introduces a phase shift
                             reflection_coefficient = self._n_reflections * self._ice.reflection_coefficient
@@ -570,13 +570,13 @@ class simulation():
             nx, ny = self._mout['multiple_triggers'].shape
             tmp[:, 0:ny] = self._mout['multiple_triggers']
             self._mout['multiple_triggers'] = tmp
-            
+
             sg = self._mout_groups[self._station_id]
             tmp = np.zeros((self._n_events, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
             nx, ny = sg['multiple_triggers'].shape
             tmp[:, 0:ny] = sg['multiple_triggers']
             sg['multiple_triggers'] = tmp
-            
+
 
     def _save_triggers_to_hdf5(self):
 
@@ -686,7 +686,7 @@ class simulation():
 
     def _write_ouput_file(self):
         folder = os.path.dirname(self._outputfilename)
-        if(not os.path.exists(folder)):
+        if(not os.path.exists(folder) and folder != ''):
             logger.warning(f"output folder {folder} does not exist, creating folder...")
             os.makedirs(folder)
         fout = h5py.File(self._outputfilename, 'w')

--- a/NuRadioMC/test/SignalGen/test_build.sh
+++ b/NuRadioMC/test/SignalGen/test_build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
+set -e
 NuRadioMC/test/SignalGen/U01unit_test.py NuRadioMC/test/SignalGen/reference_v1.pkl
-

--- a/NuRadioMC/test/SignalProp/run_signal_test.sh
+++ b/NuRadioMC/test/SignalProp/run_signal_test.sh
@@ -1,3 +1,4 @@
+set -e
 cd NuRadioMC/test/SignalProp/
 python T01test_python_vs_cpp.py
 python T02test_analytic_D_T.py

--- a/NuRadioMC/test/SingleEvents/test_build.sh
+++ b/NuRadioMC/test/SingleEvents/test_build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -e
 NuRadioMC/test/SingleEvents/T02RunSimulation.py NuRadioMC/test/SingleEvents/1e18_output_reference.hdf5 NuRadioMC/test/SingleEvents/surface_station_1GHz.json NuRadioMC/test/SingleEvents/config.yaml NuRadioMC/test/SingleEvents/1e18_output.hdf5
 
 NuRadioMC/test/SingleEvents/T03validate.py NuRadioMC/test/SingleEvents/1e18_output.hdf5 NuRadioMC/test/SingleEvents/1e18_output_reference.hdf5

--- a/NuRadioMC/test/Veff/1e18eV/test_build.sh
+++ b/NuRadioMC/test/Veff/1e18eV/test_build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -e
 NuRadioMC/test/Veff/1e18eV/T01generate_event_list.py
 
 NuRadioMC/test/Veff/1e18eV/T02RunSimulation.py 1e18_full.hdf5  ../dipole_100m.json ../config.yaml output.hdf5 output.nur

--- a/NuRadioMC/test/examples/test_examples.sh
+++ b/NuRadioMC/test/examples/test_examples.sh
@@ -1,3 +1,4 @@
+set -e
 cd NuRadioMC/examples/01_Veff_simulation
 mkdir output
 python T01generate_event_list.py


### PR DESCRIPTION
- Fixes error caused by trying to create a folder for the output file if the output file is written in the same folder
- This error should have been caught by the unit test but wasn't, because the shell scripts can catch errors. Adding set -e stops them from doing that.