### PR TITLE
extended the Veff calculation to smaller theta ranges wrt. sim file

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -83,19 +83,19 @@ jobs:
       run: |
         export PYTHONPATH=$PWD:$PYTHONPATH
         export GSLDIR=$(gsl-config --prefix)
-        pip install proposal
+        pip install proposal==6.1.6
         NuRadioMC/test/examples/test_veff_example.sh
     - name: "Test calibration pulser example"
       run: |
         export PYTHONPATH=$PWD:$PYTHONPATH
         export GSLDIR=$(gsl-config --prefix)
-        pip install proposal
+        pip install proposal==6.1.6
         NuRadioMC/test/examples/test_cal_pulser_example.sh
     - name: "Test webinar examples"
       run: |
         export PYTHONPATH=$PWD:$PYTHONPATH
         export GSLDIR=$(gsl-config --prefix)
-        pip install proposal
+        pip install proposal==6.1.6
         NuRadioMC/test/examples/test_webinar.sh
     - name: "Veff test"
       run: |
@@ -109,7 +109,7 @@ jobs:
         NuRadioMC/test/Veff/1e18eV/test_build_noise.sh
     - name: "Atmospheric Aeff test" 
       run: |
-        pip install proposal
+        pip install proposal==6.1.6
         export PYTHONPATH=$PWD:$PYTHONPATH
         export GSLDIR=$(gsl-config --prefix)
         NuRadioMC/test/atmospheric_Aeff/1e18eV/test_build.sh

--- a/NuRadioMC/utilities/Veff.py
+++ b/NuRadioMC/utilities/Veff.py
@@ -209,17 +209,18 @@ def get_Veff_Aeff_single(filename, trigger_names, trigger_names_dict, trigger_co
     if('thetamax' in fin.attrs):
         thetamax = fin.attrs['thetamax']
 
-    # restrict the theta range, if requested
     theta_width_file = abs(np.cos(thetamin) - np.cos(thetamax))
+    # restrict the theta range, if requested
     if min(bounds_theta) > thetamin:
-        logger.info("restricting thetamin from sim file from {} to {}".format(thetamin, min(bounds_theta)))
+        logger.info("restricting thetamin from {} to {}".format(thetamin, min(bounds_theta)))
         thetamin = min(bounds_theta)
     if max(bounds_theta) < thetamax:
-        logger.info("restricting thetamax from sim file from {} to {}".format(thetamax, max(bounds_theta)))
+        logger.info("restricting thetamax from {} to {}".format(thetamax, max(bounds_theta)))
         thetamax = max(bounds_theta)
-    # assumes isotropic event generation in cos(theta) band
+    # The restriction assumes isotropic event generation in cos(theta) band
     theta_fraction = abs(np.cos(thetamin) - np.cos(thetamax))/theta_width_file
     if theta_fraction<1:
+        # adjust n_events to account for solid angle fraction in the requested theta range
         n_events *= theta_fraction
 
     if('phimin' in fin.attrs):
@@ -273,9 +274,11 @@ def get_Veff_Aeff_single(filename, trigger_names, trigger_names_dict, trigger_co
         logger.warning(f"file {filename} has no triggering events. Using trigger names from a different file: {trigger_names}")
 
     weights = np.array(fin['weights'])
-    # if zenith range is restricted, multiply with zenith mask inside bounds
+    # if theta range is restricted, select events in that range
     if theta_fraction < 1:
+        # generate boolean mask for events in fin inside selected theta range
         mask_theta = np.array((fin['zeniths']>thetamin) & (fin['zeniths']<thetamax))
+        # multiply events with mask, events outside are zero-weighted
         weights *= mask_theta
 
     if(triggered.size == 0):

--- a/NuRadioMC/utilities/Veff.py
+++ b/NuRadioMC/utilities/Veff.py
@@ -140,7 +140,7 @@ def get_Veff_water_equivalent(Veff, density_medium=0.917 * units.g / units.cm **
     return Veff * density_medium / density_water
 
 
-def get_Veff_Aeff_single(filename, trigger_names, trigger_names_dict, trigger_combinations, deposited, station, veff_aeff="veff"):
+def get_Veff_Aeff_single(filename, trigger_names, trigger_names_dict, trigger_combinations, deposited, station, veff_aeff="veff", bounds_theta=[0, np.pi]):
     """
     calculates the effective volume or effective area from surface muons from a single NuRadioMC hdf5 file
 
@@ -178,7 +178,9 @@ def get_Veff_Aeff_single(filename, trigger_names, trigger_names_dict, trigger_co
         can be 
         * "veff" (default)
         * "aeff_surface_muons"
-
+    bounds_theta: list of floats
+        restrict theta to sub-range wrt. the simulated range in the file
+        bounds_theta should be a two-item list, but will care only about the min/max values
     Returns
     ----------
     list of dictionary. Each file is one entry. The dictionary keys store all relevant properties
@@ -187,6 +189,8 @@ def get_Veff_Aeff_single(filename, trigger_names, trigger_names_dict, trigger_co
         raise AttributeError(f"the paramter `veff_aeff` needs to be one of either `veff` or `aeff_surface_muons`")
     logger.warning(f"processing file  {filename}")
     fin = h5py.File(filename, 'r')
+    n_events = fin.attrs['n_events']
+
     out = {}
     Emin = fin.attrs['Emin']
     Emax = fin.attrs['Emax']
@@ -204,6 +208,20 @@ def get_Veff_Aeff_single(filename, trigger_names, trigger_names_dict, trigger_co
         thetamin = fin.attrs['thetamin']
     if('thetamax' in fin.attrs):
         thetamax = fin.attrs['thetamax']
+
+    # restrict the theta range, if requested
+    theta_width_file = abs(np.cos(thetamin) - np.cos(thetamax))
+    if min(bounds_theta) > thetamin:
+        logger.info("restricting thetamin from sim file from {} to {}".format(thetamin, min(bounds_theta)))
+        thetamin = min(bounds_theta)
+    if max(bounds_theta) < thetamax:
+        logger.info("restricting thetamax from sim file from {} to {}".format(thetamax, max(bounds_theta)))
+        thetamax = max(bounds_theta)
+    # assumes isotropic event generation in cos(theta) band
+    theta_fraction = abs(np.cos(thetamin) - np.cos(thetamax))/theta_width_file
+    if theta_fraction<1:
+        n_events *= theta_fraction
+
     if('phimin' in fin.attrs):
         phimin = fin.attrs['phimin']
     if('phimax' in fin.attrs):
@@ -231,7 +249,6 @@ def get_Veff_Aeff_single(filename, trigger_names, trigger_names_dict, trigger_co
     out[veff_aeff] = {}
     out['n_triggered_weighted'] = {}
     out['SNRs'] = {}
-    n_events = fin.attrs['n_events']
 
     if('weights' not in fin.keys()):
         logger.warning(f"file {filename} is empty")
@@ -256,6 +273,11 @@ def get_Veff_Aeff_single(filename, trigger_names, trigger_names_dict, trigger_co
         logger.warning(f"file {filename} has no triggering events. Using trigger names from a different file: {trigger_names}")
 
     weights = np.array(fin['weights'])
+    # if zenith range is restricted, multiply with zenith mask inside bounds
+    if theta_fraction < 1:
+        mask_theta = np.array((fin['zeniths']>thetamin) & (fin['zeniths']<thetamax))
+        weights *= mask_theta
+
     if(triggered.size == 0):
         FC_low, FC_high = FC_limits(0)
         Veff_low = volume_proj_area * FC_low / n_events
@@ -412,7 +434,7 @@ def get_Veff_Aeff(folder,
              trigger_combinations={},
              station=101,
              veff_aeff="veff",
-             n_cores=1):
+             n_cores=1, oversampling_theta=1):
     """
     calculates the effective volume or effective area from surface muons from NuRadioMC hdf5 files
 
@@ -450,6 +472,10 @@ def get_Veff_Aeff(folder,
     n_cores: int
         the number of cores to use
 
+    oversampling_theta: int
+        calculate the effective volume for finer binning (<oversampling_theta> data points per file):
+        * 1: no oversampling
+        * >1: oversampling with <oversampling_theta> equal-size cos(theta) bins within thetamin/max of the input file
     Returns
     ----------
     list of dictionary. Each file is one entry. The dictionary keys store all relevant properties
@@ -497,8 +523,22 @@ def get_Veff_Aeff(folder,
     logger.warning(f"running {len(filenames)} jobs on {n_cores} cores")
 
     args = []
-    for f in filenames:
-        args.append([f, trigger_names, trigger_names_dict, trigger_combinations, deposited, station, veff_aeff])
+    if oversampling_theta == 1:
+        for f in filenames:
+            args.append([f, trigger_names, trigger_names_dict, trigger_combinations, deposited, station, veff_aeff])
+    else:
+        # get the thetamin, thetamax from the files and do oversampling
+        logger.info("Calculating effective volumes with finer binning, {} bins per input file".format(oversampling_theta))
+        for f in filenames:
+            fin = h5py.File(f, 'r')
+            costhetamin = np.cos(fin.attrs['thetamin'])
+            costhetamax = np.cos(fin.attrs['thetamax'])
+            thetas = np.arccos(np.linspace(costhetamin, costhetamax, oversampling_theta+1))
+            thetas_min = thetas[:-1]
+            thetas_max = thetas[1:]
+            for bounds_theta in zip(thetas_min, thetas_max):
+                args.append([f, trigger_names, trigger_names_dict, trigger_combinations, deposited, station, veff_aeff, bounds_theta])
+            
     if n_cores == 1:
         output = []
         for arg in args:

--- a/NuRadioMC/utilities/Veff.py
+++ b/NuRadioMC/utilities/Veff.py
@@ -180,7 +180,8 @@ def get_Veff_Aeff_single(filename, trigger_names, trigger_names_dict, trigger_co
         * "aeff_surface_muons"
     bounds_theta: list of floats
         restrict theta to sub-range wrt. the simulated range in the file
-        bounds_theta should be a two-item list, but will care only about the min/max values
+        Note: assumes events were simulated uniformly in cos(theta)
+        bounds_theta should be a (two-item) list, but will care only about the min/max values
     Returns
     ----------
     list of dictionary. Each file is one entry. The dictionary keys store all relevant properties
@@ -479,6 +480,7 @@ def get_Veff_Aeff(folder,
         calculate the effective volume for finer binning (<oversampling_theta> data points per file):
         * 1: no oversampling
         * >1: oversampling with <oversampling_theta> equal-size cos(theta) bins within thetamin/max of the input file
+        Note: oversampling assumes that events were simulated uniformly in cos(theta)
     Returns
     ----------
     list of dictionary. Each file is one entry. The dictionary keys store all relevant properties

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,12 @@ Changelog - to keep track of all relevant changes
 
 please update the categories "new features" and "bugfixes" before a pull request merge!
 
+version 2.0.1
+new features
+- Veff utility can now calculate effective volumes for fine zenith angle binning
+bugfixes:
+- fixed rare cases where the Cpp implementation of the analytic ray tracer did not find a solution
+
 version 2.0.0
 - NuRadioReco is merged into the NuRadioMC repository. No new features were added and everything works (e.g. the imports)
 as before but the NuRadioReco code is now part of the NuRadioMC github repository to simplify code development where NuRadioMC 


### PR DESCRIPTION
The effective volume/area calculation up to now took the thetamin/max from the input file.
By using an additional optional argument for single files (`bounds_theta` in `get_Veff_Aeff_single()`) this range can now be limited to a smaller subrange.
In `get_Veff_Aeff`, where this function can be called for a (directory of) file(s), a corresponding optional argument `oversampling_theta=1` is introduced, allowing to calculate iteratively the Veff/Aeff for `oversampling_theta` subranges of theta.

Since the `get_Veff_Aeff_single()` is just called several times, this is not the most efficient way to do this, but the one with minor modification to the existing functions.

This function is helpful for coarse binning in theta, and even more if only one file with 4pi space angle has been generated

This shows the result with 5fold oversampling in theta:
[effective_area_oversampling.pdf](https://github.com/nu-radio/NuRadioMC/files/6359741/effective_area_oversampling.pdf)

(almost) minimum working example:
```
from NuRadioMC.utilities import cross_sections, Veff
from NuRadioReco.utilities import units
import numpy as np

# assume some hdf5 files are in this directory...
directory="./test_veff"

v = []
cz = []

# first without oversampling, i.e. identical to the previous version
veff_dataarr = Veff.get_Veff_Aeff(directory)
for veff_data in veff_dataarr:
    cosz = (np.cos(veff_data['thetamin'])+np.cos(veff_data['thetamax'])) / 2.
    veff = veff_data['veff']['dipole_2.0sigma'][0] #['PA_4channel_100Hz'][0]
    v.append(veff)
    cz.append(cosz)

# now with oversampling
oversampling_theta = 5
v_fine = []
cz_fine = []
veff_dataarr = Veff.get_Veff_Aeff(directory, oversampling_theta=oversampling_theta)
for veff_data in veff_dataarr:
    cosz = (np.cos(veff_data['thetamin'])+np.cos(veff_data['thetamax'])) / 2.
    veff = veff_data['veff']['dipole_2.0sigma'][0] #['PA_4channel_100Hz'][0]
    v_fine.append(veff)
    cz_fine.append(cosz)

# convert effective volume to effective area
a = np.array(v)/cross_sections.get_interaction_length(1e18)
a_fine = np.array(v_fine)/cross_sections.get_interaction_length(1e18)

# do the plotting...
import matplotlib.pyplot as plt
plt.plot(cz,a/units.km**2, "o")
plt.plot(cz_fine,a_fine/units.km**2, "*")

plt.xlabel("cos(zenith)")
plt.ylabel(r"Aeff [km$^2$]")
plt.savefig("effective_area_oversampling.pdf")
plt.show()
```