### PR TITLE
Fix hdf5 merge

### DIFF
--- a/NuRadioMC/utilities/merge_hdf5.py
+++ b/NuRadioMC/utilities/merge_hdf5.py
@@ -101,11 +101,11 @@ def merge2(filenames, output_filename):
                 # also change the event_group_id arrays of the station groups
                 if f in non_empty_filenames:
                     for key in groups[f]:  # loop through all groups
-                        print(f"group {key}, keys = {groups[f][key].keys()}")
-                        g_egids = groups[f][key]['event_group_ids']
-                        mask_g = gid == g_egids
-                        if(np.sum(mask_g)):  # station might not have this event group id, so skip stations where this egid is not present
-                            g_egids[mask_g] = new_egid
+                        if 'event_group_ids' in groups[f][key]:
+                            g_egids = groups[f][key]['event_group_ids']
+                            mask_g = gid == g_egids
+                            if(np.sum(mask_g)):  # station might not have this event group id, so skip stations where this egid is not present
+                                g_egids[mask_g] = new_egid
                 new_egid += 1
 
             logger.warning(f"event group ids are not unique per file, current file is {f}, new unique ids have been generated.")

--- a/NuRadioMC/utilities/merge_hdf5.py
+++ b/NuRadioMC/utilities/merge_hdf5.py
@@ -93,13 +93,15 @@ def merge2(filenames, output_filename):
         current_uegids = np.unique(data[f]['event_group_ids'])
         intersect = np.intersect1d(unique_uegids, current_uegids, assume_unique=True)
         if(np.sum(intersect)):
+            current_egids = data[f]['event_group_ids']
             new_egid = max(unique_uegids.max(), current_uegids.max()) + 1
             for gid in intersect:
-                mask = gid == current_uegids
-                current_uegids[mask] = new_egid
+                mask = gid == current_egids  # there can be multiple entries per unique event group id, we need to change all of them to the new id
+                current_egids[mask] = new_egid
                 new_egid += 1
             logger.warning(f"event group ids are not unique per file, current file is {f}, new unique ids have been generated.")
             logger.debug(f"non-unique event ids: {intersect}")
+        current_uegids = np.unique(data[f]['event_group_ids'])  # get the updated list of unique event group ids. Now there should be no intersection with the ids of the previous files
         # test again for uniqueness
         intersect = np.intersect1d(unique_uegids, current_uegids, assume_unique=True)
         if(np.sum(intersect)):

--- a/NuRadioMC/utilities/merge_hdf5.py
+++ b/NuRadioMC/utilities/merge_hdf5.py
@@ -101,6 +101,7 @@ def merge2(filenames, output_filename):
                 # also change the event_group_id arrays of the station groups
                 if f in non_empty_filenames:
                     for key in groups[f]:  # loop through all groups
+                        print(f"group {key}, keys = {groups[f][key].keys()}")
                         g_egids = groups[f][key]['event_group_ids']
                         mask_g = gid == g_egids
                         if(np.sum(mask_g)):  # station might not have this event group id, so skip stations where this egid is not present

--- a/NuRadioMC/utilities/merge_hdf5.py
+++ b/NuRadioMC/utilities/merge_hdf5.py
@@ -98,7 +98,15 @@ def merge2(filenames, output_filename):
             for gid in intersect:
                 mask = gid == current_egids  # there can be multiple entries per unique event group id, we need to change all of them to the new id
                 current_egids[mask] = new_egid
+                # also change the event_group_id arrays of the station groups
+                keys = groups[non_empty_filenames[0]]
+                for key in groups[f]:  # loop through all groups
+                    g_egids = groups[f][key]['event_group_ids']
+                    mask_g = gid == g_egids
+                    if(np.sum(mask_g)):  # station might not have this event group id, so skip stations where this egid is not present
+                        g_egids[mask_g] = new_egid
                 new_egid += 1
+
             logger.warning(f"event group ids are not unique per file, current file is {f}, new unique ids have been generated.")
             logger.debug(f"non-unique event ids: {intersect}")
         current_uegids = np.unique(data[f]['event_group_ids'])  # get the updated list of unique event group ids. Now there should be no intersection with the ids of the previous files

--- a/NuRadioMC/utilities/merge_hdf5.py
+++ b/NuRadioMC/utilities/merge_hdf5.py
@@ -78,6 +78,14 @@ def merge2(filenames, output_filename):
 
     # check event group ids for uniqueness (this is important because effective volume/area calculation uses the event
     # group id to determine if a multi station coincidence exists
+    # to start, get the 'event_group_ids' for the first file name only
+    # then, loop over all the other files (iF-th file) in the set, and check to see if there
+    # is any overlap (intersection) between the iF-th file and the first file
+    # if so, then identify what the overlap is, and increment the id number in the iF-th file by 1
+    # so that it again becomes unique; then use a np mask to replace the overlapping
+    # number with the new unique number in the iF-th file
+    # then, append the now totally unique list of id's from the iF-th file
+    # to the list from the first file, and so on
     unique_uegids = np.unique(data[filenames[0]]['event_group_ids'])
     for iF, f in enumerate(filenames):
         if(iF == 0):

--- a/NuRadioMC/utilities/merge_hdf5.py
+++ b/NuRadioMC/utilities/merge_hdf5.py
@@ -85,19 +85,17 @@ def merge2(filenames, output_filename):
         current_uegids = np.unique(data[f]['event_group_ids'])
         intersect = np.intersect1d(unique_uegids, current_uegids, assume_unique=True)
         if(np.sum(intersect)):
-            current_egids = data[f]['event_group_ids']
             new_egid = max(unique_uegids.max(), current_uegids.max()) + 1
             for gid in intersect:
-                mask = gid == current_egids
-                current_egids[mask] = new_egid
+                mask = gid == current_uegids
+                current_uegids[mask] = new_egid
                 new_egid += 1
             logger.warning(f"event group ids are not unique per file, current file is {f}, new unique ids have been generated.")
             logger.debug(f"non-unique event ids: {intersect}")
-#         # test again for uniqueness
-#         current_uegids = np.unique(data[f]['event_group_ids'])
-#         intersect = np.intersect1d(unique_uegids, current_uegids, assume_unique=True)
-#         if(np.sum(intersect)):
-#             raise IndexError(f"event group ids are not unique per file, current file is {f}")
+        # test again for uniqueness
+        intersect = np.intersect1d(unique_uegids, current_uegids, assume_unique=True)
+        if(np.sum(intersect)):
+            raise IndexError(f"event group ids are not unique per file, current file is {f}")
         unique_uegids = np.append(unique_uegids, current_uegids)
 
     # create data sets

--- a/NuRadioMC/utilities/merge_hdf5.py
+++ b/NuRadioMC/utilities/merge_hdf5.py
@@ -99,12 +99,12 @@ def merge2(filenames, output_filename):
                 mask = gid == current_egids  # there can be multiple entries per unique event group id, we need to change all of them to the new id
                 current_egids[mask] = new_egid
                 # also change the event_group_id arrays of the station groups
-                keys = groups[non_empty_filenames[0]]
-                for key in groups[f]:  # loop through all groups
-                    g_egids = groups[f][key]['event_group_ids']
-                    mask_g = gid == g_egids
-                    if(np.sum(mask_g)):  # station might not have this event group id, so skip stations where this egid is not present
-                        g_egids[mask_g] = new_egid
+                if f in non_empty_filenames:
+                    for key in groups[f]:  # loop through all groups
+                        g_egids = groups[f][key]['event_group_ids']
+                        mask_g = gid == g_egids
+                        if(np.sum(mask_g)):  # station might not have this event group id, so skip stations where this egid is not present
+                            g_egids[mask_g] = new_egid
                 new_egid += 1
 
             logger.warning(f"event group ids are not unique per file, current file is {f}, new unique ids have been generated.")

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,10 @@ Changelog - to keep track of all relevant changes
 
 please update the categories "new features" and "bugfixes" before a pull request merge!
 
+version 1.2.1
+bugfixes:
+- Fixed issue with merge hdf5 utility so that "event_group_ids" are properly unique
+
 version 1.2.0
 new features:
 - major change in internal looping. Now, the radio signal from each shower is calculated and signal arrival times 
@@ -14,6 +18,8 @@ new features:
 - specifying the detector simulation became easier (check out the updated examples)
 - memory consumption was optimized to stay <4GB per core
 - random realization of showers are saved so that triggered events can be resimulated using the same random realization
+
+
 
 
 version 1.1.2 - 


### PR DESCRIPTION
Issue being addressed: merge did not generate unique `event_group_id`

The hdf5 merger didn't seem to overwrite the non-unique `event_group_ids` elements when merging hdf5 files together. In particular, the duplicated element in `current_uegids` didn't get overwritten with the new id before `current_uegids` was appended to the running list stored in `unique_uegids`. This meant that an ID (call it X) could accidentally be included twice in	the `unique_uegids` array, and so the intersection of `current_uegids` and `unique_uegids` can return X (the duplicated element) even when `current_uegids` is empty, an this will cause a crash in the `new_egid = max(unique_uegids.max(), current_uegids.max()) + 1` line. I think this was happening because the dummy array (`current_egids`) which *does* get overwritten by the new unique ID never got put back into the `current_uegids` array.

I also restored a debugging message which I think would have caught this.

And added some docs.

Did you remember to: 
* include doc strings in all commits ? - N/A
* edit the changelog.txt file describing your changes? - yes, bump to version 1.2.1
