### PR TITLE
ARZ angular cut

### DIFF
--- a/NuRadioMC/SignalGen/ARZ/ARZ.py
+++ b/NuRadioMC/SignalGen/ARZ/ARZ.py
@@ -218,7 +218,7 @@ class ARZ(object):
         self._interp_factor2 = interp_factor
 
     def get_time_trace(self, shower_energy, theta, N, dt, shower_type, n_index, R, shift_for_xmax=False,
-                       same_shower=False, iN=None, output_mode='trace'):
+                       same_shower=False, iN=None, output_mode='trace', maximum_angle=20*units.deg):
         """
         calculates the electric-field Askaryan pulse from a charge-excess profile
 
@@ -258,6 +258,9 @@ class ARZ(object):
             * 'trace' (default): return only the electric field trace
             * 'Xmax': return trace and position of xmax in units of length
             * 'full' return trace, depth and charge_excess profile
+        maximum_angle: float
+            Maximum angular difference allowed between the observer angle and the Cherenkov angle.
+            If the difference is greater, the function returns an empty trace.
 
         Returns: array of floats
             array of electric-field time trace in 'on-sky' coordinate system eR, eTheta, ePhi
@@ -271,7 +274,6 @@ class ARZ(object):
         # than near the Cherenkov cone due to the loss of coherence. Since incoherent events
         # should not trigger, we return an empty trace for angular differences > 20 degrees.
         cherenkov_angle = np.arccos(1 / n_index)
-        maximum_angle = 20 * units.deg
 
         if np.abs(theta - cherenkov_angle) > maximum_angle:
 

--- a/NuRadioMC/SignalGen/ARZ/ARZ.py
+++ b/NuRadioMC/SignalGen/ARZ/ARZ.py
@@ -265,6 +265,19 @@ class ARZ(object):
         if not shower_type in self._library.keys():
             raise KeyError("shower type {} not present in library. Available shower types are {}".format(shower_type, *self._library.keys()))
 
+        # Due to the oscillatory nature of the ARZ integral, some numerical instabilities arise
+        # for angles near the axis and near 90 degrees. This creates some waveforms with large
+        # spikes due to numerical errors, while the real electric field should be much smaller
+        # than near the Cherenkov cone due to the loss of coherence. Since incoherent events
+        # should not trigger, we return an empty trace for angular differences > 20 degrees.
+        cherenkov_angle = np.arccos(1 / n_index)
+        maximum_angle = 20 * units.deg
+
+        if np.abs(theta - cherenkov_angle) > maximum_angle:
+
+            empty_trace = np.zeros(3, N)
+            return empty_trace
+
         # determine closes available energy in shower library
         energies = np.array([*self._library[shower_type]])
         iE = np.argmin(np.abs(energies - shower_energy))

--- a/NuRadioMC/test/requirements.txt
+++ b/NuRadioMC/test/requirements.txt
@@ -3,7 +3,7 @@
 pyyaml
 numpy
 astropy
-tinydb==3.15.2
+tinydb
 tinydb-serialization
 h5py
 matplotlib

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ new features:
 - trace start time for the electric field models adjusted such that global time of pulse position corresponds to propagation time
 - Simplified treatment of reference angles and polarization for the ARZ module
 - Proposal 6.1.1 supported
+- Safeguard for events at more than 20 degrees from the Cherenkov angle when using the ARZ models
 
 bugfixes:
 


### PR DESCRIPTION
An angular cut when using the ARZ model has been implemented. When the observer is near the axis or near 90 degrees from the shower axis, the integrals used for the ARZ method become unstable due to the loss of coherence. The result is that standard integration methods yield large peaks due to numerical errors and our trapezoid rule interpolation also fails, while the field for these regions should be much closer to zero than the fields at less than 10 degrees from the Cherenkov angle. The solution is implementing a cut - more than 20 degrees away from the Cherenkov angle, the model returns a null trace.