### PR TITLE
Fix veff secondaries

### DIFF
--- a/NuRadioMC/EvtGen/NuRadioProposal.py
+++ b/NuRadioMC/EvtGen/NuRadioProposal.py
@@ -428,13 +428,38 @@ class ProposalFunctions(object):
         bool
             True if particle produces shower, False otherwise
         """
-        energy_threshold = particle.energy > min_energy_loss
+        energy_threshold = self.__secondary_energy(particle) > min_energy_loss
         if not energy_threshold:
             return False
 
         shower_inducing = is_shower_primary(particle)
 
         return shower_inducing
+
+    def __secondary_energy(self, sec):
+        """
+        Retrieves the energy of the secondary particle
+
+        Parameters
+        ----------
+        sec: Particle
+            Secondary particle issued by Proposal
+
+        Returns
+        -------
+        energy: float
+            Energy in MeV
+        """
+
+        # Checking if the secondary type is greater than 1000000000, which means
+        # that the secondary is an interaction particle.
+        if (sec.type > 1000000000):
+            energy = (sec.parent_particle_energy - sec.energy) * units.MeV
+        # Else, the secondary is a particle issued upon decay.
+        else:
+            energy = sec.energy * units.MeV
+
+        return energy
 
     def __shower_properties(self, particle):
         """
@@ -566,13 +591,7 @@ class ProposalFunctions(object):
                 distance += ((sec.position.z - lepton_position[2]) * units.cm) ** 2
                 distance = np.sqrt(distance)
 
-                # Checking if the secondary type is greater than 1000000000, which means
-                # that the secondary is an interaction particle.
-                if (sec.type > 1000000000):
-                    energy = (sec.parent_particle_energy - sec.energy) * units.MeV
-                # Else, the secondary is a particle issued upon decay.
-                else:
-                    energy = sec.energy * units.MeV
+                energy = self.__secondary_energy(sec)
 
                 shower_type, code, name = self.__shower_properties(sec)
 

--- a/NuRadioMC/examples/06_webinar/W04EffectiveVolumes.py
+++ b/NuRadioMC/examples/06_webinar/W04EffectiveVolumes.py
@@ -75,6 +75,10 @@ Then, each Veff_item has three numbers.
 - Veff_item[1] is the poissonian uncertainty of the effective volume
 - Veff_item[2] is the sum of the weights of all the triggering events contained
 in a given energy and zenith band for the chosen trigger.
+- Veff_item[3] is the 68% confidence belt lower limit for the effective volume
+using the Feldman-Cousins method.
+- Veff_item[4] is the 68% confidence belt upper limit for the effective volume 
+using the Feldman-Cousins method.
 
 For our example, we only have a single file, so we choose the only zenith index.
 We choose as well the first trigger (index 0) just as an example.

--- a/NuRadioMC/utilities/Veff.py
+++ b/NuRadioMC/utilities/Veff.py
@@ -1,6 +1,7 @@
 import numpy as np
 import h5py
 from scipy import interpolate
+from scipy.interpolate import interp1d
 import glob
 from six import iteritems
 import json
@@ -63,7 +64,20 @@ def get_triggered(fin, iT=None):
 
 def FC_limits(counts):
 
-    from scipy.interpolate import interp1d
+    """
+    Returns the 68% confidence belt for a number of counts, using the
+    Feldman-Cousins method.
+
+    Parameters
+    ----------
+    counts: integer or float
+        Number of counts. Can be non-integer (weighted counts)
+
+    Returns
+    -------
+    (low_limit, upper_limit): float tuple
+        Lower and upper limits for the confidence belt.
+    """
 
     count_list = np.arange(0, 21)
     lower_limits = [0.00,

--- a/NuRadioMC/utilities/Veff.py
+++ b/NuRadioMC/utilities/Veff.py
@@ -717,7 +717,7 @@ def get_Veff_array(data):
     uenergies = np.unique(energies)
     uzenith_bins = np.unique(zenith_bins, axis=0)
     utrigger_names = np.unique(trigger_names)
-    output = np.zeros((len(uenergies), len(uzenith_bins), len(utrigger_names), 3))
+    output = np.zeros((len(uenergies), len(uzenith_bins), len(utrigger_names), 5))
     weights = np.ones((len(uenergies), len(uzenith_bins)))
     logger.debug(f"unique energies {uenergies}")
     logger.debug(f"unique zenith angle bins {uzenith_bins/units.deg}")

--- a/NuRadioMC/utilities/Veff.py
+++ b/NuRadioMC/utilities/Veff.py
@@ -523,10 +523,13 @@ def get_Veff(folder,
         out['SNRs'] = {}
 
         if(triggered.size == 0):
+            FC_low, FC_high = FC_limits(0)
+            Veff_low = V * FC_low / n_events
+            Veff_high = V * FC_high / n_events
             for iT, trigger_name in enumerate(trigger_names):
-                out['Veffs'][trigger_name] = [0, 0, 0]
+                out['Veffs'][trigger_name] = [0, 0, 0, Veff_low, Veff_high]
             for trigger_name, values in iteritems(trigger_combinations):
-                out['Veffs'][trigger_name] = [0, 0, 0]
+                out['Veffs'][trigger_name] = [0, 0, 0, Veff_low, Veff_high]
         else:
             for iT, trigger_name in enumerate(trigger_names):
                 triggered = get_triggered(fin, iT)
@@ -534,7 +537,13 @@ def get_Veff(folder,
                 Veff_error = 0
                 if(np.sum(weights[triggered]) > 0):
                     Veff_error = Veff / np.sum(weights[triggered]) ** 0.5
-                out['Veffs'][trigger_name] = [Veff, Veff_error, np.sum(weights[triggered])]
+
+                FC_low, FC_high = FC_limits(np.sum(weights[triggered]))
+                Veff_low = V * FC_low / n_events
+                Veff_high = V * FC_high / n_events
+
+                out['Veffs'][trigger_name] = [Veff, Veff_error, np.sum(weights[triggered]),
+                                              Veff_low, Veff_high]
 
             for trigger_name, values in iteritems(trigger_combinations):
                 indiv_triggers = values['triggers']
@@ -606,7 +615,12 @@ def get_Veff(folder,
                 Vefferror = 0
                 if(np.sum(weights[triggered]) > 0):
                     Vefferror = Veff / np.sum(weights[triggered]) ** 0.5
-                out['Veffs'][trigger_name] = [Veff, Vefferror, np.sum(weights[triggered])]
+
+                FC_low, FC_high = FC_limits(np.sum(weights[triggered]))
+                Veff_low = V * FC_low / n_events
+                Veff_high = V * FC_high / n_events
+                out['Veffs'][trigger_name] = [Veff, Vefferror, np.sum(weights[triggered]),
+                                              Veff_low, Veff_high]
         Veff_output.append(out)
 
     return Veff_output

--- a/NuRadioMC/utilities/Veff.py
+++ b/NuRadioMC/utilities/Veff.py
@@ -17,7 +17,7 @@ logging.basicConfig()
 # collection of utility function regarding the calculation of the effective volume of a neutrino detector
 
 
-def get_triggered(fin):
+def get_triggered(fin, iT=None):
     """
     Computes an array indicating the triggered events.
     If a double bang is seen, removes the second bang from the actual triggered
@@ -26,7 +26,9 @@ def get_triggered(fin):
     Parameters
     ----------
     fin: dictionary
-       Dictionary containing the output data sets from the simulation
+        Dictionary containing the output data sets from the simulation
+    iT: int
+        Index corresponding to the chosen trigger. If None, fin['trigggered'] is used
 
     Returns
     -------
@@ -34,7 +36,10 @@ def get_triggered(fin):
        The bools indicate if the events have triggered
     """
 
-    triggered = np.copy(fin['triggered'])
+    if iT is None:
+        triggered = np.copy(fin['triggered'])
+    else:
+        triggered = np.array(fin['multiple_triggers'][:, iT], dtype=np.bool)
 
     if (len(triggered) == 0):
         return triggered
@@ -125,8 +130,7 @@ def get_Aeff_proposal(folder, trigger_combinations={}, station=101):
         out['energy'] = E
 
         weights = np.array(fin['weights'])
-        # triggered = np.array(fin['triggered'])
-        triggered = get_triggered(fin)
+        triggered = np.array(fin['triggered'])
         n_events = fin.attrs['n_events']
         if(trigger_names is None):
             trigger_names = fin.attrs['trigger_names']
@@ -180,7 +184,7 @@ def get_Aeff_proposal(folder, trigger_combinations={}, station=101):
                 out['Aeffs'][trigger_name] = [0, 0, 0]
         else:
             for iT, trigger_name in enumerate(trigger_names):
-                triggered = np.array(fin['multiple_triggers'][:, iT], dtype=np.bool)
+                triggered = get_triggered(fin, iT)
                 Aeff = proj_area * np.sum(weights[triggered]) / n_events
                 Aeff_error = 0
                 if(np.sum(weights[triggered]) > 0):
@@ -361,8 +365,7 @@ def get_Veff(folder,
         out['energy'] = E
 
         weights = np.array(fin['weights'])
-        # triggered = np.array(fin['triggered'])
-        triggered = get_triggered(fin)
+        triggered = np.array(fin['triggered'])
         n_events = fin.attrs['n_events']
         if(trigger_names is None):
             trigger_names = fin.attrs['trigger_names']
@@ -439,7 +442,7 @@ def get_Veff(folder,
                 out['Veffs'][trigger_name] = [0, 0, 0]
         else:
             for iT, trigger_name in enumerate(trigger_names):
-                triggered = np.array(fin['multiple_triggers'][:, iT], dtype=np.bool)
+                triggered = get_triggered(fin, iT)
                 Veff = V * np.sum(weights[triggered]) / n_events
                 Veff_error = 0
                 if(np.sum(weights[triggered]) > 0):

--- a/NuRadioMC/utilities/Veff.py
+++ b/NuRadioMC/utilities/Veff.py
@@ -61,6 +61,65 @@ def get_triggered(fin, iT=None):
 
     return triggered
 
+def FC_limits(counts):
+
+    from scipy.interpolate import interp1d
+
+    count_list = np.arange(0, 21)
+    lower_limits = [0.00,
+                    0.37,
+                    0.74,
+                    1.10,
+                    2.34,
+                    2.75,
+                    3.82,
+                    4.25,
+                    5.30,
+                    6.33,
+                    6.78,
+                    7.81,
+                    8.83,
+                    9.28,
+                    10.30,
+                    11.32,
+                    12.33,
+                    12.79,
+                    13.81,
+                    14.82,
+                    15.83]
+    upper_limits = [1.29,
+                    2.75,
+                    4.25,
+                    5.30,
+                    6.78,
+                    7,81,
+                    9.28,
+                    10.30,
+                    11.32,
+                    12.79,
+                    13.81,
+                    14.82,
+                    16.29,
+                    17.30,
+                    18.32,
+                    19.32,
+                    20.80,
+                    21.81,
+                    22.82,
+                    25.30]
+
+    if counts > count_list[-1]:
+
+        return (counts - np.sqrt(counts), counts + np.sqrt(counts))
+
+    elif counts < 0:
+
+        return (0.00, 1.29)
+
+    low_interp = interp1d(count_list, lower_limits)
+    up_interp = interp1d(count_list, upper_limits)
+
+    return (low_interp(counts), up_interp(counts))
 
 def get_Aeff_proposal(folder, trigger_combinations={}, station=101):
     """
@@ -178,10 +237,13 @@ def get_Aeff_proposal(folder, trigger_combinations={}, station=101):
         out['SNRs'] = {}
 
         if(triggered.size == 0):
+            FC_low, FC_high = FC_limits(0)
+            Aeff_low = proj_area * FC_low / n_events
+            Aeff_high = proj_area * FC_high / n_events
             for iT, trigger_name in enumerate(trigger_names):
-                out['Aeffs'][trigger_name] = [0, 0, 0]
+                out['Aeffs'][trigger_name] = [0, 0, 0, Aeff_low, Aeff_high]
             for trigger_name, values in iteritems(trigger_combinations):
-                out['Aeffs'][trigger_name] = [0, 0, 0]
+                out['Aeffs'][trigger_name] = [0, 0, 0, Aeff_low, Aeff_high]
         else:
             for iT, trigger_name in enumerate(trigger_names):
                 triggered = get_triggered(fin, iT)
@@ -189,25 +251,31 @@ def get_Aeff_proposal(folder, trigger_combinations={}, station=101):
                 Aeff_error = 0
                 if(np.sum(weights[triggered]) > 0):
                     Aeff_error = Aeff / np.sum(weights[triggered]) ** 0.5
-                out['Aeffs'][trigger_name] = [Aeff, Aeff_error, np.sum(weights[triggered])]
+
+                FC_low, FC_high = FC_limits(np.sum(weights[triggered]))
+                Aeff_low = proj_area * FC_low / n_events
+                Aeff_high = proj_area * FC_high / n_events
+
+                out['Aeffs'][trigger_name] = [Aeff, Aeff_error, np.sum(weights[triggered]),
+                                              Aeff_low, Aeff_high]
 
             for trigger_name, values in iteritems(trigger_combinations):
                 indiv_triggers = values['triggers']
                 triggered = np.zeros_like(fin['multiple_triggers'][:, 0], dtype=np.bool)
                 if(isinstance(indiv_triggers, str)):
-                    triggered = triggered | np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_triggers]], dtype=np.bool)
+                    triggered = triggered | get_triggered(fin, trigger_names_dict[indiv_triggers])
                 else:
                     for indiv_trigger in indiv_triggers:
-                        triggered = triggered | np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_trigger]], dtype=np.bool)
+                        triggered = triggered | get_triggered(fin, trigger_names_dict[indiv_trigger])
                 if 'triggerAND' in values:
-                    triggered = triggered & np.array(fin['multiple_triggers'][:, trigger_names_dict[values['triggerAND']]], dtype=np.bool)
+                    triggered = triggered & get_triggered(fin, trigger_names_dict[indiv_trigger])
                 if 'notriggers' in values:
                     indiv_triggers = values['notriggers']
                     if(isinstance(indiv_triggers, str)):
-                        triggered = triggered & ~np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_triggers]], dtype=np.bool)
+                        triggered = triggered & ~get_triggered(fin, trigger_names_dict[indiv_trigger])
                     else:
                         for indiv_trigger in indiv_triggers:
-                            triggered = triggered & ~np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_trigger]], dtype=np.bool)
+                            triggered = triggered & ~get_triggered(fin, trigger_names_dict[indiv_trigger])
                 if('min_sigma' in values.keys()):
                     if(isinstance(values['min_sigma'], list)):
                         if(trigger_name not in out['SNR']):
@@ -250,7 +318,11 @@ def get_Aeff_proposal(folder, trigger_combinations={}, station=101):
                     e = get_eff(As / Vrms)
                     Aeff = proj_area * np.sum((weights * e)[triggered]) / n_events
 
-                out['Aeffs'][trigger_name] = [Aeff, Aeff / np.sum(weights[triggered]) ** 0.5, np.sum(weights[triggered])]
+                FC_low, FC_high = FC_limits(np.sum(weights[triggered]))
+                Aeff_low = proj_area * FC_low / n_events
+                Aeff_high = proj_area * FC_high / n_events
+                out['Aeffs'][trigger_name] = [Aeff, Aeff / np.sum(weights[triggered]) ** 0.5, np.sum(weights[triggered]),
+                                              Aeff_low, Aeff_high]
         Aeff_output.append(out)
 
     return Aeff_output
@@ -729,7 +801,7 @@ def get_Aeff_array(data):
     uenergies = np.unique(energies)
     uzenith_bins = np.unique(zenith_bins, axis=0)
     utrigger_names = np.unique(trigger_names)
-    output = np.zeros((len(uenergies), len(uzenith_bins), len(utrigger_names), 3))
+    output = np.zeros((len(uenergies), len(uzenith_bins), len(utrigger_names), 5))
     logger.debug(f"unique energies {uenergies}")
     logger.debug(f"unique zenith angle bins {uzenith_bins/units.deg}")
     logger.debug(f"unique energies {utrigger_names}")

--- a/NuRadioMC/utilities/Veff.py
+++ b/NuRadioMC/utilities/Veff.py
@@ -282,11 +282,12 @@ def get_Aeff_proposal(folder, trigger_combinations={}, station=101):
                     for indiv_trigger in indiv_triggers:
                         triggered = triggered | get_triggered(fin, trigger_names_dict[indiv_trigger])
                 if 'triggerAND' in values:
-                    triggered = triggered & get_triggered(fin, trigger_names_dict[indiv_trigger])
+                    for and_trigger in values['triggerAND']:
+                        triggered = triggered & get_triggered(fin, trigger_names_dict[and_trigger])
                 if 'notriggers' in values:
                     indiv_triggers = values['notriggers']
                     if(isinstance(indiv_triggers, str)):
-                        triggered = triggered & ~get_triggered(fin, trigger_names_dict[indiv_trigger])
+                        triggered = triggered & ~get_triggered(fin, trigger_names_dict[indiv_triggers])
                     else:
                         for indiv_trigger in indiv_triggers:
                             triggered = triggered & ~get_triggered(fin, trigger_names_dict[indiv_trigger])
@@ -539,19 +540,20 @@ def get_Veff(folder,
                 indiv_triggers = values['triggers']
                 triggered = np.zeros_like(fin['multiple_triggers'][:, 0], dtype=np.bool)
                 if(isinstance(indiv_triggers, str)):
-                    triggered = triggered | np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_triggers]], dtype=np.bool)
+                    triggered = triggered | get_triggered(fin, trigger_names_dict[indiv_triggers])
                 else:
                     for indiv_trigger in indiv_triggers:
-                        triggered = triggered | np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_trigger]], dtype=np.bool)
+                        triggered = triggered | get_triggered(fin, trigger_names_dict[indiv_trigger])
                 if 'triggerAND' in values:
-                    triggered = triggered & np.array(fin['multiple_triggers'][:, trigger_names_dict[values['triggerAND']]], dtype=np.bool)
+                    for and_trigger in values['triggerAND']:
+                        triggered = triggered & get_triggered(fin, trigger_names_dict[and_trigger])
                 if 'notriggers' in values:
                     indiv_triggers = values['notriggers']
                     if(isinstance(indiv_triggers, str)):
-                        triggered = triggered & ~np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_triggers]], dtype=np.bool)
+                        triggered = triggered & ~get_triggered(fin, trigger_names_dict[indiv_triggers])
                     else:
                         for indiv_trigger in indiv_triggers:
-                            triggered = triggered & ~np.array(fin['multiple_triggers'][:, trigger_names_dict[indiv_trigger]], dtype=np.bool)
+                            triggered = triggered & ~get_triggered(fin, trigger_names_dict[indiv_trigger])
                 if('min_sigma' in values.keys()):
                     if(isinstance(values['min_sigma'], list)):
                         if(trigger_name not in out['SNR']):

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ new features:
 bugfixes:
 - Fixed primary particle code bug when using Proposal
 - Fixed geometry cut when generating secondary particles
+- Incorrect Veff of secondary interactions fixed
 
 version 1.1.1 - 2020/03/23
 new features


### PR DESCRIPTION
The current master counts the secondary interactions incorrectly when calculating effective volumes. Every interaction counts as a detected event, but this shouldn't be the case - a maximum of one triggered interaction should be counted for every parent neutrino. This pull request fixes the problem.
