### PR TITLE
Add library_dirs to Extension call in cython cpp wrapper

### DIFF
--- a/NuRadioMC/SignalProp/CPPAnalyticRayTracing/setup.py
+++ b/NuRadioMC/SignalProp/CPPAnalyticRayTracing/setup.py
@@ -13,8 +13,8 @@ except:
 
 extensions = [
     Extension('wrapper', ['wrapper.pyx'],
-              #include_dirs=[numpy.get_include(), '../../utilities/'],
               include_dirs=[numpy.get_include(), '../../utilities/', str(os.environ['GSLDIR']) + '/include/'],
+              library_dirs=[str(os.environ['GSLDIR']) + '/lib/'],
               extra_compile_args=['-O3',"-mfpmath=sse"],
               libraries=['gsl', 'gslcblas'],
               language='c++'


### PR DESCRIPTION
setup.py for the cpp ray tracing wrapper now explicitly lists
the library_dirs to include. Otherwise, in some cases,
the compiler doesn't seem to be able to find -lgsl and -lgslcblas
during the linking stage.

Issue being addressed:
In some cases when trying to compile the gsl wrapper, compilation failed at linking stage because library_dirs were not fully specified.

Did you remember to: 
* include doc strings in all commits ?
* edit the changelog.txt file describing your changes? 
