### PR TITLE
Speedup distances

### DIFF
--- a/NuRadioMC/examples/05_pulser_calibration_measurement/config_spice.yaml
+++ b/NuRadioMC/examples/05_pulser_calibration_measurement/config_spice.yaml
@@ -5,6 +5,7 @@ speedup:
   minimum_weight_cut: 0 # disable neutrino weight cut -> we're not simulating neutrinos here
   delta_C_cut: 10  # more than 360deg, disable cone angle cut
   min_efield_amplitude: 0
+  distance_cut: False
 
 propagation:
   module: analytic

--- a/NuRadioMC/simulation/config_default.yaml
+++ b/NuRadioMC/simulation/config_default.yaml
@@ -13,9 +13,9 @@ speedup:
   redo_raytracing: False  # redo ray tracing even if previous calculated ray tracing solutions are present
   min_efield_amplitude: 2  # the minimum signal amplitude of the efield as a factor of the noise RMS. If the value is smaller, no detector simulation is performed. As the vector effecive length of antennas is typically less than 1, this cut does not introduce any bias as long as the value is smaller than the trigger threshold.
   amp_per_ray_solution: True  # if False, the maximum aplitude for each ray tracing solution is not calculated
-  distance_cut: True # if True, a cut for the vertex-observer distance as a function of shower energy is applied (log10(max_dist) = intercept + slope * log10(shower_energy))
+  distance_cut: True # if True, a cut for the vertex-observer distance as a function of shower energy is applied (log10(max_dist / m) = intercept + slope * log10(shower_energy / eV))
   distance_cut_intercept: -12.31 # intercept for the maximum distance cut
-  distance_cut_slope: 0.9542 # slope for the maximum distance cut 
+  distance_cut_slope: 0.9542 # slope for the maximum distance cut
 
 propagation:
   module: analytic

--- a/NuRadioMC/simulation/config_default.yaml
+++ b/NuRadioMC/simulation/config_default.yaml
@@ -13,7 +13,9 @@ speedup:
   redo_raytracing: False  # redo ray tracing even if previous calculated ray tracing solutions are present
   min_efield_amplitude: 2  # the minimum signal amplitude of the efield as a factor of the noise RMS. If the value is smaller, no detector simulation is performed. As the vector effecive length of antennas is typically less than 1, this cut does not introduce any bias as long as the value is smaller than the trigger threshold.
   amp_per_ray_solution: True  # if False, the maximum aplitude for each ray tracing solution is not calculated
-  distance_cut: True # if True, an energy-dependent cut for the vertex-observer distance is applied
+  distance_cut: True # if True, a cut for the vertex-observer distance as a function of shower energy is applied (log10(max_dist) = intercept + slope * log10(shower_energy))
+  distance_cut_intercept: -12.31 # intercept for the maximum distance cut
+  distance_cut_slope: 0.9542 # slope for the maximum distance cut 
 
 propagation:
   module: analytic

--- a/NuRadioMC/simulation/config_default.yaml
+++ b/NuRadioMC/simulation/config_default.yaml
@@ -13,7 +13,7 @@ speedup:
   redo_raytracing: False  # redo ray tracing even if previous calculated ray tracing solutions are present
   min_efield_amplitude: 2  # the minimum signal amplitude of the efield as a factor of the noise RMS. If the value is smaller, no detector simulation is performed. As the vector effecive length of antennas is typically less than 1, this cut does not introduce any bias as long as the value is smaller than the trigger threshold.
   amp_per_ray_solution: True  # if False, the maximum aplitude for each ray tracing solution is not calculated
-  distance_cut: True # if True, a cut for the vertex-observer distance as a function of shower energy is applied (log10(max_dist / m) = intercept + slope * log10(shower_energy / eV))
+  distance_cut: False # if True, a cut for the vertex-observer distance as a function of shower energy is applied (log10(max_dist / m) = intercept + slope * log10(shower_energy / eV))
   distance_cut_intercept: -12.14 # intercept for the maximum distance cut
   distance_cut_slope: 0.9542 # slope for the maximum distance cut
 

--- a/NuRadioMC/simulation/config_default.yaml
+++ b/NuRadioMC/simulation/config_default.yaml
@@ -13,6 +13,7 @@ speedup:
   redo_raytracing: False  # redo ray tracing even if previous calculated ray tracing solutions are present
   min_efield_amplitude: 2  # the minimum signal amplitude of the efield as a factor of the noise RMS. If the value is smaller, no detector simulation is performed. As the vector effecive length of antennas is typically less than 1, this cut does not introduce any bias as long as the value is smaller than the trigger threshold.
   amp_per_ray_solution: True  # if False, the maximum aplitude for each ray tracing solution is not calculated
+  distance_cut: True # if True, an energy-dependent cut for the vertex-observer distance is applied
 
 propagation:
   module: analytic
@@ -29,7 +30,7 @@ signal:
   zerosignal: False  # if True, the signal is set to zero. This is useful to study 'noise' only simulations
   polarization: auto # can be either 'auto' or 'custom'
   ePhi: 0.  # only used if 'polarization = custom', fraction of ePhi component, the eTheta component is eTheta = (1 - ePhi**2)**0.5
-  shower_type: null # optional argument to only simulate certain shower types. Arguments can be "had" or "em". 
+  shower_type: null # optional argument to only simulate certain shower types. Arguments can be "had" or "em".
 
 trigger:
   noise_temperature: 300  # in Kelvin

--- a/NuRadioMC/simulation/config_default.yaml
+++ b/NuRadioMC/simulation/config_default.yaml
@@ -14,7 +14,7 @@ speedup:
   min_efield_amplitude: 2  # the minimum signal amplitude of the efield as a factor of the noise RMS. If the value is smaller, no detector simulation is performed. As the vector effecive length of antennas is typically less than 1, this cut does not introduce any bias as long as the value is smaller than the trigger threshold.
   amp_per_ray_solution: True  # if False, the maximum aplitude for each ray tracing solution is not calculated
   distance_cut: True # if True, a cut for the vertex-observer distance as a function of shower energy is applied (log10(max_dist / m) = intercept + slope * log10(shower_energy / eV))
-  distance_cut_intercept: -12.31 # intercept for the maximum distance cut
+  distance_cut_intercept: -12.14 # intercept for the maximum distance cut
   distance_cut_slope: 0.9542 # slope for the maximum distance cut
 
 propagation:

--- a/NuRadioMC/simulation/config_default.yaml
+++ b/NuRadioMC/simulation/config_default.yaml
@@ -14,6 +14,7 @@ speedup:
   min_efield_amplitude: 2  # the minimum signal amplitude of the efield as a factor of the noise RMS. If the value is smaller, no detector simulation is performed. As the vector effecive length of antennas is typically less than 1, this cut does not introduce any bias as long as the value is smaller than the trigger threshold.
   amp_per_ray_solution: True  # if False, the maximum aplitude for each ray tracing solution is not calculated
   distance_cut: False # if True, a cut for the vertex-observer distance as a function of shower energy is applied (log10(max_dist / m) = intercept + slope * log10(shower_energy / eV))
+  # The intercept and the slope below have been obtained from distance histograms for several shower energy bins. A 10x10 array of 1.5 sigma dipoles in Greenland was used. The distance cut is a linear fit of the maximum distances at shower energies around 1~10 PeV with a cover factor of 1.5, or 50%.
   distance_cut_intercept: -12.14 # intercept for the maximum distance cut
   distance_cut_slope: 0.9542 # slope for the maximum distance cut
 

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -84,8 +84,8 @@ def get_distance_cut(shower_energy, intercept, slope):
         Maximum distance for ray tracing
     """
 
-    log_distance_cut = intercept + slope * np.log10(shower_energy)
-    distance_cut = 10 ** log_distance_cut
+    log_distance_cut = intercept + slope * np.log10(shower_energy / units.eV)
+    distance_cut = 10 ** log_distance_cut * units.m
 
     return distance_cut
 

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -1107,7 +1107,10 @@ class simulation():
         This function returns a distance cut as a function of shower energy for
         speeding up the code. The cut comes from a fit to the maximum values of
         distances taken from distance histograms for several shower energy bins,
-        increased a 50% as a margin.
+        increased a 50% as a margin. The setup used for the simulations used
+        for creating the histogram was a 10x10 vertical dipole array with an
+        amplitude threshold of 1.5 times the noise RMS. The ice used was the
+        Greenland ice, for attenuation and refractive index.
         """
 
         if shower_energy < 1 * units.PeV:

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -445,8 +445,6 @@ class simulation():
                                    n_frequencies_integration=int(self._cfg['propagation']['n_freq']),
                                    n_reflections=self._n_reflections)
 
-                    find_solutions = True
-
                     if self._cfg['speedup']['distance_cut']:
 
                         fem, fhad = self._get_em_had_fraction(self._inelasticity, self._inttype, self._flavor)
@@ -458,7 +456,11 @@ class simulation():
                         distance = np.linalg.norm(x1 - x2)
 
                         if distance > distance_cut:
-                            find_solutions = False
+                            logger.debug('A distance speed up cut has been applied')
+                            logger.debug('Shower energy: {:.2e} eV'.format(shower_energy / units.eV))
+                            logger.debug('Distance cut: {:.2f} m'.format(distance_cut / units.m))
+                            logger.debug('Distance to vertex: {:.2f} m'.format(distance / units.m))
+                            continue
 
                     if(pre_simulated and ray_tracing_performed and not self._cfg['speedup']['redo_raytracing']):  # check if raytracing was already performed
                         sg_pre = self._fin_stations["station_{:d}".format(self._station_id)]
@@ -469,15 +471,9 @@ class simulation():
                             temp_reflection_case = sg_pre['ray_tracing_reflection_case'][self._iE][channel_id]
                         r.set_solution(sg_pre['ray_tracing_C0'][self._iE][channel_id], sg_pre['ray_tracing_C1'][self._iE][channel_id],
                                        sg_pre['ray_tracing_solution_type'][self._iE][channel_id], temp_reflection, temp_reflection_case)
-                    elif find_solutions:
+                    else:
                         r.find_solutions()
 
-                    if (not find_solutions):
-                        logger.debug('A distance speed up cut has been applied')
-                        logger.debug('Shower energy: {:.2e} eV'.format(shower_energy / units.eV))
-                        logger.debug('Distance cut: {:.2f} m'.format(distance_cut / units.m))
-                        logger.debug('Distance to vertex: {:.2f} m'.format(distance / units.m))
-                        continue
                     if(not r.has_solution()):
                         logger.debug("event {} and station {}, channel {} does not have any ray tracing solution ({} to {})".format(
                             self._event_id, self._station_id, channel_id, x1, x2))

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -1105,28 +1105,29 @@ class simulation():
     def _get_distance_cut(self, shower_energy):
         """
         This function returns a distance cut as a function of shower energy for
-        speeding up the code. The cut comes from a fit to the maximum values of
-        distances taken from distance histograms for several shower energy bins,
-        increased a 50% as a margin. The setup used for the simulations used
-        for creating the histogram was a 10x10 vertical dipole array with an
-        amplitude threshold of 1.5 times the noise RMS. The ice used was the
-        Greenland ice, for attenuation and refractive index.
+        speeding up the code. The cut is a linear function of the shower energy
+        logarithm:
+
+        log10(distance_cut) = intercept + slope * log10(shower_energy/eV)
+
+        The intercept and slope must be specified in the config file.
+
+        Parameters
+        ----------
+        shower_energy: float
+            Shower energy
+
+        Returns
+        -------
+        distance_cut: float
+            Maximum distance for ray tracing
         """
 
-        if shower_energy < 1 * units.PeV:
-            return 100 * units.m
+        intercept = self._cfg['speedup']['distance_cut_intercept']
+        slope = self._cfg['speedup']['distance_cut_slope']
 
-        margin = 1.5
-
-        fit_pars = np.array([-1.71858223e+02, 2.76889420e+01, -1.46200554e+00, 2.58455216e-02])
-
-        log_shower_energy = np.log10(shower_energy / units.eV)
-
-        log_distance_cut = 0
-        for i_power, fit_par in enumerate(fit_pars):
-            log_distance_cut += fit_par * log_shower_energy**i_power
-
-        distance_cut = margin * 10**log_distance_cut
+        log_distance_cut = intercept + slope * np.log10(shower_energy)
+        distance_cut = 10 ** log_distance_cut
 
         return distance_cut
 

--- a/NuRadioMC/test/Veff/config.yaml
+++ b/NuRadioMC/test/Veff/config.yaml
@@ -4,6 +4,7 @@ speedup:
   minimum_weight_cut: 1.e-5
   delta_C_cut: 0.698  # 40 degree
   redo_raytracing: True  # redo ray tracing even if previous calculated ray tracing solutions are present
+  distance_cut: True # Skip ray tracing if vertex distance is greater than a distance cut that is a function of shower energy.
 propagation:
   ice_model: southpole_2015
 signal:


### PR DESCRIPTION
I've implemented a distance cut as a function of shower energy, and it seems to work really well. The time needed to simulate large arrays with Proposal is reduced by a factor of more than 10. In order to do so, I've implemented a fit to the maximum distances as a function of shower energy taken from a previous simulation for a 10x10 1.5 sigma dipole array in Greenland. I've used a cover factor of 1.5, or 50%, just to be completely sure that we're not losing events. We should study if this cut is good enough for other media, like South Pole, that have a larger attenuation length.

[fit_max_distances.pdf](https://github.com/nu-radio/NuRadioMC/files/4666751/fit_max_distances.pdf)
