### PR TITLE
Only does logging if at least one event has been properly simulated

### DIFF
--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -183,10 +183,11 @@ class simulation():
             if(self._iE > 0 and self._iE % max(1, int(self._n_events / 100.)) == 0):
                 eta = pretty_time_delta((time.time() - t_start) * (self._n_events - self._iE) / self._iE)
                 total_time = inputTime + rayTracingTime + detSimTime + outputTime
-                logger.warning("processing event {}/{} ({} triggered) = {:.1f}%, ETA {}, time consumption: ray tracing = {:.0f}% (att. length {:.0f}%), askaryan = {:.0f}%, detector simulation = {:.0f}% reading input = {:.0f}%".format(
-                    self._iE, self._n_events, np.sum(self._mout['triggered']),  100. * self._iE / self._n_events, eta, 100. * (rayTracingTime - askaryan_time) / total_time,
-                    100. * time_attenuation_length / (rayTracingTime - askaryan_time),
-                    100.* askaryan_time / total_time, 100. * detSimTime / total_time, 100.*inputTime / total_time))
+                if total_time > 0:
+                    logger.warning("processing event {}/{} ({} triggered) = {:.1f}%, ETA {}, time consumption: ray tracing = {:.0f}% (att. length {:.0f}%), askaryan = {:.0f}%, detector simulation = {:.0f}% reading input = {:.0f}%".format(
+                        self._iE, self._n_events, np.sum(self._mout['triggered']),  100. * self._iE / self._n_events, eta, 100. * (rayTracingTime - askaryan_time) / total_time,
+                        100. * time_attenuation_length / (rayTracingTime - askaryan_time),
+                        100.* askaryan_time / total_time, 100. * detSimTime / total_time, 100.*inputTime / total_time))
 #             if(self._iE > 0 and self._iE % max(1, int(self._n_events / 10000.)) == 0):
 #                 print("*", end='')
 


### PR DESCRIPTION
If events are skipped, this output can cause crashes because the run time is 0. This pull request should fix that.