### PR TITLE
fix delay_trace method.

### DIFF
--- a/NuRadioReco/utilities/trace_utilities.py
+++ b/NuRadioReco/utilities/trace_utilities.py
@@ -111,7 +111,7 @@ def get_electric_field_energy_fluence(electric_field_trace, times, signal_window
     return f_signal * dt * conversion_factor_integrated_signal
 
 
-def upsampling_fir(trace, original_sampling_frequency, int_factor=2, ntaps=2**7):
+def upsampling_fir(trace, original_sampling_frequency, int_factor=2, ntaps=2 ** 7):
     """
     This function performs an upsampling by inserting a number of zeroes
     between samples and then applying a finite impulse response (FIR) filter.
@@ -224,7 +224,7 @@ def apply_butterworth(spectrum, frequencies, passband, order=8):
     return filtered_spectrum
 
 
-def delay_trace(trace, sampling_frequency, time_delay, delayed_samples):
+def delay_trace(trace, sampling_frequency, time_delay, delayed_samples=None):
     """
     Delays a trace by transforming it to frequency and multiplying by phases.
     Since this method is cyclic, the trace has to be cropped. It only accepts
@@ -240,8 +240,9 @@ def delay_trace(trace, sampling_frequency, time_delay, delayed_samples):
         Sampling rate for the trace
     time_delay: float
         Time delay used for transforming the trace. Must be positive or 0
-    delayed_samples: integer
+    delayed_samples: integer or None
         Number of samples that the delayed trace must contain
+        if None: the trace is not cut
 
     Returns
     -------
@@ -264,7 +265,8 @@ def delay_trace(trace, sampling_frequency, time_delay, delayed_samples):
 
     init_sample = int(time_delay * sampling_frequency) + 1
 
-    delayed_trace = delayed_trace[init_sample:None]
-    delayed_trace = delayed_trace[:delayed_samples]
+    if delayed_samples is not None:
+        delayed_trace = delayed_trace[init_sample:None]
+        delayed_trace = delayed_trace[:delayed_samples]
 
     return delayed_trace


### PR DESCRIPTION
I don't understand the old way of cutting the trace. This seems to remove the time delay again. 
I made this cutting feature optional. 
