### PR TITLE
Fix codes

### DIFF
--- a/NuRadioMC/EvtGen/generator.py
+++ b/NuRadioMC/EvtGen/generator.py
@@ -15,6 +15,7 @@ from scipy.interpolate import RectBivariateSpline
 import h5py
 import os
 import math
+import copy
 import logging
 logger = logging.getLogger("EventGen")
 logging.basicConfig()
@@ -1364,7 +1365,7 @@ def generate_eventlist_cylinder(filename, n_events, Emin, Emax,
         mask_leptons = mask_leptons & mask_theta & mask_phi
 
         E_all_leptons = (1 - data_sets["inelasticity"]) * data_sets["energies"]
-        lepton_codes = data_sets["flavors"][:]
+        lepton_codes = copy.copy(data_sets["flavors"])
         lepton_codes[lepton_codes == 14] = 13
         lepton_codes[lepton_codes == -14] = -13
         lepton_codes[lepton_codes == 16] = 15

--- a/NuRadioMC/EvtGen/generator.py
+++ b/NuRadioMC/EvtGen/generator.py
@@ -1364,7 +1364,7 @@ def generate_eventlist_cylinder(filename, n_events, Emin, Emax,
         mask_leptons = mask_leptons & mask_theta & mask_phi
 
         E_all_leptons = (1 - data_sets["inelasticity"]) * data_sets["energies"]
-        lepton_codes = data_sets["flavors"]
+        lepton_codes = data_sets["flavors"][:]
         lepton_codes[lepton_codes == 14] = 13
         lepton_codes[lepton_codes == -14] = -13
         lepton_codes[lepton_codes == 16] = 15

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -1097,6 +1097,12 @@ class simulation():
         fhad: float
             hadroninc fraction
         """
+        forbidden_codes = [13, -13, 15, -15]
+        if flavor in forbidden_codes:
+            error_msg  = "Particle code is {}".format(flavor)
+            error_msg += "Muons and leptons must be propagated using Proposal."
+            raise ValueError(error_msg)
+
         fem = 0  # electrogmatnetic fraction
         fhad = 0  # hadronic fraction
         if(inttype == 'nc'):
@@ -1115,11 +1121,6 @@ class simulation():
         elif(inttype == 'em'):
             fem = 1
             fhad = 0
-        elif(np.abs(flavor) == 15):
-            if (inttype == 'tau_e'):
-                fem = inelasticity
-            elif (inttype == 'tau_had'):
-                fhad = inelasticity
         else:
             raise AttributeError("interaction type {} with flavor {} is not implemented".format(inttype, flavor))
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ new features:
 - Antenna model now needs to be fully specified in the detector description (previously `_InfFirn` was automatically appended to the antenna name for antennas below the surface)
 
 bugfixes:
+- Fixed primary particle code bug when using Proposal
 
 version 1.1.1 - 2020/03/23
 new features


### PR DESCRIPTION
There was a bug concerning the particle codes. The muon neutrinos (14 and -14) were converted to muons (13 and -13), and the tau neutrinos (16 and -16) were converted to muons (15 and -15) when using Proposal, which means that the first interaction showers were ignored during simulation. This is caused by copying by reference due to a mistake instead of copying by value. This pull request solves it.

Incidentally, even with these wrong files, the effective volume due to secondary showers with pair production did not seem to be so far away from the first interaction volume, which means that turning pair production on may give a substantial increase in sensitivity.