### PR TITLE
generate events in batches

### DIFF
--- a/NuRadioMC/EvtGen/generator.py
+++ b/NuRadioMC/EvtGen/generator.py
@@ -450,7 +450,7 @@ def set_volume_attributes(volume, proposal, attributes):
         logger.info(f"increasing rmax from {attributes['fiducial_rmax']/units.km:.01f}km to {rmax/units.km:.01f}km, zmax from {attributes['fiducial_zmax']/units.km:.01f}km to {zmax/units.km:.01f}km")
         logger.info(f"decreasing rmin from {attributes['fiducial_rmin']/units.km:.01f}km to {rmin/units.km:.01f}km")
         logger.info(f"decreasing zmin from {attributes['fiducial_zmin']/units.km:.01f}km to {zmin/units.km:.01f}km")
-        logger.info(f"increasing number of events to {n_events}")
+        logger.info(f"increasing number of events to {n_events:.6g}")
         attributes['n_events'] = n_events
 
         attributes['rmin'] = rmin
@@ -822,7 +822,7 @@ def generate_surface_muons(filename, n_events, Emin, Emax,
         n_events_batch = max_n_events_batch
         if(i_batch + 1 == n_batches):  # last batch?
             n_events_batch = n_events - (i_batch * max_n_events_batch)
-        logger.info(f"processing batch {i_batch+1:.2g}/{n_batches:.2g} with {n_events_batch:.2g} events")
+        logger.info(f"processing batch {i_batch+1:.2g}/{n_batches:.2g} with {n_events_batch:.2g} events ({len(data_sets_fiducial['event_group_ids'])} showers in fiducial volume so far.)")
         data_sets["xx"], data_sets["yy"], data_sets["zz"] = generate_vertex_positions(attributes=attributes, n_events=n_events_batch)
         data_sets["zz"] = np.zeros_like(data_sets["yy"])  # muons interact at the surface
 

--- a/NuRadioMC/EvtGen/generator.py
+++ b/NuRadioMC/EvtGen/generator.py
@@ -822,7 +822,6 @@ def generate_surface_muons(filename, n_events, Emin, Emax,
         n_events_batch = max_n_events_batch
         if(i_batch + 1 == n_batches):  # last batch?
             n_events_batch = n_events - (i_batch * max_n_events_batch)
-        logger.info(f"processing batch {i_batch+1:.2g}/{n_batches:.2g} with {n_events_batch:.2g} events ({len(data_sets_fiducial['event_group_ids'])} showers in fiducial volume so far.)")
         data_sets["xx"], data_sets["yy"], data_sets["zz"] = generate_vertex_positions(attributes=attributes, n_events=n_events_batch)
         data_sets["zz"] = np.zeros_like(data_sets["yy"])  # muons interact at the surface
 
@@ -859,6 +858,7 @@ def generate_surface_muons(filename, n_events, Emin, Emax,
         for key in data_sets:
             if(key not in data_sets_fiducial):
                 data_sets_fiducial[key] = []
+        logger.info(f"processing batch {i_batch+1:.2g}/{n_batches:.2g} with {n_events_batch:.2g} events ({len(data_sets_fiducial['event_group_ids'])} showers in fiducial volume so far.)")
 
         E_all_leptons = data_sets["energies"]
         lepton_codes = data_sets["flavors"]

--- a/NuRadioMC/EvtGen/generator.py
+++ b/NuRadioMC/EvtGen/generator.py
@@ -812,13 +812,13 @@ def generate_surface_muons(filename, n_events, Emin, Emax,
     attributes['phimax'] = phimax
     attributes['deposited'] = False
 
-    data_sets = {}
     data_sets_fiducial = {}
 
     set_volume_attributes(volume, proposal=False, attributes=attributes)
     n_events = attributes['n_events']  # important! the number of events might have been increased by the set_volume_attributes function
     n_batches = int(np.ceil(n_events / max_n_events_batch))
     for i_batch in range(n_batches):  # do generation of events in batches
+        data_sets = {}
         n_events_batch = max_n_events_batch
         if(i_batch + 1 == n_batches):  # last batch?
             n_events_batch = n_events - (i_batch * max_n_events_batch)

--- a/NuRadioMC/EvtGen/generator.py
+++ b/NuRadioMC/EvtGen/generator.py
@@ -1285,7 +1285,7 @@ def generate_eventlist_cylinder(filename, n_events, Emin, Emax,
     logger.info(f"Time per event (PROPOSAL only): {time_per_evt*1e3:.4f} ms")
     logger.info(f"Total time (PROPOSAL only) {pretty_time_delta(time_proposal)}")
 
-    logger.info(f"number of fiducial showers {len(data_sets_fiducial['flavors'])}")
+    logger.info(f"number of fiducial showers {len(data_sets_fiducial['xx'])}")
 
     # assign every shower a unique id
     data_sets_fiducial["shower_ids"] = np.arange(0, len(data_sets_fiducial['shower_energies']), dtype=np.int)

--- a/NuRadioMC/EvtGen/generator.py
+++ b/NuRadioMC/EvtGen/generator.py
@@ -206,7 +206,7 @@ def write_events_to_hdf5(filename, data_sets, attributes, n_events_per_file=None
         else:  # case 1
             n_events_this_file = evt_id_last - evt_id_last_previous
 
-        print('writing file {} with {} events (id {} - {}) and {} entries'.format(filename2, n_events_this_file, evt_id_first,
+        logger.status('writing file {} with {} events (id {} - {}) and {} entries'.format(filename2, n_events_this_file, evt_id_first,
                                                                                   evt_id_last, stop_index - start_index))
         fout.attrs['n_events'] = n_events_this_file
         fout.close()
@@ -824,6 +824,7 @@ def generate_surface_muons(filename, n_events, Emin, Emax,
     attributes['deposited'] = False
 
     data_sets_fiducial = {}
+    proposal_time = 0
 
     set_volume_attributes(volume, proposal=False, attributes=attributes)
     n_events = attributes['n_events']  # important! the number of events might have been increased by the set_volume_attributes function
@@ -925,12 +926,13 @@ def generate_surface_muons(filename, n_events, Emin, Emax,
 
                         # Flavors are particle codes taken from NuRadioProposal.py
                         data_sets_fiducial['flavors'][-1] = product.code
+        proposal_time += time.time() - init_time
 
-    time_per_evt = (time.time() - init_time) / (iE + 1)
-    print(f"Time per event: {time_per_evt*1e3:.01f}ms")
-    print(f"Total time {pretty_time_delta(time.time() - init_time)}")
+    time_per_evt = proposal_time / len(data_sets_fiducial['flavors'])
+    logger.info(f"Time per event: {time_per_evt*1e3:.01f}ms")
+    logger.info(f"Total time {pretty_time_delta(proposal_time)}")
 
-    print("number of fiducial showers", len(data_sets_fiducial['flavors']))
+    logger.status(f"number of fiducial showers {len(data_sets_fiducial['flavors'])}")
 
     # If there are no fiducial showers, passing an empty data_sets_fiducial to
     # write_events_to_hdf5 will cause the program to crash. However, we need

--- a/NuRadioMC/EvtGen/generator.py
+++ b/NuRadioMC/EvtGen/generator.py
@@ -659,7 +659,7 @@ def generate_surface_muons(filename, n_events, Emin, Emax,
                            config_file='SouthPole',
                            proposal_kwargs={},
                            log_level=None,
-                           max_n_events_batch=1e6):
+                           max_n_events_batch=1e5):
     """
     Event generator for surface muons
 
@@ -955,7 +955,7 @@ def generate_eventlist_cylinder(filename, n_events, Emin, Emax,
                                 start_file_id=0,
                                 log_level=None,
                                 proposal_kwargs={},
-                                max_n_events_batch=1e6):
+                                max_n_events_batch=1e5):
     """
     Event generator
 

--- a/NuRadioMC/EvtGen/generator.py
+++ b/NuRadioMC/EvtGen/generator.py
@@ -858,7 +858,7 @@ def generate_surface_muons(filename, n_events, Emin, Emax,
         for key in data_sets:
             if(key not in data_sets_fiducial):
                 data_sets_fiducial[key] = []
-        logger.info(f"processing batch {i_batch+1:.2g}/{n_batches:.2g} with {n_events_batch:.2g} events ({len(data_sets_fiducial['event_group_ids'])} showers in fiducial volume so far.)")
+        logger.info(f"processing batch {i_batch+1:.4g}/{n_batches:.4g} with {n_events_batch:.6g} events ({len(data_sets_fiducial['event_group_ids'])} showers in fiducial volume so far.)")
 
         E_all_leptons = data_sets["energies"]
         lepton_codes = data_sets["flavors"]

--- a/NuRadioMC/EvtGen/generator.py
+++ b/NuRadioMC/EvtGen/generator.py
@@ -531,6 +531,8 @@ def generate_vertex_positions(volume, proposal, attributes):
         yy = np.random.uniform(ymin, ymax, n_events)
         zz = np.random.uniform(zmin, zmax, n_events)
         return xx, yy, zz
+    else:
+        raise AttributeError(f"'fiducial_rmin' or 'fiducial_rmax' is not part of 'volume'")
 
 
 def intersection_box_ray(bounds, ray):
@@ -652,7 +654,8 @@ def generate_surface_muons(filename, n_events, Emin, Emax,
                            spectrum='log_uniform',
                            start_file_id=0,
                            config_file='SouthPole',
-                           proposal_kwargs={}):
+                           proposal_kwargs={},
+                           log_level=None):
     """
     Event generator for surface muons
 
@@ -766,7 +769,11 @@ def generate_surface_muons(filename, n_events, Emin, Emax,
         table paths and then copy this file to config_PROPOSAL_xxx.json.
     proposal_kwargs: dict
         additional kwargs that are passed to the get_secondaries_array function of the NuRadioProposal class
+    log_level: logging log level or None
+        sets the log level in the event generation. None means system default.
     """
+    if(log_level is not None):
+        logger.setLevel(log_level)
     t_start = time.time()
     from NuRadioMC.EvtGen.NuRadioProposal import ProposalFunctions
     proposal_functions = ProposalFunctions(config_file=config_file)
@@ -931,7 +938,7 @@ def generate_eventlist_cylinder(filename, n_events, Emin, Emax,
                                 proposal=False,
                                 proposal_config='SouthPole',
                                 start_file_id=0,
-                                log_level=logging.WARNING,
+                                log_level=None,
                                 proposal_kwargs={}):
     """
     Event generator
@@ -1052,11 +1059,14 @@ def generate_eventlist_cylinder(filename, n_events, Emin, Emax,
     start_file_id: int (default 0)
         in case the data set is distributed over several files, this number specifies the id of the first file
         (useful if an existing data set is extended)
+    log_level: logging log level or None
+        sets the log level in the event generation. None means system default.
     proposal_kwargs: dict
         additional kwargs that are passed to the get_secondaries_array function of the NuRadioProposal class
     """
     t_start = time.time()
-    logger.setLevel(log_level)
+    if(log_level is not None):
+        logger.setLevel(log_level)
     if proposal:
         from NuRadioMC.EvtGen.NuRadioProposal import ProposalFunctions
         proposal_functions = ProposalFunctions(config_file=proposal_config)

--- a/NuRadioMC/utilities/merge_hdf5.py
+++ b/NuRadioMC/utilities/merge_hdf5.py
@@ -91,8 +91,8 @@ def merge2(filenames, output_filename):
                 mask = gid == current_egids
                 current_egids[mask] = new_egid
                 new_egid += 1
-
             logger.warning(f"event group ids are not unique per file, current file is {f}, new unique ids have been generated.")
+            logger.warning(f"{intersect}")
         current_uegids = np.unique(data[f]['event_group_ids'])
         intersect = np.intersect1d(unique_uegids, current_uegids, assume_unique=True)
         if(np.sum(intersect)):

--- a/NuRadioMC/utilities/merge_hdf5.py
+++ b/NuRadioMC/utilities/merge_hdf5.py
@@ -203,7 +203,7 @@ if __name__ == "__main__":
         print("usage: python merge_hdf5.py /path/to/simulation/output/folder\nor python merge_hdf5.py outputfilename input1 input2 ...")
     elif(len(args.files) == 1):
         filenames = glob.glob("{}/*/*.hdf5.part????".format(args.files[0]))
-        filenames.extend(glob.glob("{}/*/*.hdf5.part??????".format(args.files[0])))
+        filenames = np.append(filenames, glob.glob("{}/*/*.hdf5.part??????".format(args.files[0])))
         filenames2 = []
         for i, filename in enumerate(filenames):
             filename, ext = os.path.splitext(filename)
@@ -224,7 +224,7 @@ if __name__ == "__main__":
                 else:
                     #                 try:
                     input_files = np.array(sorted(glob.glob(filename + '.part????')))
-                    input_files.extend(np.array(sorted(glob.glob(filename + '.part??????'))))
+                    input_files = np.append(input_files, np.array(sorted(glob.glob(filename + '.part??????'))))
                     mask = np.array([os.path.getsize(x) > 1000 for x in input_files], dtype=np.bool)
                     if(np.sum(~mask)):
                         logger.warning("{:d} files were deselected because their filesize was to small".format(np.sum(~mask)))

--- a/NuRadioMC/utilities/merge_hdf5.py
+++ b/NuRadioMC/utilities/merge_hdf5.py
@@ -81,7 +81,7 @@ def merge2(filenames, output_filename):
         if(iF == 0):
             continue
         current_egids = np.unique(data[f]['event_group_ids'])
-        if(np.sum(np.intersect1d(unique_egids, current_egids))):
+        if(np.sum(np.intersect1d(unique_egids, current_egids, assume_unique=True))):
             logger.error("event group ids are not unique per file")
             raise("event group ids are not unique per file")
 
@@ -203,6 +203,7 @@ if __name__ == "__main__":
         print("usage: python merge_hdf5.py /path/to/simulation/output/folder\nor python merge_hdf5.py outputfilename input1 input2 ...")
     elif(len(args.files) == 1):
         filenames = glob.glob("{}/*/*.hdf5.part????".format(args.files[0]))
+        filenames.extend(glob.glob("{}/*/*.hdf5.part??????".format(args.files[0])))
         filenames2 = []
         for i, filename in enumerate(filenames):
             filename, ext = os.path.splitext(filename)
@@ -223,6 +224,7 @@ if __name__ == "__main__":
                 else:
                     #                 try:
                     input_files = np.array(sorted(glob.glob(filename + '.part????')))
+                    input_files.extend(np.array(sorted(glob.glob(filename + '.part??????'))))
                     mask = np.array([os.path.getsize(x) > 1000 for x in input_files], dtype=np.bool)
                     if(np.sum(~mask)):
                         logger.warning("{:d} files were deselected because their filesize was to small".format(np.sum(~mask)))

--- a/NuRadioMC/utilities/merge_hdf5.py
+++ b/NuRadioMC/utilities/merge_hdf5.py
@@ -92,11 +92,12 @@ def merge2(filenames, output_filename):
                 current_egids[mask] = new_egid
                 new_egid += 1
             logger.warning(f"event group ids are not unique per file, current file is {f}, new unique ids have been generated.")
-            logger.warning(f"{intersect}")
-        current_uegids = np.unique(data[f]['event_group_ids'])
-        intersect = np.intersect1d(unique_uegids, current_uegids, assume_unique=True)
-        if(np.sum(intersect)):
-            raise IndexError(f"event group ids are not unique per file, current file is {f}")
+            logger.debug(f"non-unique event ids: {intersect}")
+#         # test again for uniqueness
+#         current_uegids = np.unique(data[f]['event_group_ids'])
+#         intersect = np.intersect1d(unique_uegids, current_uegids, assume_unique=True)
+#         if(np.sum(intersect)):
+#             raise IndexError(f"event group ids are not unique per file, current file is {f}")
         unique_uegids = np.append(unique_uegids, current_uegids)
 
     # create data sets

--- a/NuRadioMC/utilities/merge_hdf5.py
+++ b/NuRadioMC/utilities/merge_hdf5.py
@@ -74,6 +74,17 @@ def merge2(filenames, output_filename):
                 attrs['trigger_names'] = fin.attrs['trigger_names']
         fin.close()
 
+    # check event group ids for uniqueness (this is important because effective volume/area calculation uses the event
+    # group id to determine if a multi station coincidence exists
+    unique_egids = np.unique(data[filenames[0]]['event_group_ids'])
+    for iF, f in enumerate(filenames):
+        if(iF == 0):
+            continue
+        current_egids = np.unique(data[f]['event_group_ids'])
+        if(np.sum(np.intersect1d(unique_egids, current_egids))):
+            logger.error("event group ids are not unique per file")
+            raise("event group ids are not unique per file")
+
     # create data sets
     logger.info("creating data sets")
     fout = h5py.File(output_filename, 'w')


### PR DESCRIPTION
the generation of secondary interactions ran into memory issues when simulating a fixed number of events in a fiducial volume. The required number of events in a much larger volume is often so large that it exceeds available memory. Now, the computation is done in batches. The previous behavior can always be achieved by setting the number of events per batch to a high enough number, 