### PR TITLE
ARZ time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ before_script:
   - unzip /tmp/radiotools.zip
   - mv radiotools-master radiotools
   - export PYTHONPATH=$PWD/radiotools
-  - wget https://github.com/nu-radio/NuRadioReco/archive/ARZ_time.zip -O /tmp/NuRadioReco.zip
+  - wget https://github.com/nu-radio/NuRadioReco/archive/master.zip -O /tmp/NuRadioReco.zip
   - unzip /tmp/NuRadioReco.zip
-  - mv NuRadioReco-ARZ_time/NuRadioReco $PWD/NuRadioReco
+  - mv NuRadioReco-master/NuRadioReco $PWD/NuRadioReco
   - export PYTHONPATH=$PYTHONPATH:$PWD
   - wget http://arianna.ps.uci.edu/~arianna/data/AntennaModels/createLPDA_100MHz_InfFirn/createLPDA_100MHz_InfFirn.pkl
   - mkdir -p /home/travis/build/nu-radio/NuRadioReco/detector/AntennaModels/createLPDA_100MHz_InfFirn

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ before_script:
   - unzip /tmp/radiotools.zip
   - mv radiotools-master radiotools
   - export PYTHONPATH=$PWD/radiotools
-  - wget https://github.com/nu-radio/NuRadioReco/archive/master.zip -O /tmp/NuRadioReco.zip
+  - wget https://github.com/nu-radio/NuRadioReco/archive/ARZ_time.zip -O /tmp/NuRadioReco.zip
   - unzip /tmp/NuRadioReco.zip
-  - mv NuRadioReco-master/NuRadioReco $PWD/NuRadioReco
+  - mv NuRadioReco-ARZ_time/NuRadioReco $PWD/NuRadioReco
   - export PYTHONPATH=$PYTHONPATH:$PWD
   - wget http://arianna.ps.uci.edu/~arianna/data/AntennaModels/createLPDA_100MHz_InfFirn/createLPDA_100MHz_InfFirn.pkl
   - mkdir -p /home/travis/build/nu-radio/NuRadioReco/detector/AntennaModels/createLPDA_100MHz_InfFirn

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -589,8 +589,13 @@ class simulation():
                             trace_start_time = self._vertex_time + T
                         else:
                             trace_start_time = T
-                        if(self._cfg['signal']['model'] in ['ARZ2019', 'ARZ2020']):
-                            trace_start_time -= 0.5 * electric_field.get_number_of_samples() / electric_field.get_sampling_rate()
+
+                        # We shift the trace start time so that the trace time matches the propagation time.
+                        # The centre of the trace corresponds to the instant when the signal from the shower
+                        # vertex arrives at the observer. The next line makes sure that the centre time
+                        # of the trace is equal to vertex_time + T (wave propagation time)
+                        trace_start_time -= 0.5 * electric_field.get_number_of_samples() / electric_field.get_sampling_rate()
+
                         electric_field.set_trace_start_time(trace_start_time)
                         electric_field[efp.azimuth] = azimuth
                         electric_field[efp.zenith] = zenith

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -589,6 +589,8 @@ class simulation():
                             trace_start_time = self._vertex_time + T
                         else:
                             trace_start_time = T
+                        if(self._cfg['signal']['model'] in ['ARZ2019', 'ARZ2020']):
+                            trace_start_time -= 0.5 * electric_field.get_number_of_samples() / electric_field.get_sampling_rate()
                         electric_field.set_trace_start_time(trace_start_time)
                         electric_field[efp.azimuth] = azimuth
                         electric_field[efp.zenith] = zenith

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ version 1.1.2 -
 new features:
 - Veff utility can now handle extended bins
 - New tutorial and example for the webinar
+- trace start time for the electric field models adjusted such that global time of pulse position corresponds to propagation time
 
 bugfixes:
 
@@ -23,8 +24,7 @@ new features
   to happen at the surface)
 - detector description is saved to nur output files
 - new handling of random numbers. Each module has its own random generator instance. Global seed can be controlled via 
-  config file setting. 
-- trace start time for the electric field models adjusted such that global time of pulse position corresponds to propagation time
+  config file setting.
 
 bugfixes:
 - ARZxxxx and Alvarez2009 Askaryan modules now use the same (random) shower per event. 

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ new features
 - detector description is saved to nur output files
 - new handling of random numbers. Each module has its own random generator instance. Global seed can be controlled via 
   config file setting. 
+- More accurate timing for the ARZ models
 
 bugfixes:
 - ARZxxxx and Alvarez2009 Askaryan modules now use the same (random) shower per event. 

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,7 +24,7 @@ new features
 - detector description is saved to nur output files
 - new handling of random numbers. Each module has its own random generator instance. Global seed can be controlled via 
   config file setting. 
-- trace start time for the ARZ models adjusted such that global time of pulse position corresponds to propagation time
+- trace start time for the electric field models adjusted such that global time of pulse position corresponds to propagation time
 
 bugfixes:
 - ARZxxxx and Alvarez2009 Askaryan modules now use the same (random) shower per event. 

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,7 +24,7 @@ new features
 - detector description is saved to nur output files
 - new handling of random numbers. Each module has its own random generator instance. Global seed can be controlled via 
   config file setting. 
-- More accurate timing for the ARZ models
+- trace start time for the ARZ models adjusted such that global time of pulse position corresponds to propagation time
 
 bugfixes:
 - ARZxxxx and Alvarez2009 Askaryan modules now use the same (random) shower per event. 


### PR DESCRIPTION
This module implements a time shift if the electric field model used is one of the ARZ models. This is to ensure that for a first interaction, the time at which the signal from the vertex is seen is precisely T, the time calculated by the ray tracing module from vertex to observer. For subsequent interactions, the time middle of the trace is the vertex time (vertex_time) plus the propagation time T, and the middle of the trace still contains the signal emitted from the vertex.

If all the electric fields have the same sampling rate and number of samples, this is just a global shift for all events and observers, but I think this is something that makes the code more consistent.