### PR TITLE
ARZ shower realization

### DIFF
--- a/NuRadioMC/SignalGen/ARZ/ARZ.py
+++ b/NuRadioMC/SignalGen/ARZ/ARZ.py
@@ -272,12 +272,6 @@ class ARZ(object):
         # should not trigger, we return an empty trace for angular differences > 20 degrees.
         cherenkov_angle = np.arccos(1 / n_index)
 
-        if np.abs(theta - cherenkov_angle) > maximum_angle:
-            logger.info(f"viewing angle {theta/units.deg:.1f}deg is more than {maximum_angle/units.deg:.1f}deg away from the cherenkov cone. Returning zero trace.")
-            self._random_numbers[shower_type] = None
-            empty_trace = np.zeros((3, N))
-            return empty_trace
-
         # determine closes available energy in shower library
         energies = np.array([*self._library[shower_type]])
         iE = np.argmin(np.abs(energies - shower_energy))
@@ -304,6 +298,13 @@ class ARZ(object):
             iN = int(iN)  # saveguard against iN being a float
             logger.info("using shower {}/{} as specified by user".format(iN, N_profiles))
             self._random_numbers[shower_type] = iN
+
+        # we always need to generate a random shower realization. The second ray tracing solution might be closer
+        # to the cherenkov angle, but NuRadioMC will reuse the shower realization of the first ray tracing solution.
+        if np.abs(theta - cherenkov_angle) > maximum_angle:
+            logger.info(f"viewing angle {theta/units.deg:.1f}deg is more than {maximum_angle/units.deg:.1f}deg away from the cherenkov cone. Returning zero trace.")
+            empty_trace = np.zeros((3, N))
+            return empty_trace
 
         profile_depth = profiles['depth']
         profile_ce = profiles['charge_excess'][iN] * rescaling_factor

--- a/NuRadioMC/__init__.py
+++ b/NuRadioMC/__init__.py
@@ -1,3 +1,3 @@
 """ NuRadioMC: Simulating the radio emission of neutrinos from interaction to detector"""
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"


### PR DESCRIPTION
if the first RT solution is too far off the Cherenkov cone, the ARZ model will return an empty trace and also set the shower realization to None. However, NuRadioMC will reuse the shower realization of the first RT solution. The module will select then a new random realization, but in the hdf5 file (and also nur file) the shower realization of all RT solution is set to None. This PR fixes that by always generating a random shower realization. 