### PR TITLE
Use an energy that doesn't trigger warnings in the cross section file.

### DIFF
--- a/NuRadioMC/examples/05_pulser_calibration_measurement/A01generate_pulser_events.py
+++ b/NuRadioMC/examples/05_pulser_calibration_measurement/A01generate_pulser_events.py
@@ -64,7 +64,7 @@ def generate_my_events(filename, n_events):
 
     # again these parameters are irrelevant for our simulation but still need to be set
     data_sets["flavors"] = np.array([12 for i in range(n_events)])
-    data_sets["energies"] = np.ones(n_events) * 1 * units.eV
+    data_sets["energies"] = np.ones(n_events) * 1e18 * units.eV
     data_sets["inelasticity"] = np.ones(n_events) * 0.5
     data_sets["shower_energies"] = data_sets["inelasticity"] * data_sets["energies"]
     data_sets["shower_type"] = np.array(['had'] * n_events)


### PR DESCRIPTION
I tried fixing the pulser example, by at least suppressing the warning for having an energy (which is not used) of 1 eV. 

The example still doesn't run, but due to an incompatibility with NuRadioReco, I assume. 

$ python A03reconstruct_sim.py someoutput.hdf5 
using CPP version of ray tracer
distance = 653.38
WARNING:NuRadioReco.detector:loading detector description from /Users/anelles/ARIANNA/Reconstruction/NuRadioReco/NuRadioReco/detector/ARIANNA/arianna_detector_db.json
ERROR:NuRadioReco.NuRadioRecoio:data file not readable. File has version 11052129732745.2586 but current version is 2.2
