### PR TITLE
Temperature dependence

### DIFF
--- a/NuRadioReco/detector/RNO_G/analog_components.py
+++ b/NuRadioReco/detector/RNO_G/analog_components.py
@@ -6,7 +6,7 @@ import logging
 logger = logging.getLogger('analog_components')
 
 
-def load_amp_response(amp_type='rno_surface', path=os.path.dirname(os.path.realpath(__file__))):  # use this function to read in log data
+def load_amp_response(amp_type='rno_surface', temp=293.15, freqs = 100*units.MHz,  path=os.path.dirname(os.path.realpath(__file__))):  # use this function to read in log data
     """
     Read out amplifier gain and phase. Currently only examples have been implemented.
     Needs a better structure in the future, possibly with database.
@@ -15,13 +15,13 @@ def load_amp_response(amp_type='rno_surface', path=os.path.dirname(os.path.realp
     in modules/RNO_G/hardweareResponseIncorporator.py l. 52, amp response.
     """
 
-    # definition correction functions: temp in Celsius, freq in GHz
-    # functions defined in temp range [-50°, +50°]
+    # definition correction functions: temp in Kelvin, freq in GHz
+    # functions defined in temperature range [223.15 K , 323.15 K]
 
     def surface_correction_func(temp, freqs):
-        return 1.0377798029 - 0.00135258197 * temp + (0.4788208019 - 0.01790064797 * temp) * (freqs ** 5)
+        return 1.0377798029 - 0.00135258197 * (temp-273.15) + (0.4788208019 - 0.01790064797 * (temp-273.15)) * (freqs ** 5)
     def iglu_correction_func(temp, freqs):
-        return 1.1139014286 - 0.00004392995 * (temp + 28.8331610295) ** 2 + (0.6301058083 - 0.0208741539 * temp) * (freqs ** 5)
+        return 1.1139014286 - 0.00004392995 * ((temp-273.15) + 28.8331610295) ** 2 + (0.6301058083 - 0.0208741539 * (temp-273.15)) * (freqs ** 5)
     amp_response = {}
     if amp_type == 'rno_surface':
         ph = os.path.join(path, 'HardwareResponses/surface_chan0_LinA.csv')
@@ -45,7 +45,7 @@ def load_amp_response(amp_type='rno_surface', path=os.path.dirname(os.path.realp
     amp_gain_f = interp1d(ff, amp_gain_discrete, bounds_error=False, fill_value=1)
     # all requests outside of measurement range are set to 0
 
-    def get_amp_gain(temp, freqs):
+    def get_amp_gain(freqs, temp):
         amp_gain = correction_function(temp, freqs) * amp_gain_f(freqs)
         return amp_gain
 

--- a/NuRadioReco/detector/RNO_G/analog_components.py
+++ b/NuRadioReco/detector/RNO_G/analog_components.py
@@ -14,17 +14,27 @@ def load_amp_response(amp_type='rno_surface', path=os.path.dirname(os.path.realp
     If you want to read in the RI function fur your reconstruction it needs to be changed
     in modules/RNO_G/hardweareResponseIncorporator.py l. 52, amp response.
     """
+
+    # definition correction functions: temp in Celsius, freq in GHz
+    # functions defined in temp range [-50°, +50°]
+
+    def surface_correction_func(temp, freqs):
+        return 1.0377798029 - 0.00135258197 * temp + (0.4788208019 - 0.01790064797 * temp) * (freqs ** 5)
+    def iglu_correction_func(temp, freqs):
+        return 1.1139014286 - 0.00004392995 * (temp + 28.8331610295) ** 2 + (0.6301058083 - 0.0208741539 * temp) * (freqs ** 5)
     amp_response = {}
     if amp_type == 'rno_surface':
         ph = os.path.join(path, 'HardwareResponses/surface_chan0_LinA.csv')
         ff = np.loadtxt(ph, delimiter=',', skiprows=7, usecols=0)
         amp_gain_discrete = np.loadtxt(ph, delimiter=',', skiprows=7, usecols=5)
         amp_phase_discrete = np.loadtxt(ph, delimiter=',', skiprows=7, usecols=6)
+        correction_function = surface_correction_func
     elif amp_type == 'iglu':
         ph = os.path.join(path, 'HardwareResponses/iglu_drab_chan0_LinA.csv')
         ff = np.loadtxt(ph, delimiter=',', skiprows=7, usecols=0)
         amp_gain_discrete = np.loadtxt(ph, delimiter=',', skiprows=7, usecols=5)
         amp_phase_discrete = np.loadtxt(ph, delimiter=',', skiprows=7, usecols=6)
+        correction_function = iglu_correction_func
     else:
         logger.error("Amp type not recognized")
         return amp_response
@@ -35,8 +45,8 @@ def load_amp_response(amp_type='rno_surface', path=os.path.dirname(os.path.realp
     amp_gain_f = interp1d(ff, amp_gain_discrete, bounds_error=False, fill_value=1)
     # all requests outside of measurement range are set to 0
 
-    def get_amp_gain(freqs):
-        amp_gain = amp_gain_f(freqs)
+    def get_amp_gain(temp, freqs):
+        amp_gain = correction_function(temp, freqs) * amp_gain_f(freqs)
         return amp_gain
 
     # Convert to MHz and broaden range

--- a/NuRadioReco/modules/RNO_G/hardwareResponseIncorporator.py
+++ b/NuRadioReco/modules/RNO_G/hardwareResponseIncorporator.py
@@ -66,7 +66,7 @@ class hardwareResponseIncorporator:
         """
         amp_type = det.get_amplifier_type(station_id, channel_id)
         amp_response = analog_components.load_amp_response(amp_type)  # it reads the log file. change this to load_amp_measurement if you want the RI file
-        amp_response = amp_response['gain'](temp, frequencies) * amp_response['phase'](frequencies)
+        amp_response = amp_response['gain'](frequencies, temp) * amp_response['phase'](frequencies)
 
         if mingainlin is not None:
             mingainlin = float(mingainlin)

--- a/NuRadioReco/modules/RNO_G/hardwareResponseIncorporator.py
+++ b/NuRadioReco/modules/RNO_G/hardwareResponseIncorporator.py
@@ -24,7 +24,7 @@ class hardwareResponseIncorporator:
     def begin(self, debug=False):
         self.__debug = debug
 
-    def get_filter(self, frequencies, station_id, channel_id, det, temp, sim_to_data=False, phase_only=False, mode=None, mingainlin=None):
+    def get_filter(self, frequencies, station_id, channel_id, det, temp=293.15, sim_to_data=False, phase_only=False, mode=None, mingainlin=None):
         """
         helper function to return the filter that the module applies.
 
@@ -38,7 +38,7 @@ class hardwareResponseIncorporator:
             the channel id
         det: detector instance
             the detector
-        temp: temperature in Celsius, better in the range [-50°, 50°]
+        temp: temperature in Kelvin, better in the range [223.15 K , 323.15 K]
         sim_to_data: bool (default False)
             if False, deconvolve the hardware response
             if True, convolve with the hardware response
@@ -87,7 +87,7 @@ class hardwareResponseIncorporator:
             return 1. / (amp_response * cable_response)
 
     @register_run()
-    def run(self, evt, station, det, temp=20, sim_to_data=False, phase_only=False, mode=None, mingainlin=None):
+    def run(self, evt, station, det, temp=293.15, sim_to_data=False, phase_only=False, mode=None, mingainlin=None):
         """
         Switch sim_to_data to go from simulation to data or otherwise.
         The option zero_noise can be used to zero the noise around the pulse. It is unclear, how useful this is.
@@ -100,6 +100,7 @@ class hardwareResponseIncorporator:
             Station to run the module on
         det: Detector
             The detector description
+        temp: temperature in Kelvin, better in the range [223.15 K , 323.15 K]
         sim_to_data: bool (default False)
             if False, deconvolve the hardware response
             if True, convolve with the hardware response


### PR DESCRIPTION
Issue being addressed:

I added the functions of the Amplifiers temperature dependence in analog_components.py
and I modified HardwareresponseIncorporator that calls analog_components.py that now also contains the temperature as a parameter. 
The gain at a temperature T for a given amplifier is given by its gain at room temperature multiplied by a correction function. The correction function is obtained empirically for one amplifier of reference (one Surface board and one DRAB + fiber + IGLU chain) by studying its gain in a climate chamber at different temperatures in the range T = [223.15 K, 323.15 K]. In figures: _surface_CH0_temp_dep.pdf, surface_CH1_temp_dep.pdf, chain_temp_dep.pdf_ are presented the reference gain measurements at all T considered. In figures: _correction_surf_CH0.pdf, correction_surf_CH1.pdf, correction_chain.pdf_ are compared the data and the corrected gain function for each T value. 
[chain_temp_dep.pdf](https://github.com/nu-radio/NuRadioMC/files/6548975/chain_temp_dep.pdf)
[correction_chain.pdf](https://github.com/nu-radio/NuRadioMC/files/6548976/correction_chain.pdf)
[surface_CH0_temp_dep.pdf](https://github.com/nu-radio/NuRadioMC/files/6548980/surface_CH0_temp_dep.pdf)
[surface_CH1_temp_dep.pdf](https://github.com/nu-radio/NuRadioMC/files/6548981/surface_CH1_temp_dep.pdf)
[correction_surf_CH0.pdf](https://github.com/nu-radio/NuRadioMC/files/6548977/correction_surf_CH0.pdf)
[correction_surf_CH1.pdf](https://github.com/nu-radio/NuRadioMC/files/6548979/correction_surf_CH1.pdf)