### PR TITLE
add downsampling of sim channels

### DIFF
--- a/NuRadioMC/__init__.py
+++ b/NuRadioMC/__init__.py
@@ -1,3 +1,3 @@
 """ NuRadioMC: Simulating the radio emission of neutrinos from interaction to detector"""
 
-__version__ = "1.2"
+__version__ = "1.2.1"

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -960,6 +960,7 @@ class simulation():
                     if(self._outputfilenameNuRadioReco is not None and self._station.has_triggered()):
                         # downsample traces to detector sampling rate to save file size
                         channelResampler.run(self._evt, self._station, self._det, sampling_rate=self._sampling_rate_detector)
+                        channelResampler.run(self._evt, self._station.get_sim_station(), self._det, sampling_rate=self._sampling_rate_detector)
                         electricFieldResampler.run(self._evt, self._station.get_sim_station(), self._det, sampling_rate=self._sampling_rate_detector)
 
                         output_mode = {'Channels': self._cfg['output']['channel_traces'],


### PR DESCRIPTION

Sim channels were not automatically downsampled to detector resolution which increases output file size of the nur files by quite a bit