### PR TITLE
Veff bins

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ new features
 - detector description is saved to nur output files
 - new handling of random numbers. Each module has its own random generator instance. Global seed can be controlled via 
   config file setting. 
+- Veff utility can now handle extended bins
 
 bugfixes:
 - ARZxxxx and Alvarez2009 Askaryan modules now use the same (random) shower per event. 


### PR DESCRIPTION
So far, the standard effective volume utility could only handle point bins, that is, an error appeared if the bin was extended. I think that point bins should be discouraged, that's why I'm giving the possibility of using extended bins if the user makes point_bins=False. I'm keeping the point bins as the default choice.