### PR TITLE
update STD and change test to 3 sigma

### DIFF
--- a/NuRadioMC/test/Veff/1e18eV/T03check_output.py
+++ b/NuRadioMC/test/Veff/1e18eV/T03check_output.py
@@ -9,11 +9,12 @@ import os
 # Reference values from previous run, have to be updated, if code changes
 ###########################
 
-Veff_mean = 3.53
-Veff_sigma = 0.05
+Veff_mean = 3.530440897143047
+Veff_sigma = 0.05885641838442946
 
 path = os.path.dirname(os.path.abspath(__file__))
-fin = h5py.File(os.path.join(path,"output.hdf5"), 'r')
+fin = h5py.File(os.path.join(path, "output.hdf5"), 'r')
+
 
 def calculate_veff(fin):
     weights = np.array(fin['weights'])
@@ -35,6 +36,7 @@ def calculate_veff(fin):
 # calculate effective volume
 ###########################
 
+
 n_triggered, n_events, Veff = calculate_veff(fin)
 
 print('fraction of triggered events = {:.0f}/{:.0f} = {:.3f} -> {:.6g} km^3 sr'.format(n_triggered, n_events, n_triggered / n_events, Veff / units.km ** 3))
@@ -43,8 +45,8 @@ delta = (Veff / units.km ** 3 - Veff_mean) / Veff_sigma
 rdelta = (Veff / units.km ** 3 - Veff_mean) / Veff_mean
 print("effective volume deviates {:.1f} sigma ({:.0f}%) from the mean".format(delta, 100 * rdelta))
 
-if(np.abs(Veff / units.km ** 3 - Veff_mean) > 2 * Veff_sigma):
-    print("deviation is more than 2 sigma -> this should only happen in 5\% of the tests. Rerun the test and see if the error persists.")
+if(np.abs(Veff / units.km ** 3 - Veff_mean) > 3 * Veff_sigma):
+    print("deviation is more than 3 sigma -> this should only happen in less than 1\% of the tests. Rerun the test and see if the error persists.")
     sys.exit(-1)
 
 ###########################
@@ -59,10 +61,9 @@ if False:
         if (".hdf5" in file) and ("output" in file):
             fin = h5py.File(file, 'r')
             n_triggered, n_events, Veff = calculate_veff(fin)
-            Veffs.append(Veff/ units.km ** 3)
-            print(Veff/ units.km ** 3)
+            Veffs.append(Veff / units.km ** 3)
+            print(Veff / units.km ** 3)
 
     print("New mean Veff {}".format(np.mean(Veffs)))
     print("New sigma Veff {}".format(np.std(Veffs)))
-
 


### PR DESCRIPTION
The Veff test is failing too often, which is annoying. I reran the test 30 times to determine the STD and found a 16% higher value (probably compatible within the statistical precision. 
I also changed the fail criterion to 3 sigma so that this test should essentially never fail randomly so that we really need to pay attention when it does fail. 