### PR TITLE
Fix multi station simulation, add test case

### DIFF
--- a/NuRadioMC/examples/01_Veff_simulation/T02RunSimulation.py
+++ b/NuRadioMC/examples/01_Veff_simulation/T02RunSimulation.py
@@ -22,24 +22,23 @@ channelResampler = NuRadioReco.modules.channelResampler.channelResampler()
 channelBandPassFilter = NuRadioReco.modules.channelBandPassFilter.channelBandPassFilter()
 channelGenericNoiseAdder = NuRadioReco.modules.channelGenericNoiseAdder.channelGenericNoiseAdder()
 
-class mySimulation(simulation.simulation):
 
+class mySimulation(simulation.simulation):
 
     def _detector_simulation(self):
         # start detector simulation
-        if(bool(self._cfg['signal']['zerosignal'])):
-            self._increase_signal(None, 0)
-        
         efieldToVoltageConverter.run(self._evt, self._station, self._det)  # convolve efield with antenna pattern
         # downsample trace to internal simulation sampling rate (the efieldToVoltageConverter upsamples the trace to
-        # 20 GHz by default to achive a good time resolution when the two signals from the two signal paths are added) 
+        # 20 GHz by default to achive a good time resolution when the two signals from the two signal paths are added)
         channelResampler.run(self._evt, self._station, self._det, sampling_rate=1. / self._dt)
-        
-        if bool(self._cfg['noise']):
-            Vrms = self._Vrms / (self._bandwidth /( 2.5 * units.GHz))** 0.5  # normalize noise level to the bandwidth its generated for
+
+        if self._is_simulate_noise():
+            max_freq = 0.5 / self._dt
+            norm = self._get_noise_normalization(self._station.get_id())  # assuming the same noise level for all stations
+            Vrms = self._Vrms / (norm / (max_freq)) ** 0.5  # normalize noise level to the bandwidth its generated for
             channelGenericNoiseAdder.run(self._evt, self._station, self._det, amplitude=Vrms, min_freq=0 * units.MHz,
-                                         max_freq=2.5 * units.GHz, type='rayleigh')
-        
+                                         max_freq=max_freq, type='rayleigh')
+
         # bandpass filter trace, the upper bound is higher then the sampling rate which makes it just a highpass filter
         channelBandPassFilter.run(self._evt, self._station, self._det, passband=[80 * units.MHz, 1000 * units.GHz],
                                   filter_type='butter', order=2)
@@ -51,7 +50,7 @@ class mySimulation(simulation.simulation):
                              triggered_channels=None,  # run trigger on all channels
                              number_concidences=1,
                              trigger_name='simple_threshold')  # the name of the trigger
-        
+
         # run a high/low trigger on the 4 downward pointing LPDAs
         highLowThreshold.run(self._evt, self._station, self._det,
                                     threshold_high=4 * self._Vrms,
@@ -59,17 +58,17 @@ class mySimulation(simulation.simulation):
                                     triggered_channels=[0, 1, 2, 3],  # select the LPDA channels
                                     number_concidences=2,  # 2/4 majority logic
                                     trigger_name='LPDA_2of4_4.1sigma',
-                                    set_not_triggered=(not self._station.has_triggered("simple_threshold"))) # calculate more time consuming ARIANNA trigger only if station passes simple trigger
-        
-        # run a high/low trigger on the 4 surface dipoles 
+                                    set_not_triggered=(not self._station.has_triggered("simple_threshold")))  # calculate more time consuming ARIANNA trigger only if station passes simple trigger
+
+        # run a high/low trigger on the 4 surface dipoles
         highLowThreshold.run(self._evt, self._station, self._det,
                                     threshold_high=3 * self._Vrms,
                                     threshold_low=-3 * self._Vrms,
-                                    triggered_channels=[4, 5, 6, 7], # select the bicone channels
-                                    number_concidences=4, # 4/4 majority logic
+                                    triggered_channels=[4, 5, 6, 7],  # select the bicone channels
+                                    number_concidences=4,  # 4/4 majority logic
                                     trigger_name='surface_dipoles_4of4_3sigma',
-                                    set_not_triggered=(not self._station.has_triggered("simple_threshold"))) # calculate more time consuming ARIANNA trigger only if station passes simple trigger
-        
+                                    set_not_triggered=(not self._station.has_triggered("simple_threshold")))  # calculate more time consuming ARIANNA trigger only if station passes simple trigger
+
         # downsample trace back to detector sampling rate
         channelResampler.run(self._evt, self._station, self._det, sampling_rate=self._sampling_rate_detector)
 

--- a/NuRadioMC/examples/02_DnR/E01detector_simulation.py
+++ b/NuRadioMC/examples/02_DnR/E01detector_simulation.py
@@ -26,20 +26,21 @@ channelGenericNoiseAdder = NuRadioReco.modules.channelGenericNoiseAdder.channelG
 
 class mySimulation(simulation.simulation):
 
-
     def _detector_simulation(self):
-        
+
         # start detector simulation
         efieldToVoltageConverter.run(self._evt, self._station, self._det)  # convolve efield with antenna pattern
-        
+
         # downsample trace to internal simulation sampling rate (the efieldToVoltageConverter upsamples the trace to
-        # 20 GHz by default to achive a good time resolution when the two signals from the two signal paths are added) 
+        # 20 GHz by default to achive a good time resolution when the two signals from the two signal paths are added)
         channelResampler.run(self._evt, self._station, self._det, sampling_rate=1. / self._dt)
-        
-        if bool(self._cfg['noise']):
-            Vrms = self._Vrms / (self._bandwidth /( 2.5 * units.GHz))** 0.5  # normalize noise level to the bandwidth its generated for
+
+        if self._is_simulate_noise():
+            max_freq = 0.5 / self._dt
+            norm = self._get_noise_normalization(self._station.get_id())  # assuming the same noise level for all stations
+            Vrms = self._Vrms / (norm / (max_freq)) ** 0.5  # normalize noise level to the bandwidth its generated for
             channelGenericNoiseAdder.run(self._evt, self._station, self._det, amplitude=Vrms, min_freq=0 * units.MHz,
-                                         max_freq=2.5 * units.GHz, type='rayleigh')
+                                         max_freq=max_freq, type='rayleigh')
 
         # bandpass filter trace, the upper bound is higher then the sampling rate which makes it just a highpass filter
         channelBandPassFilter.run(self._evt, self._station, self._det, passband=[80 * units.MHz, 1000 * units.GHz],
@@ -51,7 +52,7 @@ class mySimulation(simulation.simulation):
                              triggered_channels=None,
                              number_concidences=1,
                              trigger_name='pre_trigger_2sigma')
-        
+
         # downsample trace back to detector sampling rate
         channelResampler.run(self._evt, self._station, self._det, sampling_rate=self._sampling_rate_detector)
 

--- a/NuRadioMC/examples/03_station_coincidences/E06RunSimPreprocess.py
+++ b/NuRadioMC/examples/03_station_coincidences/E06RunSimPreprocess.py
@@ -33,10 +33,12 @@ class mySimulation(simulation.simulation):
         # 20 GHz by default to achive a good time resolution when the two signals from the two signal paths are added) 
         channelResampler.run(self._evt, self._station, self._det, sampling_rate=1. / self._dt)
         
-        if bool(self._cfg['noise']):
-            Vrms = self._Vrms / (self._bandwidth /( 2.5 * units.GHz))** 0.5  # normalize noise level to the bandwidth its generated for
+        if self._is_simulate_noise():
+            max_freq = 0.5 / self._dt
+            norm = self._get_noise_normalization(self._station.get_id())  # assuming the same noise level for all stations
+            Vrms = self._Vrms / (norm / (max_freq)) ** 0.5  # normalize noise level to the bandwidth its generated for
             channelGenericNoiseAdder.run(self._evt, self._station, self._det, amplitude=Vrms, min_freq=0 * units.MHz,
-                                         max_freq=2.5 * units.GHz, type='rayleigh')
+                                         max_freq=max_freq, type='rayleigh')
         
         # bandpass filter trace, the upper bound is higher then the sampling rate which makes it just a highpass filter
         channelBandPassFilter.run(self._evt, self._station, self._det, passband=[80 * units.MHz, 500 * units.MHz],

--- a/NuRadioMC/examples/05_pulser_calibration_measurement/A02RunSimulation.py
+++ b/NuRadioMC/examples/05_pulser_calibration_measurement/A02RunSimulation.py
@@ -36,10 +36,12 @@ class mySimulation(simulation.simulation):
         # 20 GHz by default to achive a good time resolution when the two signals from the two signal paths are added)
         channelResampler.run(self._evt, self._station, self._det, sampling_rate=1. / self._dt)
 
-        if bool(self._cfg['noise']):
-            Vrms = self._Vrms / (self._bandwidth / (2.5 * units.GHz)) ** 0.5  # normalize noise level to the bandwidth its generated for
+        if self._is_simulate_noise():
+            max_freq = 0.5 / self._dt
+            norm = self._get_noise_normalization(self._station.get_id())  # assuming the same noise level for all stations
+            Vrms = self._Vrms / (norm / (max_freq)) ** 0.5  # normalize noise level to the bandwidth its generated for
             channelGenericNoiseAdder.run(self._evt, self._station, self._det, amplitude=Vrms, min_freq=0 * units.MHz,
-                                         max_freq=2.5 * units.GHz, type='rayleigh')
+                                         max_freq=max_freq, type='rayleigh')
 
         hardwareResponseIncorporator.run(self._evt, self._station, self._det, sim_to_data=True)
 

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -340,13 +340,13 @@ class simulation():
             cherenkov_angle = np.arccos(1. / n_index)
 
             self._evt = NuRadioReco.framework.event.Event(0, self._event_id)
-            candidate_event = False
 
             # first step: peorform raytracing to see if solution exists
             t2 = time.time()
             inputTime += (time.time() - t1)
 
             for iSt, self._station_id in enumerate(self._station_ids):
+                candidate_station = False
                 self._sampling_rate_detector = self._det.get_sampling_frequency(self._station_id, 0)
 #                 logger.warning('internal sampling rate is {:.3g}GHz, final detector sampling rate is {:.3g}GHz'.format(self.get_sampling_rate(), self._sampling_rate_detector))
                 self._n_samples = self._det.get_number_of_samples(self._station_id, 0) / self._sampling_rate_detector / self._dt
@@ -522,13 +522,13 @@ class simulation():
                         # application of antenna response will just decrease the
                         # signal amplitude
                         if(np.max(np.abs(electric_field.get_trace())) > float(self._cfg['speedup']['min_efield_amplitude']) * self._Vrms_efield):
-                            candidate_event = True
+                            candidate_station = True
 
                 t3 = time.time()
                 rayTracingTime += t3 - t2
                 # perform only a detector simulation if event had at least one
                 # candidate channel
-                if(not candidate_event):
+                if(not candidate_station):
                     logger.debug("electric field amplitude too small in all channels, skipping to next event")
                     continue
                 logger.debug("performing detector simulation")

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -588,6 +588,9 @@ class simulation():
                                                                                          100 * outputTime / t_total))
 
     def _is_simulate_noise(self):
+        """
+        returns True if noise should be added
+        """
         return bool(self._cfg['noise'])
 
     def _get_noise_normalization(self, station_id, channel_id=0):

--- a/NuRadioMC/test/SingleEvents/T02RunSimulation.py
+++ b/NuRadioMC/test/SingleEvents/T02RunSimulation.py
@@ -23,8 +23,8 @@ channelResampler = NuRadioReco.modules.channelResampler.channelResampler()
 channelBandPassFilter = NuRadioReco.modules.channelBandPassFilter.channelBandPassFilter()
 channelGenericNoiseAdder = NuRadioReco.modules.channelGenericNoiseAdder.channelGenericNoiseAdder()
 
-class mySimulation(simulation.simulation):
 
+class mySimulation(simulation.simulation):
 
     def _detector_simulation(self):
         # start detector simulation
@@ -37,7 +37,7 @@ class mySimulation(simulation.simulation):
         channelResampler.run(self._evt, self._station, self._det, sampling_rate=1. / self._dt)
 
         if bool(self._cfg['noise']):
-            Vrms = self._Vrms / (self._bandwidth /( 2.5 * units.GHz))** 0.5  # normalize noise level to the bandwidth its generated for
+            Vrms = self._Vrms / (self._bandwidth / (2.5 * units.GHz)) ** 0.5  # normalize noise level to the bandwidth its generated for
             channelGenericNoiseAdder.run(self._evt, self._station, self._det, amplitude=Vrms, min_freq=0 * units.MHz,
                                          max_freq=2.5 * units.GHz, type='rayleigh')
 
@@ -60,16 +60,16 @@ class mySimulation(simulation.simulation):
                                     triggered_channels=[0, 1, 2, 3],  # select the LPDA channels
                                     number_concidences=2,  # 2/4 majority logic
                                     trigger_name='LPDA_2of4_4.1sigma',
-                                    set_not_triggered=(not self._station.has_triggered("simple_threshold"))) # calculate more time consuming ARIANNA trigger only if station passes simple trigger
+                                    set_not_triggered=(not self._station.has_triggered("simple_threshold")))  # calculate more time consuming ARIANNA trigger only if station passes simple trigger
 
         # run a high/low trigger on the 4 surface dipoles
         triggerSimulatorHighLow.run(self._evt, self._station, self._det,
                                     threshold_high=3 * self._Vrms,
                                     threshold_low=-3 * self._Vrms,
-                                    triggered_channels=[4, 5, 6, 7], # select the bicone channels
-                                    number_concidences=4, # 4/4 majority logic
+                                    triggered_channels=[4, 5, 6, 7],  # select the bicone channels
+                                    number_concidences=4,  # 4/4 majority logic
                                     trigger_name='surface_dipoles_4of4_3sigma',
-                                    set_not_triggered=(not self._station.has_triggered("simple_threshold"))) # calculate more time consuming ARIANNA trigger only if station passes simple trigger
+                                    set_not_triggered=(not self._station.has_triggered("simple_threshold")))  # calculate more time consuming ARIANNA trigger only if station passes simple trigger
 
         # downsample trace back to detector sampling rate
         channelResampler.run(self._evt, self._station, self._det, sampling_rate=self._sampling_rate_detector)
@@ -93,6 +93,7 @@ sim = mySimulation(eventlist=args.inputfilename,
                             detectorfile=args.detectordescription,
                             outputfilenameNuRadioReco=args.outputfilenameNuRadioReco,
                             config_file=args.config,
-                            write_mode='mini')
+                            write_mode='mini',
+                            default_detector_station=101)
 sim.run()
 

--- a/NuRadioMC/test/SingleEvents/config_noise.yaml
+++ b/NuRadioMC/test/SingleEvents/config_noise.yaml
@@ -1,0 +1,18 @@
+noise: True  # specify if simulation should be run with or without noise
+sampling_rate: 5.  # sampling rate in GHz used internally in the simulation.
+speedup:
+  minimum_weight_cut: 1.e-5
+  delta_C_cut: 0.698  # 40 degree
+  redo_raytracing: True  # redo ray tracing even if previous calculated ray tracing solutions are present
+  min_efield_amplitude: 2
+propagation:
+  ice_model: ARAsim_southpole
+signal:
+  model: Alvarez2000
+trigger:
+  noise_temperature: 300  # in Kelvin
+weights:
+  weight_mode: core_mantle_crust # core_mantle_crust: use the three
+  #layer earth model, which considers the different densities of the
+  #core, mantle and crust. simple: use the simple earth model, which
+  #apply a constant earth density

--- a/NuRadioMC/test/SingleEvents/surface_station_1GHz.json
+++ b/NuRadioMC/test/SingleEvents/surface_station_1GHz.json
@@ -238,6 +238,22 @@
             "position": "SP1",
             "station_id": 101,
             "station_type": null
+        },
+        "2": {
+            "MAC_address": "0002F7F2E7B9",
+            "MBED_type": "v1",
+            "board_number": 203,
+            "commission_time": "{TinyDate}:2017-11-04T00:00:00",
+            "decommission_time": "{TinyDate}:2038-01-01T00:00:00",
+            "pos_altitude": 0,
+            "pos_easting": 10000,
+            "pos_measurement_time": null,
+            "pos_northing":  100000,
+            "pos_position": "SP1",
+            "pos_site": "southpole",
+            "position": "SP1",
+            "station_id": 102,
+            "station_type": null
         }
     }
 }

--- a/NuRadioMC/test/SingleEvents/test_build.sh
+++ b/NuRadioMC/test/SingleEvents/test_build.sh
@@ -6,3 +6,5 @@ NuRadioMC/test/SingleEvents/T02RunSimulation.py NuRadioMC/test/SingleEvents/1e18
 NuRadioMC/test/SingleEvents/T03validate.py NuRadioMC/test/SingleEvents/1e18_output.hdf5 NuRadioMC/test/SingleEvents/1e18_output_reference.hdf5
 
 NuRadioMC/test/SingleEvents/T05validate_nur_file.py NuRadioMC/test/SingleEvents/1e18_output.nur NuRadioMC/test/SingleEvents/1e18_output_reference.nur
+
+NuRadioMC/test/SingleEvents/T02RunSimulation.py NuRadioMC/test/SingleEvents/1e18_output_reference.hdf5 NuRadioMC/test/SingleEvents/surface_station_1GHz.json NuRadioMC/test/SingleEvents/config_noise.yaml NuRadioMC/test/SingleEvents/1e18_output_noise.hdf5

--- a/NuRadioMC/utilities/Veff.py
+++ b/NuRadioMC/utilities/Veff.py
@@ -560,9 +560,9 @@ def get_Veff_array(data):
     uzenith_bins = np.unique(zenith_bins, axis=0)
     utrigger_names = np.unique(trigger_names)
     output = np.zeros((len(uenergies), len(uzenith_bins), len(utrigger_names), 3))
-    print(f"unique energies {uenergies}")
-    print(f"unique zenith angle bins {uzenith_bins/units.deg}")
-    print(f"unique energies {utrigger_names}")
+#     print(f"unique energies {uenergies}")
+#     print(f"unique zenith angle bins {uzenith_bins/units.deg}")
+#     print(f"unique energies {utrigger_names}")
 
     for d in data:
         iE = np.squeeze(np.argwhere(d['energy'] == uenergies))


### PR DESCRIPTION
This pull request fixes a bug when multiple stations were simulated. It was not checked if a station has any efields. Now, we check per station if we need to calculate a detector description at all. 

2 station simulation also added to test suite. Reference files stay the same because 2nd station never triggers and the comparison script anyway only compares station 101. 
