### PR TITLE
change in effective volume calculation utitlity

### DIFF
--- a/NuRadioMC/examples/Sensitivities/E2_fluxes3.py
+++ b/NuRadioMC/examples/Sensitivities/E2_fluxes3.py
@@ -491,21 +491,24 @@ def get_E2_limit_figure(diffuse = True,
     plt.tight_layout()
     return fig, ax
 
-def add_limit(ax, limit_labels, E, Veff, n_stations, label, livetime=3*units.year, linestyle='-',color='r',linewidth=3,band=False):
+def add_limit(ax, limit_labels, E, Veffsr, n_stations, label, livetime=3*units.year, linestyle='-',color='r',linewidth=3,band=False):
+    """
+    add limit curve to limit plot
+    """
     E = np.array(E)
-    Veff = np.array(Veff)
+    Veffsr = np.array(Veffsr)
 
     if band:
 
         limit_lower = fluxes.get_limit_e2_flux(energy = E,
-                                         veff = Veff[0],
+                                         veff = Veffsr[0],
                                          livetime = livetime,
                                          signalEff = n_stations,
                                          energyBinsPerDecade=energyBinsPerDecade,
                                          upperLimOnEvents=2.44,
                                          nuCrsScn='ctw')
         limit_upper = fluxes.get_limit_e2_flux(energy = E,
-                                         veff = Veff[1],
+                                         veff = Veffsr[1],
                                          livetime = livetime,
                                          signalEff = n_stations,
                                          energyBinsPerDecade=energyBinsPerDecade,
@@ -518,7 +521,7 @@ def add_limit(ax, limit_labels, E, Veff, n_stations, label, livetime=3*units.yea
     else:
 
         limit = fluxes.get_limit_e2_flux(energy = E,
-                                         veff = Veff,
+                                         veff = Veffsr,
                                          livetime = livetime,
                                          signalEff = n_stations,
                                          energyBinsPerDecade=energyBinsPerDecade,

--- a/NuRadioMC/simulation/T05visualize_sim_output.py
+++ b/NuRadioMC/simulation/T05visualize_sim_output.py
@@ -93,6 +93,16 @@ ax.set_title(trigger_name)
 fig.tight_layout()
 fig.savefig(os.path.join(plot_folder, 'neutrino_direction.png'))
 
+czen = np.cos(np.array(fin['zeniths'])[triggered])
+bins = np.linspace(-1, 1, 21)
+fig, ax = php.get_histogram(czen, weights=weights,
+                            ylabel='weighted entries', xlabel='cos(zenith angle)',
+                            bins=bins, figsize=(6, 6))
+# ax.set_xticks(np.arange(0, 181, 45))
+ax.set_title(trigger_name)
+fig.tight_layout()
+fig.savefig(os.path.join(plot_folder, 'neutrino_direction_cos.png'))
+
 ###########################
 # calculate sky coverage of 90% quantile
 ###########################

--- a/NuRadioMC/utilities/Veff.py
+++ b/NuRadioMC/utilities/Veff.py
@@ -7,8 +7,8 @@ from six import iteritems
 import json
 import os
 
-
 # collection of utility function regarding the calculation of the effective volume of a neutrino detector
+
 
 def get_triggered(fin):
     """
@@ -33,14 +33,14 @@ def get_triggered(fin):
         return triggered
 
     mask_secondaries = np.array(fin['n_interaction']) > 1
-    if ( True not in mask_secondaries ):
+    if (True not in mask_secondaries):
         return triggered
 
     # We count the multiple triggering bangs as a single triggered event
     for event_id in np.unique(np.array(fin['event_ids'])[mask_secondaries]):
         mask_interactions = np.array(fin['event_ids']) == event_id
-        multiple_interaction_indexes = np.argwhere( np.array(fin['event_ids']) == event_id )[0]
-        if (len(multiple_interaction_indexes)==1):
+        multiple_interaction_indexes = np.argwhere(np.array(fin['event_ids']) == event_id)[0]
+        if (len(multiple_interaction_indexes) == 1):
             continue
 
         for int_index in multiple_interaction_indexes[1:]:
@@ -48,6 +48,7 @@ def get_triggered(fin):
         triggered[multiple_interaction_indexes[0]] = True
 
     return triggered
+
 
 def get_Aeff_proposal(folder, trigger_combinations={}, zenithbins=False):
     """
@@ -121,7 +122,7 @@ def get_Aeff_proposal(folder, trigger_combinations={}, zenithbins=False):
         Es.append(E)
 
         weights = np.array(fin['weights'])
-        #triggered = np.array(fin['triggered'])
+        # triggered = np.array(fin['triggered'])
         triggered = get_triggered(fin)
         n_events = fin.attrs['n_events']
         if(trigger_names is None):
@@ -134,7 +135,7 @@ def get_Aeff_proposal(folder, trigger_combinations={}, zenithbins=False):
         else:
             if(np.any(trigger_names != fin.attrs['trigger_names'])):
 
-                if( triggered.size == 0 and fin.attrs['trigger_names'].size == 0 ):
+                if(triggered.size == 0 and fin.attrs['trigger_names'].size == 0):
                     print("file {} has not triggering events. Using trigger names from another file".format(filename))
                 else:
                     print("file {} has inconsistent trigger names: {}".format(filename, fin.attrs['trigger_names']))
@@ -158,19 +159,19 @@ def get_Aeff_proposal(folder, trigger_combinations={}, zenithbins=False):
         if('phimax' in fin.attrs):
             fin.attrs['phimax']
         dZ = fin.attrs['zmax'] - fin.attrs['zmin']
-        area = np.pi * (rmax**2 - rmin**2)
+        area = np.pi * (rmax ** 2 - rmin ** 2)
         V = area * dZ
         Vrms = fin.attrs['Vrms']
 
         # Solid angle needed for the effective volume calculations
-        omega = np.abs(phimax - phimin) * np.abs( np.cos(thetamin)-np.cos(thetamax) )
+        omega = np.abs(phimax - phimin) * np.abs(np.cos(thetamin) - np.cos(thetamax))
 
         for iT, trigger_name in enumerate(trigger_names):
             triggered = np.array(fin['multiple_triggers'][:, iT], dtype=np.bool)
             Aeff = area * np.sum(weights[triggered]) / n_events
             Aeffs[trigger_name].append(Aeff)
             try:
-                Aeffs_error[trigger_name].append(Aeff / np.sum(weights[triggered])**0.5)
+                Aeffs_error[trigger_name].append(Aeff / np.sum(weights[triggered]) ** 0.5)
             except:
                 Aeffs_error[trigger_name].append(np.nan)
 
@@ -201,7 +202,7 @@ def get_Aeff_proposal(folder, trigger_combinations={}, zenithbins=False):
                     masks = np.zeros_like(triggered)
                     for iS in range(len(values['min_sigma'])):
 #                         As = np.array(fin['maximum_amplitudes'])
-                        As = np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1) # we use the this quantity because it is always computed before noise is added!
+                        As = np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1)  # we use the this quantity because it is always computed before noise is added!
                         As_sorted = np.sort(As[:, values['channels'][iS]], axis=1)
                         # the smallest of the three largest amplitudes
                         max_amplitude = As_sorted[:, -values['n_channels'][iS]]
@@ -215,7 +216,7 @@ def get_Aeff_proposal(folder, trigger_combinations={}, zenithbins=False):
                     if(trigger_name not in SNR):
                         SNR[trigger_name] = []
 #                     As = np.array(fin['maximum_amplitudes'])
-                    As = np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1) # we use the this quantity because it is always computed before noise is added!
+                    As = np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1)  # we use the this quantity because it is always computed before noise is added!
     #                 print(As.shape)
 #                     print(trigger_name, values['channels'])
                     As_sorted = np.sort(As[:, values['channels']], axis=1)
@@ -233,7 +234,7 @@ def get_Aeff_proposal(folder, trigger_combinations={}, zenithbins=False):
 #                 print(sol[:,values['ray_channel']][max_amps].shape)
 #                 print(max_amps.shape)
 #                 a = 1/0
-                mask = np.array([sol[i,values['ray_channel'], max_amps[i]] == values['ray_solution'] for i in range(len(max_amps))], dtype=np.bool)
+                mask = np.array([sol[i, values['ray_channel'], max_amps[i]] == values['ray_solution'] for i in range(len(max_amps))], dtype=np.bool)
                 triggered = triggered & mask
 
             Aeff = area * np.sum(weights[triggered]) / n_events
@@ -241,14 +242,14 @@ def get_Aeff_proposal(folder, trigger_combinations={}, zenithbins=False):
             if('efficiency' in values.keys()):
                 SNReff, eff = np.loadtxt("analysis_efficiency_{}.csv".format(values['efficiency']), delimiter=",", unpack=True)
                 get_eff = interpolate.interp1d(SNReff, eff, bounds_error=False, fill_value=(0, eff[-1]))
-                As = np.max(np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1)[:,np.append(range(0, 8), range(12, 20))], axis=-1) # we use the this quantity because it is always computed before noise is added!
+                As = np.max(np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1)[:, np.append(range(0, 8), range(12, 20))], axis=-1)  # we use the this quantity because it is always computed before noise is added!
                 if('efficiency_scale' in values.keys()):
                     As *= values['efficiency_scale']
-                e = get_eff(As/Vrms)
-                Aeff = area * np.sum((weights*e)[triggered]) / n_events
+                e = get_eff(As / Vrms)
+                Aeff = area * np.sum((weights * e)[triggered]) / n_events
 
             Aeffs[trigger_name].append(Aeff)
-            Aeffs_error[trigger_name].append(Aeff / np.sum(weights[triggered])**0.5)
+            Aeffs_error[trigger_name].append(Aeff / np.sum(weights[triggered]) ** 0.5)
     for trigger_name in Aeffs.keys():
         Aeffs[trigger_name] = np.array(Aeffs[trigger_name])
         Aeffs_error[trigger_name] = np.array(Aeffs_error[trigger_name])
@@ -258,9 +259,31 @@ def get_Aeff_proposal(folder, trigger_combinations={}, zenithbins=False):
     else:
         return np.array(Es), Aeffs, Aeffs_error, SNR, trigger_names, deposited
 
+
+def get_Veff_water_equivalent(Veff, density_medium=0.917 * units.g / units.cm ** 3, density_water=1 * units.g / units.cm ** 3):
+    """
+    convenience function to converte the effective volume of a medium with density `density_medium` to the 
+    water equivalent effective volume
+    
+    Parameters
+    ----------
+    Veff: float or array
+        the effective volume
+    dentity_medium: float (optional)
+        the density of the medium of the Veff simulation (default deep ice)
+    density water: float (optional)
+        the density of water
+        
+    Returns: water equivalen effective volume
+    """
+    return Veff * density_water / density_medium
+
+
 def get_Veff(folder, trigger_combinations={}, station=101):
     """
     calculates the effective volume from NuRadioMC hdf5 files
+    
+    the effective volume is NOT normalized to a water equivalent. 
 
     Parameters
     ----------
@@ -323,7 +346,7 @@ def get_Veff(folder, trigger_combinations={}, station=101):
         out['energy'] = E
 
         weights = np.array(fin['weights'])
-        #triggered = np.array(fin['triggered'])
+        # triggered = np.array(fin['triggered'])
         triggered = get_triggered(fin)
         n_events = fin.attrs['n_events']
         if(trigger_names is None):
@@ -332,7 +355,7 @@ def get_Veff(folder, trigger_combinations={}, station=101):
                 trigger_names_dict[trigger_name] = iT
         else:
             if(np.any(trigger_names != fin.attrs['trigger_names'])):
-                if( triggered.size == 0 and fin.attrs['trigger_names'].size == 0 ):
+                if(triggered.size == 0 and fin.attrs['trigger_names'].size == 0):
                     print("file {} has no triggering events. Using trigger names from another file".format(filename))
                 else:
                     print("file {} has inconsistent trigger names: {}".format(filename, fin.attrs['trigger_names']))
@@ -354,19 +377,19 @@ def get_Veff(folder, trigger_combinations={}, station=101):
         if('phimax' in fin.attrs):
             fin.attrs['phimax']
         dZ = fin.attrs['zmax'] - fin.attrs['zmin']
-        area = np.pi * (rmax**2 - rmin**2)
+        area = np.pi * (rmax ** 2 - rmin ** 2)
         V = area * dZ
         Vrms = fin.attrs['Vrms']
 
         # Solid angle needed for the effective volume calculations
-        out['domega'] = np.abs(phimax - phimin) * np.abs( np.cos(thetamin)-np.cos(thetamax) )
+        out['domega'] = np.abs(phimax - phimin) * np.abs(np.cos(thetamin) - np.cos(thetamax))
         out['thetamin'] = thetamin
         out['thetamax'] = thetamax
         out['deposited'] = deposited
         out['Veffs'] = {}
         out['n_triggered_weighted'] = {}
         out['SNRs'] = {}
-        
+
         if(triggered.size == 0):
             for iT, trigger_name in enumerate(trigger_names):
                 out['Veffs'][trigger_name] = [0, 0, 0]
@@ -378,7 +401,7 @@ def get_Veff(folder, trigger_combinations={}, station=101):
                 Veff = V * np.sum(weights[triggered]) / n_events
                 Veff_error = 0
                 if(np.sum(weights[triggered]) > 0):
-                    Veff_error = Veff / np.sum(weights[triggered])**0.5
+                    Veff_error = Veff / np.sum(weights[triggered]) ** 0.5
                 out['Veffs'][trigger_name] = [Veff, Veff_error, np.sum(weights[triggered])]
 
             for trigger_name, values in iteritems(trigger_combinations):
@@ -405,7 +428,7 @@ def get_Veff(folder, trigger_combinations={}, station=101):
                         masks = np.zeros_like(triggered)
                         for iS in range(len(values['min_sigma'])):
     #                         As = np.array(fin['maximum_amplitudes'])
-                            As = np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1) # we use the this quantity because it is always computed before noise is added!
+                            As = np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1)  # we use the this quantity because it is always computed before noise is added!
                             As_sorted = np.sort(As[:, values['channels'][iS]], axis=1)
                             # the smallest of the three largest amplitudes
                             max_amplitude = As_sorted[:, -values['n_channels'][iS]]
@@ -415,7 +438,7 @@ def get_Veff(folder, trigger_combinations={}, station=101):
                         triggered = triggered & masks
                     else:
     #                     As = np.array(fin['maximum_amplitudes'])
-                        As = np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1) # we use the this quantity because it is always computed before noise is added!
+                        As = np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1)  # we use the this quantity because it is always computed before noise is added!
         #                 print(As.shape)
     #                     print(trigger_name, values['channels'])
                         As_sorted = np.sort(As[:, values['channels']], axis=1)
@@ -433,24 +456,24 @@ def get_Veff(folder, trigger_combinations={}, station=101):
     #                 print(sol[:,values['ray_channel']][max_amps].shape)
     #                 print(max_amps.shape)
     #                 a = 1/0
-                    mask = np.array([sol[i,values['ray_channel'], max_amps[i]] == values['ray_solution'] for i in range(len(max_amps))], dtype=np.bool)
+                    mask = np.array([sol[i, values['ray_channel'], max_amps[i]] == values['ray_solution'] for i in range(len(max_amps))], dtype=np.bool)
                     triggered = triggered & mask
-                    
+
                 if('n_reflections' in values.keys()):
-                    triggered = triggered & (np.array(fin[f'station_{station:d}/ray_tracing_reflection'])[:,0,0] == values['n_reflections'])
-    
+                    triggered = triggered & (np.array(fin[f'station_{station:d}/ray_tracing_reflection'])[:, 0, 0] == values['n_reflections'])
+
                 Veff = V * np.sum(weights[triggered]) / n_events
-    
+
                 if('efficiency' in values.keys()):
                     SNReff, eff = np.loadtxt("analysis_efficiency_{}.csv".format(values['efficiency']), delimiter=",", unpack=True)
                     get_eff = interpolate.interp1d(SNReff, eff, bounds_error=False, fill_value=(0, eff[-1]))
-                    As = np.max(np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1)[:,np.append(range(0, 8), range(12, 20))], axis=-1) # we use the this quantity because it is always computed before noise is added!
+                    As = np.max(np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1)[:, np.append(range(0, 8), range(12, 20))], axis=-1)  # we use the this quantity because it is always computed before noise is added!
                     if('efficiency_scale' in values.keys()):
                         As *= values['efficiency_scale']
-                    e = get_eff(As/Vrms)
-                    Veff = V * np.sum((weights*e)[triggered]) / n_events
-    
-                out['Veffs'][trigger_name] = [Veff, Veff / np.sum(weights[triggered])**0.5, np.sum(weights[triggered])]
+                    e = get_eff(As / Vrms)
+                    Veff = V * np.sum((weights * e)[triggered]) / n_events
+
+                out['Veffs'][trigger_name] = [Veff, Veff / np.sum(weights[triggered]) ** 0.5, np.sum(weights[triggered])]
         Veff_output.append(out)
 
     return Veff_output
@@ -539,7 +562,7 @@ def get_Veff_array(data):
         zenith_bins.append([d['thetamin'], d['thetamax']])
         for triggername in d['Veffs']:
             trigger_names.append(triggername)
-            
+
     energies = np.array(energies)
     zenith_bins = np.array(zenith_bins)
     trigger_names = np.array(trigger_names)
@@ -550,7 +573,7 @@ def get_Veff_array(data):
     print(f"unique energies {uenergies}")
     print(f"unique zenith angle bins {uzenith_bins/units.deg}")
     print(f"unique energies {utrigger_names}")
-    
+
     for d in data:
         iE = np.squeeze(np.argwhere(d['energy'] == uenergies))
         iT = np.squeeze(np.argwhere([d['thetamin'], d['thetamax']] == uzenith_bins))[0][0]
@@ -560,8 +583,10 @@ def get_Veff_array(data):
 #                 print(f"{iE}  {iT} {iTrig} {Veff}")
     return output, uenergies, uzenith_bins, utrigger_names
 
+
 def get_index(value, array):
-    return np.squeeze(np.argwhere(value==array))
+    return np.squeeze(np.argwhere(value == array))
+
 
 def exportVeff(filename, trigger_names, Es, Veffs, Veffs_error):
     """
@@ -591,6 +616,7 @@ def exportVeff(filename, trigger_names, Es, Veffs, Veffs_error):
 
     with open(filename, 'w') as fout:
         json.dump(output, fout, sort_keys=True, indent=4)
+
 
 def exportVeffPerZenith(folderlist, outputfile):
     """
@@ -622,6 +648,7 @@ def exportVeffPerZenith(folderlist, outputfile):
     with open(outputfile, 'w+') as fout:
 
         json.dump(output, fout, sort_keys=True, indent=4)
+
 
 def exportAeffPerZenith(folderlist, outputfile):
     """

--- a/NuRadioMC/utilities/Veff.py
+++ b/NuRadioMC/utilities/Veff.py
@@ -50,10 +50,12 @@ def get_triggered(fin):
     return triggered
 
 
-def get_Aeff_proposal(folder, trigger_combinations={}, zenithbins=False):
+def get_Aeff_proposal(folder, trigger_combinations={}, station=101):
     """
-    calculates the effective area from NuRadioMC hdf5 files calculated using
-    PROPOSAL for propagating surface muons.
+    Calculates the effective area from NuRadioMC hdf5 files simulated after
+    using PROPOSAL as the lepton propagator. The interaction length is already
+    factorised thanks to the energy losses returned by PROPOSAL, which in turn
+    can trigger our radio array.
 
     Parameters
     ----------
@@ -63,37 +65,30 @@ def get_Aeff_proposal(folder, trigger_combinations={}, zenithbins=False):
         keys are the names of triggers to calculate. Values are dicts again:
             * 'triggers': list of strings
                 name of individual triggers that are combines with an OR
+            the following additional options are optional
             * 'efficiency': string
                 the signal efficiency vs. SNR (=Vmax/Vrms) to use. E.g. 'Chris'
             * 'efficiency_scale': float
                 rescaling of the efficiency curve by SNR' = SNR * scale
-    zenithbins: bool
-        If true, returns the minimum and maximum zenith angles
+            * 'n_reflections': int
+                the number of bottom reflections of the ray tracing solution that likely triggered
+                assuming that the solution with the shortest travel time caused the trigger, only considering channel 0
+
+    station: int
+        the station that should be considered
 
     Returns
     ----------
-    np.array(Es): numpy floats array
-        Smallest energy for each bin
-    Aeffs: floats list
-        Effective volumes (m^2)
-    Aeffs_error: floats list
-        Effective volume uncertainties (m^2)
-    SNR: floats list
-        Signal to noise ratios
-    trigger_names: string list
-        Trigger names
-    [thetamin, thetamax]: [float, float]
-        Mimimum and maximum zenith angles
+    list of dictionary. Each file is one entry. The dictionary keys store all relevant properties
     """
+    Aeff_output = []
     trigger_names = None
     trigger_names_dict = {}
-    Aeffs = {}
-    SNR = {}
-    Aeffs_error = {}
-    Es = []
     prev_deposited = None
     deposited = False
 
+    if(len(glob.glob(os.path.join(folder, '*.hdf5'))) == 0):
+        raise FileNotFoundError(f"couldnt find any hdf5 file in folder {folder}")
     for iF, filename in enumerate(sorted(glob.glob(os.path.join(folder, '*.hdf5')))):
         print(f"reading {filename}")
         fin = h5py.File(filename, 'r')
@@ -102,14 +97,12 @@ def get_Aeff_proposal(folder, trigger_combinations={}, zenithbins=False):
             if prev_deposited is None:
                 prev_deposited = deposited
             elif prev_deposited != deposited:
-                print("Warning! The deposited parameter is not consistent!")
+                raise AttributeError("The deposited parameter is not consistent among the input files!")
 
         if('trigger_names' in fin.attrs):
             trigger_names = fin.attrs['trigger_names']
         if(len(trigger_names) > 0):
             for iT, trigger_name in enumerate(trigger_names):
-                Aeffs[trigger_name] = []
-                Aeffs_error[trigger_name] = []
                 trigger_names_dict[trigger_name] = iT
             break
 
@@ -118,8 +111,9 @@ def get_Aeff_proposal(folder, trigger_combinations={}, zenithbins=False):
 
     for iF, filename in enumerate(sorted(glob.glob(os.path.join(folder, '*.hdf5')))):
         fin = h5py.File(filename, 'r')
+        out = {}
         E = fin.attrs['Emin']
-        Es.append(E)
+        out['energy'] = E
 
         weights = np.array(fin['weights'])
         # triggered = np.array(fin['triggered'])
@@ -128,22 +122,16 @@ def get_Aeff_proposal(folder, trigger_combinations={}, zenithbins=False):
         if(trigger_names is None):
             trigger_names = fin.attrs['trigger_names']
             for iT, trigger_name in enumerate(trigger_names):
-                Aeffs[trigger_name] = []
-                Aeffs_error[trigger_name] = []
                 trigger_names_dict[trigger_name] = iT
-            print(trigger_names)
         else:
             if(np.any(trigger_names != fin.attrs['trigger_names'])):
-
                 if(triggered.size == 0 and fin.attrs['trigger_names'].size == 0):
-                    print("file {} has not triggering events. Using trigger names from another file".format(filename))
+                    print("file {} has no triggering events. Using trigger names from another file".format(filename))
                 else:
                     print("file {} has inconsistent trigger names: {}".format(filename, fin.attrs['trigger_names']))
                     raise
 
         # calculate effective
-        density_ice = 0.9167 * units.g / units.cm ** 3
-        density_water = 997 * units.kg / units.m ** 3
         rmin = fin.attrs['rmin']
         rmax = fin.attrs['rmax']
         thetamin = 0
@@ -164,107 +152,108 @@ def get_Aeff_proposal(folder, trigger_combinations={}, zenithbins=False):
         Vrms = fin.attrs['Vrms']
 
         # Solid angle needed for the effective volume calculations
-        omega = np.abs(phimax - phimin) * np.abs(np.cos(thetamin) - np.cos(thetamax))
+        out['domega'] = np.abs(phimax - phimin) * np.abs(np.cos(thetamin) - np.cos(thetamax))
+        out['thetamin'] = thetamin
+        out['thetamax'] = thetamax
+        out['deposited'] = deposited
+        out['Aeffs'] = {}
+        out['n_triggered_weighted'] = {}
+        out['SNRs'] = {}
 
-        for iT, trigger_name in enumerate(trigger_names):
-            triggered = np.array(fin['multiple_triggers'][:, iT], dtype=np.bool)
-            Aeff = area * np.sum(weights[triggered]) / n_events
-            Aeffs[trigger_name].append(Aeff)
-            try:
-                Aeffs_error[trigger_name].append(Aeff / np.sum(weights[triggered]) ** 0.5)
-            except:
-                Aeffs_error[trigger_name].append(np.nan)
+        if(triggered.size == 0):
+            for iT, trigger_name in enumerate(trigger_names):
+                out['Aeffs'][trigger_name] = [0, 0, 0]
+            for trigger_name, values in iteritems(trigger_combinations):
+                out['Aeffs'][trigger_name] = [0, 0, 0]
+        else:
+            for iT, trigger_name in enumerate(trigger_names):
+                triggered = np.array(fin['multiple_triggers'][:, iT], dtype=np.bool)
+                Aeff = area * np.sum(weights[triggered]) / n_events
+                Aeff_error = 0
+                if(np.sum(weights[triggered]) > 0):
+                    Aeff_error = Aeff / np.sum(weights[triggered]) ** 0.5
+                out['Aeffs'][trigger_name] = [Aeff, Aeff_error, np.sum(weights[triggered])]
 
-        for trigger_name, values in iteritems(trigger_combinations):
-            indiv_triggers = values['triggers']
-            if(trigger_name not in Aeffs):
-                Aeffs[trigger_name] = []
-                Aeffs_error[trigger_name] = []
-            triggered = np.zeros_like(fin['multiple_triggers'][:, 0], dtype=np.bool)
-            if(isinstance(indiv_triggers, str)):
-                triggered = triggered | np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_triggers]], dtype=np.bool)
-            else:
-                for indiv_trigger in indiv_triggers:
-                    triggered = triggered | np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_trigger]], dtype=np.bool)
-            if 'triggerAND' in values:
-                triggered = triggered & np.array(fin['multiple_triggers'][:, trigger_names_dict[values['triggerAND']]], dtype=np.bool)
-            if 'notriggers' in values:
-                indiv_triggers = values['notriggers']
+            for trigger_name, values in iteritems(trigger_combinations):
+                indiv_triggers = values['triggers']
+                triggered = np.zeros_like(fin['multiple_triggers'][:, 0], dtype=np.bool)
                 if(isinstance(indiv_triggers, str)):
-                    triggered = triggered & ~np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_triggers]], dtype=np.bool)
+                    triggered = triggered | np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_triggers]], dtype=np.bool)
                 else:
                     for indiv_trigger in indiv_triggers:
-                        triggered = triggered & ~np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_trigger]], dtype=np.bool)
-            if('min_sigma' in values.keys()):
-                if(isinstance(values['min_sigma'], list)):
-                    if(trigger_name not in SNR):
-                        SNR[trigger_name] = {}
-                    masks = np.zeros_like(triggered)
-                    for iS in range(len(values['min_sigma'])):
-#                         As = np.array(fin['maximum_amplitudes'])
+                        triggered = triggered | np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_trigger]], dtype=np.bool)
+                if 'triggerAND' in values:
+                    triggered = triggered & np.array(fin['multiple_triggers'][:, trigger_names_dict[values['triggerAND']]], dtype=np.bool)
+                if 'notriggers' in values:
+                    indiv_triggers = values['notriggers']
+                    if(isinstance(indiv_triggers, str)):
+                        triggered = triggered & ~np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_triggers]], dtype=np.bool)
+                    else:
+                        for indiv_trigger in indiv_triggers:
+                            triggered = triggered & ~np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_trigger]], dtype=np.bool)
+                if('min_sigma' in values.keys()):
+                    if(isinstance(values['min_sigma'], list)):
+                        if(trigger_name not in out['SNR']):
+                            out['SNR'][trigger_name] = {}
+                        masks = np.zeros_like(triggered)
+                        for iS in range(len(values['min_sigma'])):
+    #                         As = np.array(fin['maximum_amplitudes'])
+                            As = np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1)  # we use the this quantity because it is always computed before noise is added!
+                            As_sorted = np.sort(As[:, values['channels'][iS]], axis=1)
+                            # the smallest of the three largest amplitudes
+                            max_amplitude = As_sorted[:, -values['n_channels'][iS]]
+                            mask = np.sum(As[:, values['channels'][iS]] >= (values['min_sigma'][iS] * Vrms), axis=1) >= values['n_channels'][iS]
+                            masks = masks | mask
+                            out['SNR'][trigger_name][iS] = max_amplitude[mask] / Vrms
+                        triggered = triggered & masks
+                    else:
+    #                     As = np.array(fin['maximum_amplitudes'])
                         As = np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1)  # we use the this quantity because it is always computed before noise is added!
-                        As_sorted = np.sort(As[:, values['channels'][iS]], axis=1)
-                        # the smallest of the three largest amplitudes
-                        max_amplitude = As_sorted[:, -values['n_channels'][iS]]
-                        mask = np.sum(As[:, values['channels'][iS]] >= (values['min_sigma'][iS] * Vrms), axis=1) >= values['n_channels'][iS]
-                        masks = masks | mask
-                        if(iS not in SNR[trigger_name]):
-                            SNR[trigger_name][iS] = []
-                        SNR[trigger_name][iS].append([max_amplitude[mask] / Vrms])
-                    triggered = triggered & masks
-                else:
-                    if(trigger_name not in SNR):
-                        SNR[trigger_name] = []
-#                     As = np.array(fin['maximum_amplitudes'])
-                    As = np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1)  # we use the this quantity because it is always computed before noise is added!
-    #                 print(As.shape)
-#                     print(trigger_name, values['channels'])
-                    As_sorted = np.sort(As[:, values['channels']], axis=1)
-                    max_amplitude = As_sorted[:, -values['n_channels']]  # the smallest of the three largest amplitudes
-    #                 print(np.sum(As_sorted[:, -values['n_channels']] > (values['min_sigma'] * Vrms)))
-                    mask = np.sum(As[:, values['channels']] >= (values['min_sigma'] * Vrms), axis=1) >= values['n_channels']
-    #                 max_amplitude[~mask] = 0
-                    SNR[trigger_name].append(As_sorted[mask] / Vrms)
-    #                 print(Vrms, mask.shape, np.sum(mask))
+        #                 print(As.shape)
+    #                     print(trigger_name, values['channels'])
+                        As_sorted = np.sort(As[:, values['channels']], axis=1)
+                        max_amplitude = As_sorted[:, -values['n_channels']]  # the smallest of the three largest amplitudes
+        #                 print(np.sum(As_sorted[:, -values['n_channels']] > (values['min_sigma'] * Vrms)))
+                        mask = np.sum(As[:, values['channels']] >= (values['min_sigma'] * Vrms), axis=1) >= values['n_channels']
+        #                 max_amplitude[~mask] = 0
+                        out['SNR'][trigger_name] = As_sorted[mask] / Vrms
+        #                 print(Vrms, mask.shape, np.sum(mask))
+                        triggered = triggered & mask
+                if('ray_solution' in values.keys()):
+                    As = np.array(fin['max_amp_ray_solution'])
+                    max_amps = np.argmax(As[:, values['ray_channel']], axis=-1)
+                    sol = np.array(fin['ray_tracing_solution_type'])
+    #                 print(sol[:,values['ray_channel']][max_amps].shape)
+    #                 print(max_amps.shape)
+    #                 a = 1/0
+                    mask = np.array([sol[i, values['ray_channel'], max_amps[i]] == values['ray_solution'] for i in range(len(max_amps))], dtype=np.bool)
                     triggered = triggered & mask
-            if('ray_solution' in values.keys()):
-                As = np.array(fin['max_amp_ray_solution'])
-                max_amps = np.argmax(As[:, values['ray_channel']], axis=-1)
-                sol = np.array(fin['ray_tracing_solution_type'])
-#                 print(sol[:,values['ray_channel']][max_amps].shape)
-#                 print(max_amps.shape)
-#                 a = 1/0
-                mask = np.array([sol[i, values['ray_channel'], max_amps[i]] == values['ray_solution'] for i in range(len(max_amps))], dtype=np.bool)
-                triggered = triggered & mask
 
-            Aeff = area * np.sum(weights[triggered]) / n_events
+                if('n_reflections' in values.keys()):
+                    triggered = triggered & (np.array(fin[f'station_{station:d}/ray_tracing_reflection'])[:, 0, 0] == values['n_reflections'])
 
-            if('efficiency' in values.keys()):
-                SNReff, eff = np.loadtxt("analysis_efficiency_{}.csv".format(values['efficiency']), delimiter=",", unpack=True)
-                get_eff = interpolate.interp1d(SNReff, eff, bounds_error=False, fill_value=(0, eff[-1]))
-                As = np.max(np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1)[:, np.append(range(0, 8), range(12, 20))], axis=-1)  # we use the this quantity because it is always computed before noise is added!
-                if('efficiency_scale' in values.keys()):
-                    As *= values['efficiency_scale']
-                e = get_eff(As / Vrms)
-                Aeff = area * np.sum((weights * e)[triggered]) / n_events
+                Aeff = area * np.sum(weights[triggered]) / n_events
 
-            Aeffs[trigger_name].append(Aeff)
-            Aeffs_error[trigger_name].append(Aeff / np.sum(weights[triggered]) ** 0.5)
-    for trigger_name in Aeffs.keys():
-        Aeffs[trigger_name] = np.array(Aeffs[trigger_name])
-        Aeffs_error[trigger_name] = np.array(Aeffs_error[trigger_name])
+                if('efficiency' in values.keys()):
+                    SNReff, eff = np.loadtxt("analysis_efficiency_{}.csv".format(values['efficiency']), delimiter=",", unpack=True)
+                    get_eff = interpolate.interp1d(SNReff, eff, bounds_error=False, fill_value=(0, eff[-1]))
+                    As = np.max(np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1)[:, np.append(range(0, 8), range(12, 20))], axis=-1)  # we use the this quantity because it is always computed before noise is added!
+                    if('efficiency_scale' in values.keys()):
+                        As *= values['efficiency_scale']
+                    e = get_eff(As / Vrms)
+                    Aeff = area * np.sum((weights * e)[triggered]) / n_events
 
-    if zenithbins:
-        return np.array(Es), Aeffs, Aeffs_error, SNR, trigger_names, [thetamin, thetamax], deposited
-    else:
-        return np.array(Es), Aeffs, Aeffs_error, SNR, trigger_names, deposited
+                out['Aeffs'][trigger_name] = [Aeff, Aeff / np.sum(weights[triggered]) ** 0.5, np.sum(weights[triggered])]
+        Aeff_output.append(out)
+
+    return Aeff_output
 
 
 def get_Veff_water_equivalent(Veff, density_medium=0.917 * units.g / units.cm ** 3, density_water=1 * units.g / units.cm ** 3):
     """
-    convenience function to converte the effective volume of a medium with density `density_medium` to the 
+    convenience function to converte the effective volume of a medium with density `density_medium` to the
     water equivalent effective volume
-    
+
     Parameters
     ----------
     Veff: float or array
@@ -273,7 +262,7 @@ def get_Veff_water_equivalent(Veff, density_medium=0.917 * units.g / units.cm **
         the density of the medium of the Veff simulation (default deep ice)
     density water: float (optional)
         the density of water
-        
+
     Returns: water equivalen effective volume
     """
     return Veff * density_medium / density_water
@@ -282,7 +271,7 @@ def get_Veff_water_equivalent(Veff, density_medium=0.917 * units.g / units.cm **
 def get_Veff(folder, trigger_combinations={}, station=101):
     """
     calculates the effective volume from NuRadioMC hdf5 files
-    
+
     the effective volume is NOT normalized to a water equivalent. It is also NOT multiplied with the solid angle (typically 4pi).
 
     Parameters
@@ -482,48 +471,48 @@ def get_Veff(folder, trigger_combinations={}, station=101):
 def get_Veff_array(data):
     """
     calculates a multi dimensional array of effective volume calculations for fast slicing
-    
+
     the array dimensions are (energy, zenith bin, triggername, 3) where the
     last tuple is the effective volume, its uncertainty and the weighted sum of triggered events
-    
+
     Parameters
     -----------
     data: dict
         the result of the `get_Veff` function
-    
+
     Returns
     --------
      * (n_energy, n_zenith_bins, n_triggernames, 3) dimensional array of floats
      * array of unique energies
      * array of unique zenith bins
      * array of unique trigger names
-     
-     
+
+
     Examples
     ---------
-    
+
     To plot the full sky effective volume for 'all_triggers' do
-    
+
     ```
     output, uenergies, uzenith_bins, utrigger_names = get_Veff_array(data)
-    
-    
+
+
     fig, ax = plt.subplots(1, 1)
     tname = "all_triggers"
     Veff = np.average(output[:,:,get_index(tname, utrigger_names),0], axis=1)
     Vefferror = Veff / np.sum(output[:,:,get_index(tname, utrigger_names),2], axis=1)**0.5
     ax.errorbar(uenergies/units.eV, Veff/units.km**3 * 4 * np.pi, yerr=Vefferror/units.km**3 * 4 * np.pi, fmt='-o', label=tname)
-    
+
     ax.legend()
     ax.semilogy(True)
     ax.semilogx(True)
     fig.tight_layout()
     plt.show()
     ```
-    
-    
+
+
     To plot the effective volume for different declination bands do
-    
+
     ```
     fig, ax = plt.subplots(1, 1)
     tname = "LPDA_2of4_100Hz"
@@ -531,7 +520,7 @@ def get_Veff_array(data):
     Veff = output[:,iZ,get_index(tname, utrigger_names)]
     ax.errorbar(uenergies/units.eV, Veff[:,0]/units.km**3, yerr=Veff[:,1]/units.km**3,
                 label=f"zenith bin {uzenith_bins[iZ][0]/units.deg:.0f} - {uzenith_bins[iZ][1]/units.deg:.0f}")
-    
+
     iZ = 8
     Veff = output[:,iZ,get_index(tname, utrigger_names)]
     ax.errorbar(uenergies/units.eV, Veff[:,0]/units.km**3, yerr=Veff[:,1]/units.km**3,
@@ -544,15 +533,15 @@ def get_Veff_array(data):
     Veff = output[:,iZ,get_index(tname, utrigger_names)]
     ax.errorbar(uenergies/units.eV, Veff[:,0]/units.km**3, yerr=Veff[:,1]/units.km**3,
                 label=f"zenith bin {uzenith_bins[iZ][0]/units.deg:.0f} - {uzenith_bins[iZ][1]/units.deg:.0f}")
-    
-    
+
+
     ax.legend()
     ax.semilogy(True)
     ax.semilogx(True)
     fig.tight_layout()
     plt.show()
     ```
-    
+
     """
     energies = []
     zenith_bins = []
@@ -583,6 +572,109 @@ def get_Veff_array(data):
 #                 print(f"{iE}  {iT} {iTrig} {Veff}")
     return output, uenergies, uzenith_bins, utrigger_names
 
+def get_Aeff_array(data):
+    """
+    calculates a multi dimensional array of effective area calculations for fast slicing
+
+    the array dimensions are (energy, zenith bin, triggername, 3) where the
+    last tuple is the effective area, its uncertainty and the weighted sum of triggered events
+
+    Parameters
+    -----------
+    data: dict
+        the result of the `get_Aeff` function
+
+    Returns
+    --------
+     * (n_energy, n_zenith_bins, n_triggernames, 3) dimensional array of floats
+     * array of unique energies
+     * array of unique zenith bins
+     * array of unique trigger names
+
+
+    Examples
+    ---------
+
+    To plot the full sky effective volume for 'all_triggers' do
+
+    ```
+    output, uenergies, uzenith_bins, utrigger_names = get_Aeff_array(data)
+
+
+    fig, ax = plt.subplots(1, 1)
+    tname = "all_triggers"
+    Aeff = np.average(output[:,:,get_index(tname, utrigger_names),0], axis=1)
+    Aefferror = Aeff / np.sum(output[:,:,get_index(tname, utrigger_names),2], axis=1)**0.5
+    ax.errorbar(uenergies/units.eV, Aeff/units.km**3 * 4 * np.pi, yerr=Aefferror/units.km**3 * 4 * np.pi, fmt='-o', label=tname)
+
+    ax.legend()
+    ax.semilogy(True)
+    ax.semilogx(True)
+    fig.tight_layout()
+    plt.show()
+    ```
+
+
+    To plot the effective area for different declination bands do
+
+    ```
+    fig, ax = plt.subplots(1, 1)
+    tname = "LPDA_2of4_100Hz"
+    iZ = 9
+    Aeff = output[:,iZ,get_index(tname, utrigger_names)]
+    ax.errorbar(uenergies/units.eV, Aeff[:,0]/units.km**2, yerr=Aeff[:,1]/units.km**2,
+                label=f"zenith bin {uzenith_bins[iZ][0]/units.deg:.0f} - {uzenith_bins[iZ][1]/units.deg:.0f}")
+
+    iZ = 8
+    Aeff = output[:,iZ,get_index(tname, utrigger_names)]
+    ax.errorbar(uenergies/units.eV, Aeff[:,0]/units.km**2, yerr=Aeff[:,1]/units.km**2,
+                label=f"zenith bin {uzenith_bins[iZ][0]/units.deg:.0f} - {uzenith_bins[iZ][1]/units.deg:.0f}")
+    iZ = 7
+    Aeff = output[:,iZ,get_index(tname, utrigger_names)]
+    ax.errorbar(uenergies/units.eV, Aeff[:,0]/units.km**2, yerr=Aeff[:,1]/units.km**2,
+                label=f"zenith bin {uzenith_bins[iZ][0]/units.deg:.0f} - {uzenith_bins[iZ][1]/units.deg:.0f}")
+    iZ = 10
+    Aeff = output[:,iZ,get_index(tname, utrigger_names)]
+    ax.errorbar(uenergies/units.eV, Aeff[:,0]/units.km**2, yerr=Aeff[:,1]/units.km**2,
+                label=f"zenith bin {uzenith_bins[iZ][0]/units.deg:.0f} - {uzenith_bins[iZ][1]/units.deg:.0f}")
+
+
+    ax.legend()
+    ax.semilogy(True)
+    ax.semilogx(True)
+    fig.tight_layout()
+    plt.show()
+    ```
+
+    """
+    energies = []
+    zenith_bins = []
+    trigger_names = []
+    for d in data:
+        energies.append(d['energy'])
+        zenith_bins.append([d['thetamin'], d['thetamax']])
+        for triggername in d['Aeffs']:
+            trigger_names.append(triggername)
+
+    energies = np.array(energies)
+    zenith_bins = np.array(zenith_bins)
+    trigger_names = np.array(trigger_names)
+    uenergies = np.unique(energies)
+    uzenith_bins = np.unique(zenith_bins, axis=0)
+    utrigger_names = np.unique(trigger_names)
+    output = np.zeros((len(uenergies), len(uzenith_bins), len(utrigger_names), 3))
+    print(f"unique energies {uenergies}")
+    print(f"unique zenith angle bins {uzenith_bins/units.deg}")
+    print(f"unique energies {utrigger_names}")
+
+    for d in data:
+        iE = np.squeeze(np.argwhere(d['energy'] == uenergies))
+        iT = np.squeeze(np.argwhere([d['thetamin'], d['thetamax']] == uzenith_bins))[0][0]
+        for triggername, Veff in d['Aeffs'].items():
+            iTrig = np.squeeze(np.argwhere(triggername == utrigger_names))
+            output[iE, iT, iTrig] = Aeff
+#                 print(f"{iE}  {iT} {iTrig} {Aeff}")
+    return output, uenergies, uzenith_bins, utrigger_names
 
 def get_index(value, array):
     return np.squeeze(np.argwhere(value == array))
@@ -630,34 +722,45 @@ def export(filename, data, trigger_names=None, export_format='yaml'):
         elif(export_format == 'json'):
             json.dump(output, fout, sort_keys=True, indent=4)
 
-
-def exportAeffPerZenith(folderlist, outputfile):
+def export_Aeff(filename, data, trigger_names=None, export_format='yaml'):
     """
-    export effective areas into a human readable JSON file
-    We assume a binning in zenithal angles
+    export effective areas into a human readable JSON or YAML file
 
     Parameters
     ----------
-    folderlist: strings list
-        list containing the input folders
-    outputfile: string
-        name for the output file
+    filename: string
+        the output filename of the JSON file
+    data: array
+        the output of the `getAeff` function
+    trigger_names: list of strings (optional, default None)
+        save only specific trigger names, if None all triggers are exported
+    export_format: string (default "yaml")
+        specify output format, choose
+        * "yaml"
+        * "json"
     """
-    output = {}
-    for folder in folderlist:
-
-        Es, Aeffs, Aeffs_error, SNR, trigger_names, thetas, deposited = get_Aeff_proposal(folder, zenithbins=True)
-        output[thetas[0]] = {}
-
-        for trigger_name in trigger_names:
-            output[thetas[0]][trigger_name] = {}
-            if deposited:
-                output[thetas[0]][trigger_name]['deposited_energies'] = list(Es)
-            else:
-                output[thetas[0]][trigger_name]['energies'] = list(Es)
-            output[thetas[0]][trigger_name]['Aeff'] = list(Aeffs[trigger_name])
-            output[thetas[0]][trigger_name]['Aeff_error'] = list(Aeffs_error[trigger_name])
-
-    with open(outputfile, 'w+') as fout:
-
-        json.dump(output, fout, sort_keys=True, indent=4)
+    output = []
+    for i in range(len(data)):
+        tmp = {}
+        for key in data[i]:
+            if (key != 'Aeffs'):
+                if isinstance(data[i][key], np.generic):
+                    tmp[key] = data[i][key].item()
+                else:
+                    tmp[key] = data[i][key]
+        tmp['Aeffs'] = {}
+        for trigger_name in data[i]['Aeffs']:
+            if(trigger_names is None or trigger_name in trigger_names):
+                print(trigger_name)
+                tmp['Aeffs'][trigger_name] = []
+                for value in data[i]['Aeffs'][trigger_name]:
+                    tmp['Aeffs'][trigger_name].append(float(value))
+        output.append(tmp)
+    for key in output:
+        print("miau", key)
+    with open(filename, 'w') as fout:
+        if(export_format == 'yaml'):
+            import yaml
+            yaml.dump(output, fout)
+        elif(export_format == 'json'):
+            json.dump(output, fout, sort_keys=True, indent=4)

--- a/NuRadioMC/utilities/Veff.py
+++ b/NuRadioMC/utilities/Veff.py
@@ -278,40 +278,17 @@ def get_Veff(folder, trigger_combinations={}, station=101):
             * 'n_reflections': int
                 the number of bottom reflections of the ray tracing solution that likely triggered
                 assuming that the solution with the shortest travel time caused the trigger, only considering channel 0
-            
-    zenithbins: bool
-        If true, returns the minimum and maximum zenith angles
+
     station: int
         the station that should be considered
 
     Returns
     ----------
-    np.array(Es): numpy floats array
-        Smallest energy for each bin
-    Veffs: dict of floats list
-        Effective volumes (m^3)
-    Veffs_error: dict of floats list
-        Effective volume uncertainties (m^3)
-    SNR: floats list
-        Signal to noise ratios
-    trigger_names: string list
-        Trigger names
-    dOmegas: numpy floats array
-        the solid angle the effective volume is calculated for
-    thetamin/max: numpy array of [float, float] tuples
-        Mimimum and maximum zenith angles
-    deposited: bool
-        True if the energies are deposited energies
-        False if the energies are primary neutrino energies
+    list of dictionary. Each file is one entry. The dictionary keys store all relevant properties
     """
+    Veff_output = []
     trigger_names = None
     trigger_names_dict = {}
-    Veffs = {}
-    SNR = {}
-    Veffs_error = {}
-    dOmegas = []
-    zenith_bins = []
-    Es = []
     prev_deposited = None
     deposited = False
 
@@ -325,14 +302,12 @@ def get_Veff(folder, trigger_combinations={}, station=101):
             if prev_deposited is None:
                 prev_deposited = deposited
             elif prev_deposited != deposited:
-                print("Warning! The deposited parameter is not consistent!")
+                raise AttributeError("The deposited parameter is not consistent among the input files!")
 
         if('trigger_names' in fin.attrs):
             trigger_names = fin.attrs['trigger_names']
         if(len(trigger_names) > 0):
             for iT, trigger_name in enumerate(trigger_names):
-                Veffs[trigger_name] = []
-                Veffs_error[trigger_name] = []
                 trigger_names_dict[trigger_name] = iT
             break
 
@@ -341,8 +316,11 @@ def get_Veff(folder, trigger_combinations={}, station=101):
 
     for iF, filename in enumerate(sorted(glob.glob(os.path.join(folder, '*.hdf5')))):
         fin = h5py.File(filename, 'r')
+        out = {}
         E = fin.attrs['Emin']
-        Es.append(E)
+        if(fin.attrs['Emax'] != E):
+            raise AttributeError("min and max energy do not match!")
+        out['energy'] = E
 
         weights = np.array(fin['weights'])
         #triggered = np.array(fin['triggered'])
@@ -351,15 +329,11 @@ def get_Veff(folder, trigger_combinations={}, station=101):
         if(trigger_names is None):
             trigger_names = fin.attrs['trigger_names']
             for iT, trigger_name in enumerate(trigger_names):
-                Veffs[trigger_name] = []
-                Veffs_error[trigger_name] = []
                 trigger_names_dict[trigger_name] = iT
-            print(trigger_names)
         else:
             if(np.any(trigger_names != fin.attrs['trigger_names'])):
-
                 if( triggered.size == 0 and fin.attrs['trigger_names'].size == 0 ):
-                    print("file {} has not triggering events. Using trigger names from another file".format(filename))
+                    print("file {} has no triggering events. Using trigger names from another file".format(filename))
                 else:
                     print("file {} has inconsistent trigger names: {}".format(filename, fin.attrs['trigger_names']))
                     raise
@@ -385,103 +359,209 @@ def get_Veff(folder, trigger_combinations={}, station=101):
         Vrms = fin.attrs['Vrms']
 
         # Solid angle needed for the effective volume calculations
-        omega = np.abs(phimax - phimin) * np.abs( np.cos(thetamin)-np.cos(thetamax) )
-        dOmegas.append(omega)
-        zenith_bins.append((thetamin, thetamax))
+        out['domega'] = np.abs(phimax - phimin) * np.abs( np.cos(thetamin)-np.cos(thetamax) )
+        out['thetamin'] = thetamin
+        out['thetamax'] = thetamax
+        out['deposited'] = deposited
+        out['Veffs'] = {}
+        out['n_triggered_weighted'] = {}
+        out['SNRs'] = {}
+        
+        if(triggered.size == 0):
+            for iT, trigger_name in enumerate(trigger_names):
+                out['Veffs'][trigger_name] = [0, 0, 0]
+            for trigger_name, values in iteritems(trigger_combinations):
+                out['Veffs'][trigger_name] = [0, 0, 0]
+        else:
+            for iT, trigger_name in enumerate(trigger_names):
+                triggered = np.array(fin['multiple_triggers'][:, iT], dtype=np.bool)
+                Veff = V * np.sum(weights[triggered]) / n_events
+                Veff_error = 0
+                if(np.sum(weights[triggered]) > 0):
+                    Veff_error = Veff / np.sum(weights[triggered])**0.5
+                out['Veffs'][trigger_name] = [Veff, Veff_error, np.sum(weights[triggered])]
 
-        for iT, trigger_name in enumerate(trigger_names):
-            triggered = np.array(fin['multiple_triggers'][:, iT], dtype=np.bool)
-            Veff = V * np.sum(weights[triggered]) / n_events
-            Veffs[trigger_name].append(Veff)
-            try:
-                Veffs_error[trigger_name].append(Veff / np.sum(weights[triggered])**0.5)
-            except:
-                Veffs_error[trigger_name].append(np.nan)
-#             print("{}: log(E) = {:.3g}, Veff = {:.3f}km^3 st".format(trigger_name, np.log10(E), Veff / units.km**3))
-
-        for trigger_name, values in iteritems(trigger_combinations):
-            indiv_triggers = values['triggers']
-            if(trigger_name not in Veffs):
-                Veffs[trigger_name] = []
-                Veffs_error[trigger_name] = []
-            triggered = np.zeros_like(fin['multiple_triggers'][:, 0], dtype=np.bool)
-            if(isinstance(indiv_triggers, str)):
-                triggered = triggered | np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_triggers]], dtype=np.bool)
-            else:
-                for indiv_trigger in indiv_triggers:
-                    triggered = triggered | np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_trigger]], dtype=np.bool)
-            if 'triggerAND' in values:
-                triggered = triggered & np.array(fin['multiple_triggers'][:, trigger_names_dict[values['triggerAND']]], dtype=np.bool)
-            if 'notriggers' in values:
-                indiv_triggers = values['notriggers']
+            for trigger_name, values in iteritems(trigger_combinations):
+                indiv_triggers = values['triggers']
+                triggered = np.zeros_like(fin['multiple_triggers'][:, 0], dtype=np.bool)
                 if(isinstance(indiv_triggers, str)):
-                    triggered = triggered & ~np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_triggers]], dtype=np.bool)
+                    triggered = triggered | np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_triggers]], dtype=np.bool)
                 else:
                     for indiv_trigger in indiv_triggers:
-                        triggered = triggered & ~np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_trigger]], dtype=np.bool)
-            if('min_sigma' in values.keys()):
-                if(isinstance(values['min_sigma'], list)):
-                    if(trigger_name not in SNR):
-                        SNR[trigger_name] = {}
-                    masks = np.zeros_like(triggered)
-                    for iS in range(len(values['min_sigma'])):
-#                         As = np.array(fin['maximum_amplitudes'])
+                        triggered = triggered | np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_trigger]], dtype=np.bool)
+                if 'triggerAND' in values:
+                    triggered = triggered & np.array(fin['multiple_triggers'][:, trigger_names_dict[values['triggerAND']]], dtype=np.bool)
+                if 'notriggers' in values:
+                    indiv_triggers = values['notriggers']
+                    if(isinstance(indiv_triggers, str)):
+                        triggered = triggered & ~np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_triggers]], dtype=np.bool)
+                    else:
+                        for indiv_trigger in indiv_triggers:
+                            triggered = triggered & ~np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_trigger]], dtype=np.bool)
+                if('min_sigma' in values.keys()):
+                    if(isinstance(values['min_sigma'], list)):
+                        if(trigger_name not in out['SNR']):
+                            out['SNR'][trigger_name] = {}
+                        masks = np.zeros_like(triggered)
+                        for iS in range(len(values['min_sigma'])):
+    #                         As = np.array(fin['maximum_amplitudes'])
+                            As = np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1) # we use the this quantity because it is always computed before noise is added!
+                            As_sorted = np.sort(As[:, values['channels'][iS]], axis=1)
+                            # the smallest of the three largest amplitudes
+                            max_amplitude = As_sorted[:, -values['n_channels'][iS]]
+                            mask = np.sum(As[:, values['channels'][iS]] >= (values['min_sigma'][iS] * Vrms), axis=1) >= values['n_channels'][iS]
+                            masks = masks | mask
+                            out['SNR'][trigger_name][iS] = max_amplitude[mask] / Vrms
+                        triggered = triggered & masks
+                    else:
+    #                     As = np.array(fin['maximum_amplitudes'])
                         As = np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1) # we use the this quantity because it is always computed before noise is added!
-                        As_sorted = np.sort(As[:, values['channels'][iS]], axis=1)
-                        # the smallest of the three largest amplitudes
-                        max_amplitude = As_sorted[:, -values['n_channels'][iS]]
-                        mask = np.sum(As[:, values['channels'][iS]] >= (values['min_sigma'][iS] * Vrms), axis=1) >= values['n_channels'][iS]
-                        masks = masks | mask
-                        if(iS not in SNR[trigger_name]):
-                            SNR[trigger_name][iS] = []
-                        SNR[trigger_name][iS].append([max_amplitude[mask] / Vrms])
-                    triggered = triggered & masks
-                else:
-                    if(trigger_name not in SNR):
-                        SNR[trigger_name] = []
-#                     As = np.array(fin['maximum_amplitudes'])
-                    As = np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1) # we use the this quantity because it is always computed before noise is added!
-    #                 print(As.shape)
-#                     print(trigger_name, values['channels'])
-                    As_sorted = np.sort(As[:, values['channels']], axis=1)
-                    max_amplitude = As_sorted[:, -values['n_channels']]  # the smallest of the three largest amplitudes
-    #                 print(np.sum(As_sorted[:, -values['n_channels']] > (values['min_sigma'] * Vrms)))
-                    mask = np.sum(As[:, values['channels']] >= (values['min_sigma'] * Vrms), axis=1) >= values['n_channels']
-    #                 max_amplitude[~mask] = 0
-                    SNR[trigger_name].append(As_sorted[mask] / Vrms)
-    #                 print(Vrms, mask.shape, np.sum(mask))
+        #                 print(As.shape)
+    #                     print(trigger_name, values['channels'])
+                        As_sorted = np.sort(As[:, values['channels']], axis=1)
+                        max_amplitude = As_sorted[:, -values['n_channels']]  # the smallest of the three largest amplitudes
+        #                 print(np.sum(As_sorted[:, -values['n_channels']] > (values['min_sigma'] * Vrms)))
+                        mask = np.sum(As[:, values['channels']] >= (values['min_sigma'] * Vrms), axis=1) >= values['n_channels']
+        #                 max_amplitude[~mask] = 0
+                        out['SNR'][trigger_name] = As_sorted[mask] / Vrms
+        #                 print(Vrms, mask.shape, np.sum(mask))
+                        triggered = triggered & mask
+                if('ray_solution' in values.keys()):
+                    As = np.array(fin['max_amp_ray_solution'])
+                    max_amps = np.argmax(As[:, values['ray_channel']], axis=-1)
+                    sol = np.array(fin['ray_tracing_solution_type'])
+    #                 print(sol[:,values['ray_channel']][max_amps].shape)
+    #                 print(max_amps.shape)
+    #                 a = 1/0
+                    mask = np.array([sol[i,values['ray_channel'], max_amps[i]] == values['ray_solution'] for i in range(len(max_amps))], dtype=np.bool)
                     triggered = triggered & mask
-            if('ray_solution' in values.keys()):
-                As = np.array(fin['max_amp_ray_solution'])
-                max_amps = np.argmax(As[:, values['ray_channel']], axis=-1)
-                sol = np.array(fin['ray_tracing_solution_type'])
-#                 print(sol[:,values['ray_channel']][max_amps].shape)
-#                 print(max_amps.shape)
-#                 a = 1/0
-                mask = np.array([sol[i,values['ray_channel'], max_amps[i]] == values['ray_solution'] for i in range(len(max_amps))], dtype=np.bool)
-                triggered = triggered & mask
-                
-            if('n_reflections' in values.keys()):
-                triggered = triggered & (np.array(fin[f'station_{station:d}/ray_tracing_reflection'])[:,0,0] == values['n_reflections'])
+                    
+                if('n_reflections' in values.keys()):
+                    triggered = triggered & (np.array(fin[f'station_{station:d}/ray_tracing_reflection'])[:,0,0] == values['n_reflections'])
+    
+                Veff = V * np.sum(weights[triggered]) / n_events
+    
+                if('efficiency' in values.keys()):
+                    SNReff, eff = np.loadtxt("analysis_efficiency_{}.csv".format(values['efficiency']), delimiter=",", unpack=True)
+                    get_eff = interpolate.interp1d(SNReff, eff, bounds_error=False, fill_value=(0, eff[-1]))
+                    As = np.max(np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1)[:,np.append(range(0, 8), range(12, 20))], axis=-1) # we use the this quantity because it is always computed before noise is added!
+                    if('efficiency_scale' in values.keys()):
+                        As *= values['efficiency_scale']
+                    e = get_eff(As/Vrms)
+                    Veff = V * np.sum((weights*e)[triggered]) / n_events
+    
+                out['Veffs'][trigger_name] = [Veff, Veff / np.sum(weights[triggered])**0.5, np.sum(weights[triggered])]
+        Veff_output.append(out)
 
-            Veff = V * np.sum(weights[triggered]) / n_events
+    return Veff_output
 
-            if('efficiency' in values.keys()):
-                SNReff, eff = np.loadtxt("analysis_efficiency_{}.csv".format(values['efficiency']), delimiter=",", unpack=True)
-                get_eff = interpolate.interp1d(SNReff, eff, bounds_error=False, fill_value=(0, eff[-1]))
-                As = np.max(np.max(np.nan_to_num(fin['max_amp_ray_solution']), axis=-1)[:,np.append(range(0, 8), range(12, 20))], axis=-1) # we use the this quantity because it is always computed before noise is added!
-                if('efficiency_scale' in values.keys()):
-                    As *= values['efficiency_scale']
-                e = get_eff(As/Vrms)
-                Veff = V * np.sum((weights*e)[triggered]) / n_events
 
-            Veffs[trigger_name].append(Veff)
-            Veffs_error[trigger_name].append(Veff / np.sum(weights[triggered])**0.5)
-    for trigger_name in Veffs.keys():
-        Veffs[trigger_name] = np.array(Veffs[trigger_name])
-        Veffs_error[trigger_name] = np.array(Veffs_error[trigger_name])
+def get_Veff_array(data):
+    """
+    calculates a multi dimensional array of effective volume calculations for fast slicing
+    
+    the array dimensions are (energy, zenith bin, triggername, 3) where the
+    last tuple is the effective volume, its uncertainty and the weighted sum of triggered events
+    
+    Parameters
+    -----------
+    data: dict
+        the result of the `get_Veff` function
+    
+    Returns
+    --------
+     * (n_energy, n_zenith_bins, n_triggernames, 3) dimensional array of floats
+     * array of unique energies
+     * array of unique zenith bins
+     * array of unique trigger names
+     
+     
+    Examples
+    ---------
+    
+    To plot the full sky effective volume for 'all_triggers' do
+    
+    ```
+    output, uenergies, uzenith_bins, utrigger_names = get_Veff_array(data)
+    
+    
+    fig, ax = plt.subplots(1, 1)
+    tname = "all_triggers"
+    Veff = np.average(output[:,:,get_index(tname, utrigger_names),0], axis=1)
+    Vefferror = Veff / np.sum(output[:,:,get_index(tname, utrigger_names),2], axis=1)**0.5
+    ax.errorbar(uenergies/units.eV, Veff/units.km**3 * 4 * np.pi, yerr=Vefferror/units.km**3 * 4 * np.pi, fmt='-o', label=tname)
+    
+    ax.legend()
+    ax.semilogy(True)
+    ax.semilogx(True)
+    fig.tight_layout()
+    plt.show()
+    ```
+    
+    
+    To plot the effective volume for different declination bands do
+    
+    ```
+    fig, ax = plt.subplots(1, 1)
+    tname = "LPDA_2of4_100Hz"
+    iZ = 9
+    Veff = output[:,iZ,get_index(tname, utrigger_names)]
+    ax.errorbar(uenergies/units.eV, Veff[:,0]/units.km**3, yerr=Veff[:,1]/units.km**3,
+                label=f"zenith bin {uzenith_bins[iZ][0]/units.deg:.0f} - {uzenith_bins[iZ][1]/units.deg:.0f}")
+    
+    iZ = 8
+    Veff = output[:,iZ,get_index(tname, utrigger_names)]
+    ax.errorbar(uenergies/units.eV, Veff[:,0]/units.km**3, yerr=Veff[:,1]/units.km**3,
+                label=f"zenith bin {uzenith_bins[iZ][0]/units.deg:.0f} - {uzenith_bins[iZ][1]/units.deg:.0f}")
+    iZ = 7
+    Veff = output[:,iZ,get_index(tname, utrigger_names)]
+    ax.errorbar(uenergies/units.eV, Veff[:,0]/units.km**3, yerr=Veff[:,1]/units.km**3,
+                label=f"zenith bin {uzenith_bins[iZ][0]/units.deg:.0f} - {uzenith_bins[iZ][1]/units.deg:.0f}")
+    iZ = 10
+    Veff = output[:,iZ,get_index(tname, utrigger_names)]
+    ax.errorbar(uenergies/units.eV, Veff[:,0]/units.km**3, yerr=Veff[:,1]/units.km**3,
+                label=f"zenith bin {uzenith_bins[iZ][0]/units.deg:.0f} - {uzenith_bins[iZ][1]/units.deg:.0f}")
+    
+    
+    ax.legend()
+    ax.semilogy(True)
+    ax.semilogx(True)
+    fig.tight_layout()
+    plt.show()
+    ```
+    
+    """
+    energies = []
+    zenith_bins = []
+    trigger_names = []
+    for d in data:
+        energies.append(d['energy'])
+        zenith_bins.append([d['thetamin'], d['thetamax']])
+        for triggername in d['Veffs']:
+            trigger_names.append(triggername)
+            
+    energies = np.array(energies)
+    zenith_bins = np.array(zenith_bins)
+    trigger_names = np.array(trigger_names)
+    uenergies = np.unique(energies)
+    uzenith_bins = np.unique(zenith_bins, axis=0)
+    utrigger_names = np.unique(trigger_names)
+    output = np.zeros((len(uenergies), len(uzenith_bins), len(utrigger_names), 3))
+    print(f"unique energies {uenergies}")
+    print(f"unique zenith angle bins {uzenith_bins/units.deg}")
+    print(f"unique energies {utrigger_names}")
+    
+    for d in data:
+        iE = np.squeeze(np.argwhere(d['energy'] == uenergies))
+        iT = np.squeeze(np.argwhere([d['thetamin'], d['thetamax']] == uzenith_bins))[0][0]
+        for triggername, Veff in d['Veffs'].items():
+            iTrig = np.squeeze(np.argwhere(triggername == utrigger_names))
+            output[iE, iT, iTrig] = Veff
+#                 print(f"{iE}  {iT} {iTrig} {Veff}")
+    return output, uenergies, uzenith_bins, utrigger_names
 
-    return np.array(Es), Veffs, Veffs_error, SNR, trigger_names, np.array(dOmegas), np.array(zenith_bins), deposited
+def get_index(value, array):
+    return np.squeeze(np.argwhere(value==array))
 
 def exportVeff(filename, trigger_names, Es, Veffs, Veffs_error):
     """

--- a/NuRadioMC/utilities/Veff.py
+++ b/NuRadioMC/utilities/Veff.py
@@ -276,7 +276,7 @@ def get_Veff_water_equivalent(Veff, density_medium=0.917 * units.g / units.cm **
         
     Returns: water equivalen effective volume
     """
-    return Veff * density_water / density_medium
+    return Veff * density_medium / density_water
 
 
 def get_Veff(folder, trigger_combinations={}, station=101):

--- a/NuRadioMC/utilities/Veff.py
+++ b/NuRadioMC/utilities/Veff.py
@@ -283,7 +283,7 @@ def get_Veff(folder, trigger_combinations={}, station=101):
     """
     calculates the effective volume from NuRadioMC hdf5 files
     
-    the effective volume is NOT normalized to a water equivalent. 
+    the effective volume is NOT normalized to a water equivalent. It is also NOT multiplied with the solid angle (typically 4pi).
 
     Parameters
     ----------

--- a/NuRadioMC/utilities/cross_sections.py
+++ b/NuRadioMC/utilities/cross_sections.py
@@ -13,21 +13,21 @@ def param(energy, inttype='cc'):
     """
 
     if inttype == 'cc':
-        c = (-1.826, -17.31, -6.406, 1.431, -17.91) # nu, CC
+        c = (-1.826, -17.31, -6.406, 1.431, -17.91)  # nu, CC
     elif inttype == 'nc':
-        c = (-1.826, -17.31, -6.448, 1.431, -18.61) # nu, NC
+        c = (-1.826, -17.31, -6.448, 1.431, -18.61)  # nu, NC
     elif inttype == 'cc_bar':
-        c = (-1.033, -15.95, -7.247, 1.569, -17.72) # nu_bar, CC
+        c = (-1.033, -15.95, -7.247, 1.569, -17.72)  # nu_bar, CC
     elif inttype == 'nc_bar':
-        c = (-1.033, -15.95, -7.296, 1.569, -18.30) # nu_bar, NC
+        c = (-1.033, -15.95, -7.296, 1.569, -18.30)  # nu_bar, NC
     else:
         logger.error("Type {0} of interaction not defined".format(inttype))
         raise NotImplementedError
 
-    epsilon = np.log10(energy/units.GeV)
+    epsilon = np.log10(energy / units.GeV)
     l_eps = np.log(epsilon - c[0])
-    crscn = c[1] + c[2] * l_eps + c[3] * l_eps**2 + c[4]/l_eps
-    crscn = np.power(10,crscn) * units.cm**2
+    crscn = c[1] + c[2] * l_eps + c[3] * l_eps ** 2 + c[4] / l_eps
+    crscn = np.power(10, crscn) * units.cm ** 2
     return crscn
 
 
@@ -38,92 +38,92 @@ def csms(energy, inttype, flavors):
     JHEP 08 (2011) 042
     """
     if type(inttype) == str:
-        inttype = np.array([inttype]*energy.shape[0])
+        inttype = np.array([inttype] * energy.shape[0])
 
-    if ( type(flavors) == int or type(flavors) == np.int64 ):
-        flavors = np.array([flavors]*energy.shape[0])
+    if (type(flavors) == int or type(flavors) == np.int64):
+        flavors = np.array([flavors] * energy.shape[0])
 
     neutrino = np.array((
-        [50,0.32,0.10],
-        [100,0.65,0.20],
-        [200,1.3,0.41],
-        [500,3.2,1.0],
-        [1000,6.2,2.0],
-        [2000,12.,3.8],
-        [5000,27.,8.6],
-        [10000,47.,15.],
-        [20000,77.,26.],
-        [50000,140.,49.],
-        [100000,210.,75.],
-        [200000,310.,110.],
-        [500000,490.,180.],
-        [1e6,690.,260.],
-        [2e6,950.,360.],
-        [5e6,1400.,540.],
-        [1e7,1900.,730.],
-        [2e7,2600.,980.],
-        [5e7,3700.,1400.],
-        [1e8,4800.,1900.],
-        [2e8,6200.,2400.],
-        [5e8,8700.,3400.],
-        [1e9,11000.,4400.],
-        [2e9,14000.,5600.],
-        [5e9,19000.,7600.],
-        [1e10,24000.,9600.],
-        [2e10,30000.,12000.],
-        [5e10,39000.,16000.],
-        [1e11,48000.,20000.],
-        [2e11,59000.,24000.],
-        [5e11,75000.,31000.]
+        [50, 0.32, 0.10],
+        [100, 0.65, 0.20],
+        [200, 1.3, 0.41],
+        [500, 3.2, 1.0],
+        [1000, 6.2, 2.0],
+        [2000, 12., 3.8],
+        [5000, 27., 8.6],
+        [10000, 47., 15.],
+        [20000, 77., 26.],
+        [50000, 140., 49.],
+        [100000, 210., 75.],
+        [200000, 310., 110.],
+        [500000, 490., 180.],
+        [1e6, 690., 260.],
+        [2e6, 950., 360.],
+        [5e6, 1400., 540.],
+        [1e7, 1900., 730.],
+        [2e7, 2600., 980.],
+        [5e7, 3700., 1400.],
+        [1e8, 4800., 1900.],
+        [2e8, 6200., 2400.],
+        [5e8, 8700., 3400.],
+        [1e9, 11000., 4400.],
+        [2e9, 14000., 5600.],
+        [5e9, 19000., 7600.],
+        [1e10, 24000., 9600.],
+        [2e10, 30000., 12000.],
+        [5e10, 39000., 16000.],
+        [1e11, 48000., 20000.],
+        [2e11, 59000., 24000.],
+        [5e11, 75000., 31000.]
         ))
 
-    neutrino[:,0] *= units.GeV
-    neutrino[:,1] *= units.picobarn #CC
-    neutrino[:,2] *= units.picobarn #NC
+    neutrino[:, 0] *= units.GeV
+    neutrino[:, 1] *= units.picobarn  # CC
+    neutrino[:, 2] *= units.picobarn  # NC
 
-    neutrino_cc = interp1d(neutrino[:,0], neutrino[:,1],bounds_error=True)
-    neutrino_nc = interp1d(neutrino[:,0], neutrino[:,2],bounds_error=True)
+    neutrino_cc = interp1d(neutrino[:, 0], neutrino[:, 1], bounds_error=True)
+    neutrino_nc = interp1d(neutrino[:, 0], neutrino[:, 2], bounds_error=True)
 
     antineutrino = np.array((
-        [50,0.15,0.05],
-        [100,0.33,0.12],
-        [200,0.69,0.24],
-        [500,1.8,0.61],
-        [1000,3.6,1.20],
-        [2000,7.,2.4],
-        [5000,17.,5.8],
-        [10000,31.,11.],
-        [20000,55.,19.],
-        [50000,110.,39.],
-        [100000,180.,64.],
-        [200000,270.,99.],
-        [500000,460.,170.],
-        [1e6,660.,240.],
-        [2e6,920.,350.],
-        [5e6,1400.,530.],
-        [1e7,1900.,730.],
-        [2e7,2500.,980.],
-        [5e7,3700.,1400.],
-        [1e8,4800.,1900.],
-        [2e8,6200.,2400.],
-        [5e8,8700.,3400.],
-        [1e9,11000.,4400.],
-        [2e9,14000.,5600.],
-        [5e9,19000.,7600.],
-        [1e10,24000.,9600.],
-        [2e10,30000.,12000.],
-        [5e10,39000.,16000.],
-        [1e11,48000.,20000.],
-        [2e11,59000.,24000.],
-        [5e11,75000.,31000.]
+        [50, 0.15, 0.05],
+        [100, 0.33, 0.12],
+        [200, 0.69, 0.24],
+        [500, 1.8, 0.61],
+        [1000, 3.6, 1.20],
+        [2000, 7., 2.4],
+        [5000, 17., 5.8],
+        [10000, 31., 11.],
+        [20000, 55., 19.],
+        [50000, 110., 39.],
+        [100000, 180., 64.],
+        [200000, 270., 99.],
+        [500000, 460., 170.],
+        [1e6, 660., 240.],
+        [2e6, 920., 350.],
+        [5e6, 1400., 530.],
+        [1e7, 1900., 730.],
+        [2e7, 2500., 980.],
+        [5e7, 3700., 1400.],
+        [1e8, 4800., 1900.],
+        [2e8, 6200., 2400.],
+        [5e8, 8700., 3400.],
+        [1e9, 11000., 4400.],
+        [2e9, 14000., 5600.],
+        [5e9, 19000., 7600.],
+        [1e10, 24000., 9600.],
+        [2e10, 30000., 12000.],
+        [5e10, 39000., 16000.],
+        [1e11, 48000., 20000.],
+        [2e11, 59000., 24000.],
+        [5e11, 75000., 31000.]
     ))
 
-    antineutrino[:,0] *= units.GeV
-    antineutrino[:,1] *= units.picobarn #CC
-    antineutrino[:,2] *= units.picobarn #NC
+    antineutrino[:, 0] *= units.GeV
+    antineutrino[:, 1] *= units.picobarn  # CC
+    antineutrino[:, 2] *= units.picobarn  # NC
 
-    antineutrino_cc = interp1d(antineutrino[:,0], antineutrino[:,1],bounds_error=True)
-    antineutrino_nc = interp1d(antineutrino[:,0], antineutrino[:,2],bounds_error=True)
+    antineutrino_cc = interp1d(antineutrino[:, 0], antineutrino[:, 1], bounds_error=True)
+    antineutrino_nc = interp1d(antineutrino[:, 0], antineutrino[:, 2], bounds_error=True)
 
     crscn = np.zeros_like(energy)
 
@@ -140,7 +140,7 @@ def csms(energy, inttype, flavors):
     return crscn
 
 
-def get_nu_cross_section(energy, flavors, inttype='total', cross_section_type = 'ctw'):
+def get_nu_cross_section(energy, flavors, inttype='total', cross_section_type='ctw'):
     """
     return neutrino cross-section
 
@@ -171,48 +171,46 @@ def get_nu_cross_section(energy, flavors, inttype='total', cross_section_type = 
         csms   : A. Cooper-Sarkar, P. Mertsch, S. Sarkar, JHEP 08 (2011) 042
     """
 
-
     if cross_section_type == 'ghandi':
-        crscn = 7.84e-36 * units.cm**2 * np.power(energy/units.GeV,0.363)
+        crscn = 7.84e-36 * units.cm ** 2 * np.power(energy / units.GeV, 0.363)
 
     elif cross_section_type == 'ctw':
         crscn = np.zeros_like(energy)
         if type(inttype) == str:
             if inttype == 'total':
 
-                if ( type(flavors) == int or type(flavors) == np.int64 ):
+                if (type(flavors) == int or type(flavors) == np.int64):
                     if flavors >= 0:
-                        crscn = param(energy,'nc') + param(energy,'cc')
+                        crscn = param(energy, 'nc') + param(energy, 'cc')
                     else:
-                        crscn = param(energy,'nc_bar') + param(energy,'cc_bar')
+                        crscn = param(energy, 'nc_bar') + param(energy, 'cc_bar')
                 else:
                     antiparticles = np.where(flavors < 0)
                     particles = np.where(flavors >= 0)
 
-                    crscn[particles] = param(energy[particles],'nc') + param(energy[particles],'cc')
-                    crscn[antiparticles] = param(energy[antiparticles],'nc_bar') + param(energy[antiparticles],'cc_bar')
+                    crscn[particles] = param(energy[particles], 'nc') + param(energy[particles], 'cc')
+                    crscn[antiparticles] = param(energy[antiparticles], 'nc_bar') + param(energy[antiparticles], 'cc_bar')
 
-            if (inttype == 'cc') or (inttype =='nc'):
-                if ( type(flavors) == int or type(flavors) == np.int64 ):
-                    crscn = param(energy,inttype)
+            if (inttype == 'cc') or (inttype == 'nc'):
+                if (type(flavors) == int or type(flavors) == np.int64):
+                    crscn = param(energy, inttype)
                 else:
                     antiparticles = np.where(flavors < 0)
                     particles = np.where(flavors >= 0)
-                    crscn[particles] = param(energy[particles],inttype)
-                    crscn[antiparticles] = param(energy[antiparticles],inttype)
+                    crscn[particles] = param(energy[particles], inttype)
+                    crscn[antiparticles] = param(energy[antiparticles], inttype)
         else:
 
-                if ( type(flavors) == int or type(flavors) == np.int64 ):
+                if (type(flavors) == int or type(flavors) == np.int64):
 
                     particles_cc = np.where(inttype == 'cc')
                     particles_nc = np.where(inttype == 'nc')
                     if flavors >= 0:
-                        crscn[particles_cc] = param(energy[particles_cc],'cc')
-                        crscn[particles_nc] = param(energy[particles_nc],'nc')
+                        crscn[particles_cc] = param(energy[particles_cc], 'cc')
+                        crscn[particles_nc] = param(energy[particles_nc], 'nc')
                     else:
-                        crscn[particles_cc] = param(energy[particles_cc],'cc_bar')
-                        crscn[particles_nc] = param(energy[particles_nc],'nc_bar')
-
+                        crscn[particles_cc] = param(energy[particles_cc], 'cc_bar')
+                        crscn[particles_nc] = param(energy[particles_nc], 'nc_bar')
 
                 else:
                     particles_cc = np.where((flavors >= 0) & (inttype == 'cc'))
@@ -220,10 +218,10 @@ def get_nu_cross_section(energy, flavors, inttype='total', cross_section_type = 
                     antiparticles_cc = np.where((flavors < 0) & (inttype == 'cc'))
                     antiparticles_nc = np.where((flavors < 0) & (inttype == 'nc'))
 
-                    crscn[particles_cc] = param(energy[particles_cc],'cc')
-                    crscn[particles_nc] = param(energy[particles_nc],'nc')
-                    crscn[antiparticles_cc] = param(energy[antiparticles_cc],'cc_bar')
-                    crscn[antiparticles_nc] = param(energy[antiparticles_nc],'nc_bar')
+                    crscn[particles_cc] = param(energy[particles_cc], 'cc')
+                    crscn[particles_nc] = param(energy[particles_nc], 'nc')
+                    crscn[antiparticles_cc] = param(energy[antiparticles_cc], 'cc_bar')
+                    crscn[antiparticles_nc] = param(energy[antiparticles_nc], 'nc_bar')
 
     elif cross_section_type == 'csms':
         crscn = csms(energy, inttype, flavors)
@@ -234,40 +232,70 @@ def get_nu_cross_section(energy, flavors, inttype='total', cross_section_type = 
 
     return crscn
 
-def get_interaction_length(Enu, flavor):
+
+def get_interaction_length(Enu, density=.917 * units.g / units.cm ** 3, flavor=12, inttype='total',
+                           cross_section_type='ctw'):
     """
     calculates interaction length from cross section
+    
+    Parameters
+    ----------
+    Enu: float
+        neutrino energy
+    density: float (optional)
+        density of the medium, default density of ice = 0.917 g/cm**3 
+    flavors: float / array of floats
+        neutrino flavor (integer) encoded as using PDG numbering scheme,
+        particles have positive sign, anti-particles have negative sign, relevant are:
+        12: electron neutrino
+        14: muon neutrino
+        16: tau neutrino
+
+    inttype: str, array of str
+        interaction type
+        nc : neutral current
+        cc : charged current
+        total: total (for non-array type)
+
+    cross_section_type: str
+        defines model of cross-section
+        ghandi : according to Ghandi et al. Phys.Rev.D58:093009,1998
+                 only one cross-section for all interactions and flavors
+        ctw    : A. Connolly, R. S. Thorne, and D. Waters, Phys. Rev.D 83, 113009 (2011).
+                 cross-sections for all interaction types and flavors
+        csms   : A. Cooper-Sarkar, P. Mertsch, S. Sarkar, JHEP 08 (2011) 042
+        
+    Returns float: interaction length
+        
     """
-    m_n = constants.m_p *units.kg  # nucleon mass, assuming proton mass
-    density_ice = .917 * units.g/units.cm**3
-    L_int = m_n / get_nu_cross_section(Enu, flavor) / density_ice
+    m_n = constants.m_p * units.kg  # nucleon mass, assuming proton mass
+    L_int = m_n / get_nu_cross_section(Enu, flavor=flavor, inttype=inttype, cross_section_type=cross_section_type) / density
     return L_int
 
 
-if __name__=="__main__":  # this part of the code gets only executed it the script is directly called
+if __name__ == "__main__":  # this part of the code gets only executed it the script is directly called
 
-    inttype = np.array(['cc']*10)
+    inttype = np.array(['cc'] * 10)
 
 #     inttype = 'cc'
 
-    flavors = np.array([14]*10)
+    flavors = np.array([14] * 10)
 
 #     flavors = 14
 
-    energy = np.array([1e12,1e14,1e16,2e17,6e17,1e18,5e18,9e18,1e19,1e20])*units.eV
+    energy = np.array([1e12, 1e14, 1e16, 2e17, 6e17, 1e18, 5e18, 9e18, 1e19, 1e20]) * units.eV
 
-    cc = get_nu_cross_section(energy, flavors,inttype=inttype)/units.picobarn
+    cc = get_nu_cross_section(energy, flavors, inttype=inttype) / units.picobarn
 
-    cc_new = get_nu_cross_section(energy, flavors, inttype=inttype, cross_section_type = 'csms')/units.picobarn
+    cc_new = get_nu_cross_section(energy, flavors, inttype=inttype, cross_section_type='csms') / units.picobarn
 
     import matplotlib.pyplot as plt
 
     plt.figure()
-    plt.loglog(energy/units.GeV,cc,label='CTW')
-    plt.loglog(energy/units.GeV,cc_new,label='CSMS')
+    plt.loglog(energy / units.GeV, cc, label='CTW')
+    plt.loglog(energy / units.GeV, cc_new, label='CSMS')
     plt.xlabel("Energy [GeV]")
     plt.ylabel("CC [pb]")
     plt.legend()
-
 
     plt.show()

--- a/NuRadioMC/utilities/cross_sections.py
+++ b/NuRadioMC/utilities/cross_sections.py
@@ -1,6 +1,7 @@
 import numpy as np
 from NuRadioMC.utilities import units
 from scipy.interpolate import interp1d
+from scipy import constants
 
 
 def param(energy, inttype='cc'):
@@ -232,6 +233,15 @@ def get_nu_cross_section(energy, flavors, inttype='total', cross_section_type = 
         raise NotImplementedError
 
     return crscn
+
+def get_interaction_length(Enu, flavor):
+    """
+    calculates interaction length from cross section
+    """
+    m_n = constants.m_p *units.kg  # nucleon mass, assuming proton mass
+    density_ice = .917 * units.g/units.cm**3
+    L_int = m_n / get_nu_cross_section(Enu, flavor) / density_ice
+    return L_int
 
 
 if __name__=="__main__":  # this part of the code gets only executed it the script is directly called

--- a/NuRadioMC/utilities/cross_sections.py
+++ b/NuRadioMC/utilities/cross_sections.py
@@ -269,7 +269,7 @@ def get_interaction_length(Enu, density=.917 * units.g / units.cm ** 3, flavor=1
         
     """
     m_n = constants.m_p * units.kg  # nucleon mass, assuming proton mass
-    L_int = m_n / get_nu_cross_section(Enu, flavor=flavor, inttype=inttype, cross_section_type=cross_section_type) / density
+    L_int = m_n / get_nu_cross_section(Enu, flavors=flavor, inttype=inttype, cross_section_type=cross_section_type) / density
     return L_int
 
 

--- a/NuRadioMC/utilities/fluxes.py
+++ b/NuRadioMC/utilities/fluxes.py
@@ -6,21 +6,6 @@ import logging
 logger = logging.getLogger('fluxes')
 
 
-
-def get_interaction_length(energy,flavors=12, inttype='total', cross_section_type = 'ctw'):
-    """
-    return interaction length at given energy, assuming a constant ice density
-    """
-    ice_density = 0.917 # units.g/units.cm**3 water equivalent is 1, so unitless
-    N_A = scipy.constants.Avogadro * units.cm**-3
-    L = 1./(N_A * ice_density * cross_sections.get_nu_cross_section(energy, flavors=flavors,inttype=inttype,cross_section_type=cross_section_type))
-    return L
-
-    m_n = constants.m_p *units.kg  # nucleon mass, assuming proton mass
-    density_ice = .917 * units.g/units.cm**3
-    L_int = m_n / cross_sections.get_nu_cross_section(Enu, flavor) / density_ice
-    return L_int
-
 def get_limit_from_aeff(energy, aeff,
                         livetime,
                         signalEff = 1.00,
@@ -92,7 +77,7 @@ def get_limit_flux(energy, veff_sr,
 
     evtsPerFluxPerEnergy = veff_sr * signalEff
     evtsPerFluxPerEnergy *= livetime
-    evtsPerFluxPerEnergy /= get_interaction_length(energy, cross_section_type = nuCrsScn)
+    evtsPerFluxPerEnergy /= cross_sections.get_interaction_length(energy, cross_section_type = nuCrsScn)
 
     ul  = upperLimOnEvents / evtsPerFluxPerEnergy
     ul *= energyBinsPerDecade / np.log(10)
@@ -173,7 +158,7 @@ def get_limit_e1_flux(energy, veff_sr,
 
     evtsPerFluxPerEnergy = veff_sr * signalEff
     evtsPerFluxPerEnergy *= livetime
-    evtsPerFluxPerEnergy /= get_interaction_length(energy, cross_section_type = nuCrsScn)
+    evtsPerFluxPerEnergy /= cross_sections.get_interaction_length(energy, cross_section_type = nuCrsScn)
 
     ul  = upperLimOnEvents / evtsPerFluxPerEnergy
     ul *= energyBinsPerDecade / np.log(10)
@@ -235,7 +220,7 @@ def get_number_of_events_for_flux(energies, flux, Veff, livetime, nuCrsScn='ctw'
     Veff = np.array(Veff)
     logE = np.log10(energies)
     dlogE = logE[1] - logE[0]
-    return np.log(10) * livetime * flux * energies * Veff / get_interaction_length(energies, cross_section_type = nuCrsScn) * dlogE
+    return np.log(10) * livetime * flux * energies * Veff / cross_sections.get_interaction_length(energies, cross_section_type = nuCrsScn) * dlogE
 
 
 def get_exposure(energy, Veff, field_of_view=2*np.pi):
@@ -254,7 +239,7 @@ def get_exposure(energy, Veff, field_of_view=2*np.pi):
     Returns
     float: exposure
     """
-    return Veff / field_of_view / get_interaction_length(energy)
+    return Veff / field_of_view / cross_sections.get_interaction_length(energy)
 
 def get_integrated_exposure(exp_func, E_low, E_high):
     """
@@ -289,7 +274,7 @@ if __name__=="__main__":  # this part of the code gets only executed it the scri
 
     print("Cross section: {} cm^2".format(cross_sections.get_nu_cross_section(energy, cross_section_type = 'ctw')))
 
-    print("interaction length: {} km".format(get_interaction_length(energy, cross_section_type = 'ctw')/units.km))
+    print("interaction length: {} km".format(cross_sections.get_interaction_length(energy, cross_section_type = 'ctw')/units.km))
 
     print("calculating flux limit for {time} years and Veff of {veff} km^3 sr".format(time=livetime/units.year,
                             veff = veff/ (units.km**3 * units.sr)))

--- a/NuRadioMC/utilities/fluxes.py
+++ b/NuRadioMC/utilities/fluxes.py
@@ -16,6 +16,11 @@ def get_interaction_length(energy,flavors=12, inttype='total', cross_section_typ
     L = 1./(N_A * ice_density * cross_sections.get_nu_cross_section(energy, flavors=flavors,inttype=inttype,cross_section_type=cross_section_type))
     return L
 
+    m_n = constants.m_p *units.kg  # nucleon mass, assuming proton mass
+    density_ice = .917 * units.g/units.cm**3
+    L_int = m_n / cross_sections.get_nu_cross_section(Enu, flavor) / density_ice
+    return L_int
+
 def get_limit_from_aeff(energy, aeff,
                         livetime,
                         signalEff = 1.00,
@@ -54,7 +59,7 @@ def get_limit_from_aeff(energy, aeff,
 
 
 
-def get_limit_flux(energy, veff,
+def get_limit_flux(energy, veff_sr,
                     livetime,
                     signalEff = 1.00,
                     energyBinsPerDecade=1.000,
@@ -68,8 +73,8 @@ def get_limit_flux(energy, veff,
         --------------
     energy: array of floats
         neutrino energy
-    veff: array of floats
-        effective volumes
+    veff_sr: array of floats
+        effective volume x solid angle
     livetime: float
         time used
     signalEff: float
@@ -85,7 +90,7 @@ def get_limit_flux(energy, veff,
 
     """
 
-    evtsPerFluxPerEnergy = veff * signalEff
+    evtsPerFluxPerEnergy = veff_sr * signalEff
     evtsPerFluxPerEnergy *= livetime
     evtsPerFluxPerEnergy /= get_interaction_length(energy, cross_section_type = nuCrsScn)
 
@@ -135,7 +140,7 @@ def get_limit_flux(energy, veff,
 #
 #     return ul
 
-def get_limit_e1_flux(energy, veff,
+def get_limit_e1_flux(energy, veff_sr,
                     livetime,
                     signalEff = 1.00,
                     energyBinsPerDecade=1.000,
@@ -149,8 +154,8 @@ def get_limit_e1_flux(energy, veff,
         --------------
     energy: array of floats
         neutrino energy
-    veff: array of floats
-        effective volumes
+    veff_sr: array of floats
+        effective volume x solid angle
     livetime: float
         time used
     signalEff: float
@@ -166,7 +171,7 @@ def get_limit_e1_flux(energy, veff,
 
     """
 
-    evtsPerFluxPerEnergy = veff * signalEff
+    evtsPerFluxPerEnergy = veff_sr * signalEff
     evtsPerFluxPerEnergy *= livetime
     evtsPerFluxPerEnergy /= get_interaction_length(energy, cross_section_type = nuCrsScn)
 
@@ -175,7 +180,7 @@ def get_limit_e1_flux(energy, veff,
 
     return ul
 
-def get_limit_e2_flux(energy, veff,
+def get_limit_e2_flux(energy, veff_sr,
                     livetime,
                     signalEff = 1.00,
                     energyBinsPerDecade=1.000,
@@ -188,8 +193,8 @@ def get_limit_e2_flux(energy, veff,
         --------------
     energy: array of floats
         neutrino energy
-    veff: array of floats
-        effective volumes
+    veff_sr: array of floats
+        effective volumes x solid angle
     livetime: float
         time used
     signalEff: float
@@ -204,7 +209,7 @@ def get_limit_e2_flux(energy, veff,
 
 
     """
-    return energy**2 * get_limit_flux(energy, veff, livetime, signalEff, energyBinsPerDecade, upperLimOnEvents,nuCrsScn)
+    return energy**2 * get_limit_flux(energy, veff_sr, livetime, signalEff, energyBinsPerDecade, upperLimOnEvents,nuCrsScn)
 
 
 def get_number_of_events_for_flux(energies, flux, Veff, livetime, nuCrsScn='ctw'):

--- a/NuRadioMC/utilities/plotting.py
+++ b/NuRadioMC/utilities/plotting.py
@@ -38,7 +38,7 @@ def plot_vertex_distribution(xx, yy, zz, weights=None,
     divider = make_axes_locatable(ax)
     cax = divider.append_axes("right", size="5%", pad=0.05)
     cb = plt.colorbar(h[3], ax=ax, cax=cax)
-    cb.set_label("weighted number of events")
+    cb.set_label("# (weighted)")
     ax.set_aspect('equal')
     ax.set_xlabel("r [m]")
     ax.set_ylabel("z [m]")


### PR DESCRIPTION
The getVeff function now returns just the effective volume which is 
simulated volume / number of simulated event * sum over triggered events (neutrino weight)

To get the Veff steradian, the user needs to multiply this number by the solid angle of the simulation which is also returned. 

Also the normalization to 'water' is removed. 

The interaction length function is moved to the cross sections script. I also changed it to use the proton mass (and not the avogadro constant) which is the prescription of Eq. 28 of 10.1103/PhysRevD.83.113009. In the previous definition also the units didn't work out but the numerical value was essentially the same. 