### PR TITLE
Fix typo in raytraycing and make print statements py3 compatible

### DIFF
--- a/NuRadioMC/SignalProp/examples/A01IceCubePulserToARA.py
+++ b/NuRadioMC/SignalProp/examples/A01IceCubePulserToARA.py
@@ -1,7 +1,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import time
-from NuRadioMC.SignalProp import analyticraytraycing as ray
+from NuRadioMC.SignalProp import analyticraytracing as ray
 from NuRadioMC.utilities import medium
 from NuRadioReco.utilities import units
 import logging
@@ -22,7 +22,7 @@ ax.set_ylim(-1600, 0)
 ax.set_xlabel('x [m]')
 ax.set_ylabel('z [m]')
 fig.tight_layout()
-fig.savefig("plots/IceCubePulserToARA1.png")
+fig.savefig("IceCubePulserToARA1.png")
 
 x1 = [-4 * units.km, -1500. * units.m]  # pulser position
 x2 = [0., -200. * units.m]  # ARA antanna
@@ -38,5 +38,5 @@ ax.set_ylim(-1600, 0)
 ax.set_xlabel('x [m]')
 ax.set_ylabel('z [m]')
 fig.tight_layout()
-fig.savefig("plots/IceCubePulserToARA2.png")
+fig.savefig("IceCubePulserToARA2.png")
 plt.show()

--- a/NuRadioMC/SignalProp/examples/example_3d.py
+++ b/NuRadioMC/SignalProp/examples/example_3d.py
@@ -1,7 +1,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import time
-from NuRadioMC.SignalProp import analyticraytraycing as ray
+from NuRadioMC.SignalProp import analyticraytracing as ray
 from NuRadioReco.utilities import units
 from NuRadioMC.utilities import medium
 import logging
@@ -38,14 +38,14 @@ for i, x in enumerate([x2, x3, x4, x5]):
         for iS in range(r.get_number_of_solutions()):
             ray_tracing_C0[i, iS] = r.get_results()[iS]['C0']
             ray_tracing_solution_type[i, iS] = r.get_solution_type(iS)
-            print "     Solution %d, Type %d: "%(iS,ray_tracing_solution_type[i, iS])
+            print("     Solution %d, Type %d: "%(iS,ray_tracing_solution_type[i, iS]))
             R = r.get_path_length(iS)  # calculate path length
             T = r.get_travel_time(iS)  # calculate travel time
-            print "     Ray Distance %.3f and Travel Time %.3f"%(R/units.m,T/units.ns)
+            print("     Ray Distance %.3f and Travel Time %.3f"%(R/units.m,T/units.ns))
             receive_vector = r.get_receive_vector(iS)
             receive_vectors[i, iS] = receive_vector
             zenith, azimuth = hp.cartesian_to_spherical(*receive_vector)
-            print "     Receiving Zenith %.3f and Azimuth %.3f "%(zenith/units.deg, azimuth/units.deg)
+            print("     Receiving Zenith %.3f and Azimuth %.3f "%(zenith/units.deg, azimuth/units.deg))
 
             #to readout the actual trace, we have to flatten to 2D
             dX = x - x1

--- a/NuRadioMC/simulation/T07plot_ray_tracing_solutions.py
+++ b/NuRadioMC/simulation/T07plot_ray_tracing_solutions.py
@@ -5,7 +5,7 @@ from radiotools import plthelpers as php
 from matplotlib import pyplot as plt
 from NuRadioReco.utilities import units
 from NuRadioMC.utilities import medium
-from NuRadioMC.SignalProp import analyticraytraycing as ray
+from NuRadioMC.SignalProp import analyticraytracing as ray
 import h5py
 import argparse
 import json


### PR DESCRIPTION
This commit modifies three files where there is an typo calling `raytraycing`, which is an old version of the ray tracer which had typos. It should be `raytracing` The module name was fixed, but the change wasn't propagated to the examples apparently.

Also, three print statements only worked in py2 in one of the examples, so those are now py3 compatible.