### PR TITLE
add option to simulate emitters

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -69,6 +69,11 @@ jobs:
         export PYTHONPATH=$PWD:$PYTHONPATH
         export GSLDIR=$(gsl-config --prefix)
         NuRadioMC/test/SingleEvents/validate_ARZ.sh
+    - name: Single event test (emitter)
+      run: |
+        export PYTHONPATH=$PWD:$PYTHONPATH
+        export GSLDIR=$(gsl-config --prefix)
+        NuRadioMC/test/emitter/run_test.sh
     - name: Signal generation test
       run : |
           export PYTHONPATH=$PWD:$PYTHONPATH

--- a/NuRadioMC/EvtGen/generator_skeleton.py
+++ b/NuRadioMC/EvtGen/generator_skeleton.py
@@ -79,6 +79,7 @@ def generate_my_events(filename, n_events):
     # give each shower a unique id (we can also have multiple showers for a single event by just giving several showers
     # the same event_group_id)
     data_sets["event_group_ids"] = np.arange(n_events)
+    data_sets["shower_ids"] = np.arange(n_events)
 
     # there are a couple of additional parameters that are required to run a NuRadioMC simulations. These parameters
     # don't influence the simulated radio signals but are required for other post analysis tasks. If these parameters

--- a/NuRadioMC/SignalGen/emitter.py
+++ b/NuRadioMC/SignalGen/emitter.py
@@ -11,7 +11,7 @@ def set_log_level(level):
     par.set_log_level(level)
 
 
-def get_time_trace(energy, theta, N, dt, shower_type, n_index, R, model, full_output=False, **kwargs):
+def get_time_trace(amplitude, N, dt, model, full_output=False, **kwargs):
     """
     returns the electric field of an emitter
 
@@ -53,16 +53,13 @@ def get_time_trace(energy, theta, N, dt, shower_type, n_index, R, model, full_ou
         only available if `full_output` enabled
 
     """
-    shower_type = shower_type.upper()  # some convenience to be sloppy with upper/lower case
     trace = None
     additional_output = {}
-    if(energy == 0):
+    if(amplitude == 0):
         trace = np.zeros(3, N)
     if(model == 'spherical'):
-        amplitude = 1. * energy / R
-        trace = np.zeros(3, N)
-        trace[1, N // 2] = amplitude / 0.5 ** 2  # equal amplitude in eTheta (p-polarization) and ePhi (s-polarization)
-        trace[2, N // 2] = amplitude / 0.5 ** 2
+        trace = np.zeros(N)
+        trace[N // 2] = amplitude
     else:
         raise NotImplementedError("model {} unknown".format(model))
     if(full_output):
@@ -71,7 +68,7 @@ def get_time_trace(energy, theta, N, dt, shower_type, n_index, R, model, full_ou
         return trace
 
 
-def get_frequency_spectrum(energy, theta, N, dt, shower_type, n_index, R, model, full_output=False, **kwargs):
+def get_frequency_spectrum(amplitude, N, dt, model, full_output=False, **kwargs):
     """
     returns the complex amplitudes of the frequency spectrum of an emitter
 
@@ -107,7 +104,7 @@ def get_frequency_spectrum(energy, theta, N, dt, shower_type, n_index, R, model,
         only available if `full_output` enabled
 
     """
-    tmp = get_time_trace(energy, theta, N, dt, shower_type, n_index, R, model, full_output=full_output, **kwargs)
+    tmp = get_time_trace(amplitude, N, dt, model, full_output=full_output, **kwargs)
     if(full_output):
         return fft.time2freq(tmp[0], 1 / dt), tmp[1]
     else:

--- a/NuRadioMC/SignalGen/emitter.py
+++ b/NuRadioMC/SignalGen/emitter.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+from NuRadioReco.utilities import units, fft
+from NuRadioMC.SignalGen import parametrizations as par
+import logging
+logger = logging.getLogger("SignalGen.askaryan")
+
+
+def set_log_level(level):
+    logger.setLevel(level)
+    par.set_log_level(level)
+
+
+def get_time_trace(energy, theta, N, dt, shower_type, n_index, R, model, full_output=False, **kwargs):
+    """
+    returns the electric field of an emitter
+
+    We implement only the time-domain solution and obtain the frequency spectrum
+    via FFT (with the standard normalization of NuRadioMC). This approach assures
+    that the units are interpreted correctly. In the time domain, the amplitudes
+    are well defined and not details about fourier transform normalizations needs
+    to be known by the user.
+
+    Parameters
+    ----------
+    energy : float
+        energy of the shower
+    theta: float
+        viewangle: angle between shower axis (neutrino direction) and the line
+        of sight between interaction and detector
+    N : int
+        number of samples in the time domain
+    dt: float
+        time bin width, i.e. the inverse of the sampling rate
+    shower_type: string (default "HAD")
+        type of shower, either "HAD" (hadronic), "EM" (electromagnetic) or "TAU" (tau lepton induced)
+        note that TAU showers are currently only implemented in the ARZ2019 model
+    n_index: float
+        index of refraction at interaction vertex
+    R: float
+        distance from vertex to observer
+    model: string
+        specifies the signal model
+        * spherical: a simple signal model of a spherical delta pulse emitter
+    full_output: bool (default False)
+        if True, askaryan modules can return additional output
+
+    Returns
+    -------
+    time trace: 2d array, shape (3, N)
+        the amplitudes for each time bin
+    additional information: dict
+        only available if `full_output` enabled
+
+    """
+    shower_type = shower_type.upper()  # some convenience to be sloppy with upper/lower case
+    trace = None
+    additional_output = {}
+    if(energy == 0):
+        trace = np.zeros(3, N)
+    if(model == 'spherical'):
+        amplitude = 1. * energy / R
+        trace = np.zeros(3, N)
+        trace[1, N // 2] = amplitude / 0.5 ** 2  # equal amplitude in eTheta (p-polarization) and ePhi (s-polarization)
+        trace[2, N // 2] = amplitude / 0.5 ** 2
+    else:
+        raise NotImplementedError("model {} unknown".format(model))
+    if(full_output):
+        return trace, additional_output
+    else:
+        return trace
+
+
+def get_frequency_spectrum(energy, theta, N, dt, shower_type, n_index, R, model, full_output=False, **kwargs):
+    """
+    returns the complex amplitudes of the frequency spectrum of an emitter
+
+    Parameters
+    ----------
+    energy : float
+        energy of the shower
+    theta: float
+        viewangle: angle between shower axis (neutrino direction) and the line
+        of sight between interaction and detector
+    N : int
+        number of samples in the time domain
+    dt: float
+        time bin width, i.e. the inverse of the sampling rate
+    shower_type: string (default "HAD")
+        type of shower, either "HAD" (hadronic), "EM" (electromagnetic) or "TAU" (tau lepton induced)
+        note that TAU showers are currently only implemented in the ARZ2019 model
+    n_index: float
+        index of refraction at interaction vertex
+    R: float
+        distance from vertex to observer
+    model: string
+        specifies the signal model
+        * spherical: a simple signal model of a spherical delta pulse emitter
+    full_output: bool (default False)
+        if True, askaryan modules can return additional output
+
+    Returns
+    -------
+    time trace: 2d array, shape (3, N)
+        the amplitudes for each time bin
+    additional information: dict
+        only available if `full_output` enabled
+
+    """
+    tmp = get_time_trace(energy, theta, N, dt, shower_type, n_index, R, model, full_output=full_output, **kwargs)
+    if(full_output):
+        return fft.time2freq(tmp[0], 1 / dt), tmp[1]
+    else:
+        return fft.time2freq(tmp, 1 / dt)

--- a/NuRadioMC/simulation/config_default.yaml
+++ b/NuRadioMC/simulation/config_default.yaml
@@ -32,6 +32,7 @@ propagation:
   n_reflections: 0  # the maximum number of reflections off a reflective layer at the bottom of the ice layer
 
 signal:
+  type: shower  # specify the signal source. The default is an in-ice particle shower. Can also be 'emitter'
   model: Alvarez2009
   zerosignal: False  # if True, the signal is set to zero. This is useful to study 'noise' only simulations
   polarization: auto # can be either 'auto' or 'custom'

--- a/NuRadioMC/simulation/config_default.yaml
+++ b/NuRadioMC/simulation/config_default.yaml
@@ -32,7 +32,6 @@ propagation:
   n_reflections: 0  # the maximum number of reflections off a reflective layer at the bottom of the ice layer
 
 signal:
-  type: shower  # specify the signal source. The default is an in-ice particle shower. Can also be 'emitter'
   model: Alvarez2009
   zerosignal: False  # if True, the signal is set to zero. This is useful to study 'noise' only simulations
   polarization: auto # can be either 'auto' or 'custom'

--- a/NuRadioMC/test/emitter/T01generate_events.py
+++ b/NuRadioMC/test/emitter/T01generate_events.py
@@ -1,0 +1,131 @@
+import numpy as np
+from NuRadioReco.utilities import units
+from NuRadioMC.EvtGen.generator import write_events_to_hdf5
+import logging
+logger = logging.getLogger("EventGen")
+logging.basicConfig()
+
+VERSION_MAJOR = 1
+VERSION_MINOR = 1
+
+
+def generate_my_events(filename, n_events):
+    """
+    Event generator skeleton
+
+    Parameters
+    ----------
+    filename: string
+        the output filename of the hdf5 file
+    n_events: int
+        number of events to generate
+    """
+
+    # first set the meta attributes
+    attributes = {}
+    n_events = int(n_events)
+    attributes['simulation_mode'] = "emitter"
+    attributes['n_events'] = n_events  # the number of events contained in this file
+    attributes['start_event_id'] = 0
+    # define the fiducial simulation volume. Instead of specifying fiducial_rmin and fiducial_rmin one can also specify
+    # fiducial_xmin, fiducial_xmax, fiducial_ymin and fiducial_ymax
+    # the concept of the diducial volume is described in the NuRadioMC paper. In short: only interactions in this smaller
+    # fiducial volume are saved. This is useful for the simulation of secondary interactions. For this dummy example
+    # the fiduial volume is the same as the full volume.
+    # attributes['fiducial_rmin'] = 0
+    # attributes['fiducial_rmax'] = 1 * units.km
+    # attributes['fiducial_zmin'] = 0 * units.m
+    # attributes['fiducial_zmax'] = -2 * units.km
+    # define the full simulation volume. Instead of specifying rmin and rmin one can also specify
+    # xmin, xmax, ymin and ymax
+    # attributes['rmin'] = 0
+    # attributes['rmax'] = 1 * units.km
+    # attributes['zmin'] = 0 * units.m
+    # attributes['zmax'] = -2 * units.km
+    #
+    # attributes['volume'] = attributes['rmax'] ** 2 * np.pi * np.abs(attributes['zmax'])
+
+    # if only interactions on a surface (e.g. for muons from air showers) are generated, the surface area needs to be
+    # specified attributes['area']
+
+    # define the minumum and maximum energy
+    # attributes['Emin'] = 1 * units.EeV
+    # attributes['Emax'] = 1 * units.EeV
+
+    # the interval of zenith directions
+    # attributes['thetamin'] = 0
+    # attributes['thetamax'] = np.pi
+    # the interval of azimuths directions
+    # attributes['phimin'] = 0
+    # attributes['phimax'] = 2 * np.pi
+
+    # now generate the events and fill all required data sets
+    # here we fill all data sets with dummy values
+
+    # each line/entry specified a particle shower of certain energy.
+    # In principle only the shower direction (zeniths, azimuths fields), the shower position (xx, yy, zz fields)
+    # the shower energy, the shower type and the event group id are required. We set them first
+    data_sets = {}
+
+    # the position of the emitter
+    data_sets["xx"] = np.ones(n_events) * -1 * units.km
+    data_sets["yy"] = np.ones(n_events) * 0
+    data_sets["zz"] = np.ones(n_events) * -2 * units.km
+    # the amplitude of the emitter
+    data_sets["emitter_amplitudes"] = np.ones(n_events) * 1000 * units.V
+    # the orientation of the emiting antenna, defined via two vectors that are defined with two angles each (see https://nu-radio.github.io/NuRadioReco/pages/detector_database_fields.html)
+    # the following definition specifies a traditional “upright” dipole.
+    data_sets["emitter_orientation_phi"] = np.ones(n_events) * 0
+    data_sets["emitter_orientation_theta"] = np.ones(n_events) * 0
+    data_sets["emitter_rotation_phi"] = np.ones(n_events) * 0
+    data_sets["emitter_rotation_theta"] = np.ones(n_events) * 90 * units.deg
+    data_sets["emitter_antenna_type"] = ["RNOG_vpol_v1_n1.73"] * n_events
+    data_sets["emitter_model"] = ["spherical"] * n_events
+
+    # give each shower a unique id (we can also have multiple showers for a single event by just giving several showers
+    # the same event_group_id)
+    data_sets["event_group_ids"] = np.arange(n_events)
+
+    # there are a couple of additional parameters that are required to run a NuRadioMC simulations. These parameters
+    # don't influence the simulated radio signals but are required for other post analysis tasks. If these parameters
+    # are not relevant for the type of data you're generating, just set them to any value.
+    
+    # the shower type (here we only generate hadronic showers). This infomration is needed for the Askaryan emission model
+    data_sets["shower_type"] = ['had'] * n_events
+    data_sets["shower_energies"] = np.ones(n_events)
+    data_sets["shower_ids"] = np.arange(n_events)
+    # the direction of the shower
+    data_sets["azimuths"] = np.ones(n_events)
+    data_sets["zeniths"] = np.ones(n_events)
+
+    # specify which interaction it is (only relevant if multiple showers from the same initial neutrino are simulated)
+    # here it is just 1 for all events.
+    data_sets["n_interaction"] = np.ones(n_events, dtype=int)
+
+    # the neutrino flavor. Here we only generate electron neutinos which have the integer code 12.
+    # the neutrino flavor is only used in the calculation of the "weight", i.e. the probability of the neutrino reaching
+    # the detector. If other particles than a neutrino are simulated, just set the flavor to the corresponding particle code
+    # following https://pdg.lbl.gov/2019/reviews/rpp2019-rev-monte-carlo-numbering.pdf or just set it to zero.
+    data_sets["flavors"] = 12 * np.ones(n_events, dtype=int)
+    # the neutrino energy. This field is also only used for the weight calculation.
+    data_sets["energies"] = np.ones(n_events) * 1 * units.EeV
+
+    # optionally one can also directly set the event weight here (useful if particles other than neutrinos, or calibration
+    # setups are simulated
+    # data_sets["weights"] = np.ones(n_events)
+
+    # the interaction type. For neutrino interactions is can be either CC or NC. This parameter is not used but passed
+    # to the output file for information purposes.
+    data_sets["interaction_type"] = np.full(n_events, "nc", dtype='U2')
+    # The inelasiticiy, i.e. the fraction of the neutrino energy that is transferred into the hadronic shower.
+    # This parameter is not used but saved into the output file for information purposes.
+    data_sets["inelasticity"] = np.ones(n_events)
+
+    # write events to file
+    write_events_to_hdf5(filename, data_sets, attributes)
+
+
+# add some test code
+if __name__ == "__main__":
+    generate_my_events("emitter_event_list.hdf5", 20)
+

--- a/NuRadioMC/test/emitter/T02RunSimulation.py
+++ b/NuRadioMC/test/emitter/T02RunSimulation.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+from __future__ import absolute_import, division, print_function
+import argparse
+# import detector simulation modules
+import NuRadioReco.modules.trigger.highLowThreshold
+import NuRadioReco.modules.trigger.simpleThreshold
+import NuRadioReco.modules.channelBandPassFilter
+from NuRadioReco.utilities import units
+from NuRadioMC.simulation import simulation
+import logging
+import os
+logging.basicConfig(level=logging.WARNING)
+logger = logging.getLogger("runstrawman")
+
+# initialize detector sim modules
+triggerSimulatorHighLow = NuRadioReco.modules.trigger.highLowThreshold.triggerSimulator()
+triggerSimulatorSimple = NuRadioReco.modules.trigger.simpleThreshold.triggerSimulator()
+channelBandPassFilter = NuRadioReco.modules.channelBandPassFilter.channelBandPassFilter()
+
+
+class mySimulation(simulation.simulation):
+
+    def _detector_simulation_filter_amp(self, evt, station, det):
+        # bandpass filter trace, the upper bound is higher then the sampling rate which makes it just a highpass filter
+        channelBandPassFilter.run(evt, station, det, passband=[80 * units.MHz, 1000 * units.GHz],
+                                  filter_type='butter', order=2)
+        channelBandPassFilter.run(evt, station, det, passband=[0, 500 * units.MHz],
+                                  filter_type='butter', order=10)
+
+    def _detector_simulation_trigger(self, evt, station, det):
+        # run a high/low trigger on the 4 downward pointing LPDAs
+        triggerSimulatorHighLow.run(evt, station, det,
+                                    threshold_high=2 * self._Vrms,
+                                    threshold_low=-2 * self._Vrms,
+                                    triggered_channels=None,  # select the LPDA channels
+                                    number_concidences=1,  # 2/4 majority logic
+                                    trigger_name='highlow_2sigma')
+
+
+path = os.path.dirname(os.path.abspath(__file__))
+
+parser = argparse.ArgumentParser(description='Run NuRadioMC simulation')
+parser.add_argument('inputfilename', type=str,
+                    help='path to NuRadioMC input event list')
+parser.add_argument('detectordescription', type=str,
+                    help='path to file containing the detector description')
+parser.add_argument('config', type=str,
+                    help='NuRadioMC yaml config file')
+parser.add_argument('outputfilename', type=str,
+                    help='hdf5 output filename')
+parser.add_argument('outputfilenameNuRadioReco', type=str, nargs='?', default=None,
+                    help='outputfilename of NuRadioReco detector sim file')
+args = parser.parse_args()
+outputfilenameNuRadioReco = args.outputfilenameNuRadioReco
+if(outputfilenameNuRadioReco is not None):
+    outputfilenameNuRadioReco = os.path.join(path, outputfilenameNuRadioReco)
+
+sim = mySimulation(inputfilename=os.path.join(path, args.inputfilename),
+                    outputfilename=os.path.join(path, args.outputfilename),
+                    detectorfile=os.path.join(path, args.detectordescription),
+                    outputfilenameNuRadioReco=outputfilenameNuRadioReco,
+                    config_file=os.path.join(path, args.config),
+                    file_overwrite=True,
+                    log_level=logging.DEBUG)
+sim.run()
+

--- a/NuRadioMC/test/emitter/config.yaml
+++ b/NuRadioMC/test/emitter/config.yaml
@@ -1,0 +1,15 @@
+noise: False  # specify if simulation should be run with or without noise
+sampling_rate: 2.  # sampling rate in GHz used internally in the simulation.
+speedup:
+  minimum_weight_cut: 1.e-5
+  delta_C_cut: 100  # 40 degree
+  redo_raytracing: True  # redo ray tracing even if previous calculated ray tracing solutions are present
+  distance_cut: False # Skip ray tracing if vertex distance is greater than a distance cut that is a function of shower energy.
+propagation:
+  ice_model: southpole_2015
+signal:
+  model: Alvarez2000
+trigger:
+  noise_temperature: 300  # in Kelvin
+weights:
+  weight_mode: core_mantle_crust_simple

--- a/NuRadioMC/test/emitter/dipole_100m.json
+++ b/NuRadioMC/test/emitter/dipole_100m.json
@@ -1,0 +1,55 @@
+{
+    "_default": {},
+    "channels": {
+        
+        "1": {
+            "adc_id": null,
+            "adc_n_samples": 256,
+            "adc_nbits": null,
+            "adc_sampling_frequency": 1.0,
+            "adc_time_delay": null,
+            "amp_reference_measurement": null,
+            "amp_type": "300",
+            "ant_comment": "South Pole Station channel1",
+            "ant_orientation_phi": 0.0,
+            "ant_orientation_theta": 0.0,
+            "ant_position_x": 0.0,
+            "ant_position_y": 0.0,
+            "ant_position_z": -100.0,
+            "ant_rotation_phi": 90.0,
+            "ant_rotation_theta": 90.0,
+            "ant_type": "XFDTD_Vpol_CrossFeed_150mmHole_n1.78",
+            "cab_id": "17-09",
+            "cab_length": 5.0,
+            "cab_reference_measurement": null,
+            "cab_time_delay": 19.8,
+            "cab_type": "LMR_400",
+            "channel_id": 0,
+            "commission_time": "{TinyDate}:2017-11-01T00:00:00",
+            "decommission_time": "{TinyDate}:2038-01-01T00:00:00",
+            "station_id": 101
+        }
+    },
+    "comment": {
+        "1": "a surface station with 4 downward facing LPDAs and 4 dipoles with 1GHz sampling, i.e., the bandwidth is 0-500MHz"
+    },
+    "positions": {},
+    "stations": {
+        "1": {
+            "MAC_address": "0002F7F2E7B9",
+            "MBED_type": "v1",
+            "board_number": 203,
+            "commission_time": "{TinyDate}:2017-11-04T00:00:00",
+            "decommission_time": "{TinyDate}:2038-01-01T00:00:00",
+            "pos_altitude": 0,
+            "pos_easting": 0,
+            "pos_northing": 0,
+            "pos_measurement_time": null,
+            "pos_position": "SP1",
+            "pos_site": "southpole",
+            "position": "SP1",
+            "station_id": 101,
+            "station_type": null
+        }
+    }
+}

--- a/NuRadioMC/test/emitter/run_test.sh
+++ b/NuRadioMC/test/emitter/run_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
-
+cd NuRadioMC/test/emitter
 python T01generate_events.py
 python T02RunSimulation.py emitter_event_list.hdf5  dipole_100m.json config.yaml output.hdf5

--- a/NuRadioMC/test/emitter/run_test.sh
+++ b/NuRadioMC/test/emitter/run_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-python T01generate_event_list.py
+python T01generate_events.py
 python T02RunSimulation.py emitter_event_list.hdf5  dipole_100m.json config.yaml output.hdf5

--- a/NuRadioMC/test/emitter/run_test.sh
+++ b/NuRadioMC/test/emitter/run_test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+python T01generate_event_list.py
+python T02RunSimulation.py emitter_event_list.hdf5  dipole_100m.json config.yaml output.hdf5


### PR DESCRIPTION
This pull requests will add the option to simulate emitter with arbitrary polarization to NuRadioMC. This is useful to simulate calibration measurments. 
Ilya summarized the problem with the current code very well and I quote him below:

> Hi Christian,
> While discussing implementation details between me and Pawan, we came to realization of a fundamental difficulty of implementing a radio emitter as simply another plug-and-play option alongside with various askaryan shower models in NuRadioMC.
> 
>   Let me run by you my understanding of how simulation happens:
> 
> =========
> 
> 1. The electric field emitted by a source is assumed to be radial. All models in askaryan.py return a 1D E-field vector sampled in time, which is taken to be the “theta” component at this point. This is seen in here, in the get_time_trace function.
> 
> https://github.com/nu-radio/NuRadioMC/blob/857991c8e06db00196e222606e99654cc76b2f90/NuRadioMC/SignalGen/askaryan.py#L14-L17
> 
> In Pawan’s code, we have get_time_trace implemented for a radio emitter of chosen design that is fed a chosen V_src(time) pattern. We produce E(time) trace, where E is the theta polarization component (p-mode) while the phi polarization component is (s-mode) is ignored for the time being.
> 
> 2. What is actually used for event simulation is the E-field as a function of frequency, the get_frequency_spectrum of askaryan.py:
> 
> https://github.com/nu-radio/NuRadioMC/blob/857991c8e06db00196e222606e99654cc76b2f90/NuRadioMC/SignalGen/askaryan.py#L122
> 
> which simply calls the get_time_trace and makes an fft spectrum out of that.
> 
> 3. The get_time_trace is used from the simulation.py file:
> 
> https://github.com/nu-radio/NuRadioMC/blob/857991c8e06db00196e222606e99654cc76b2f90/NuRadioMC/simulation/simulation.py#L698
> 
> At this point, the electric field is 1D array E(f) representing nominally “theta” polarization. 
> 
> 4. Then, the electric field vector, originally nominally “theta”, gets rotated appropriate to the geometry of the given event in this line:
> 
> https://github.com/nu-radio/NuRadioMC/blob/857991c8e06db00196e222606e99654cc76b2f90/NuRadioMC/simulation/simulation.py#L726
> 
> which, as far as I understand, rotates the original “theta” vector appropriately so that the E-field vector is in the plane that goes through the neutrino line-of-flight, the receiver antenna location, and is directed away from the neutrino line-of-flight in that plane (assuming I am reading the code correctly). Thus, the E-field vector now has both theta and phi transverse polarizations that depend on the neutrino line-of-flight and receiver position.
> 
> ==========
> 
> This implementation, assuming I am right, is presenting us with difficulties. What we would ideally do is we would generate both theta and phi components of the electric field for a generic radio emitter, and we would disable the rotation of the polarization vector for such an emitter that assumes radial polarization direction. As far as I can see, it would be non-trivial, with get_time_trace and get_frequency_spectrum returning 2D array covering both transverse polarizations (with the second polarization being zero for neutrino showers), and then simulation.py handing that appropriately, rotating or not rotating the E-field vector depending on whether the source is a shower or a generic emitter. What solutions do you see given your knowledge?
> 
> On the shorter term, it is still possible to work with VPol emitters, it seems to me, setting the dummy “neutrino” direction to point anywhere as long as it lies in a vertical plane that goes through the receiver and the emitter locations. For this to work for a station with multiple receiver locations, one would need to point the dummy neutrino direction straight up or straight down. This would assume that pick-up on the other polarization is negligible.
> 
> However, an HPol transmitter, seems to me, would be not possible to simulate this way, both because with the difficulty to define the “dummy” neutrino direction and the fact that HPol (I think) emits both non-negligible theta and phi components to start with.
> 
> Please let me know if we are misunderstanding something or if you think non-trivial changes to askaryan.py and simulation.py that would accumulate handling two transverse polarizations without assuming radial direction with respect to a shower axis could be possible.
> 
> Thanks,
> Ilya

I think the best option is to add another config parameter that specifies if the signal source is a shower or an emitter (with the potential to add more classes in the future). The main difference is that the emitter model directly returns a 3-dim electric field. I created a new file called "emitter.py" which is similar to "askaryan.py" and has the same interface but returns a 3d vector.  This file can then store a variety of different emitters. Please have a look at the code and tell me what you think. 

I have a few questions myself
* should we better integrate emitter.py into askrayan.py? This would help to keep the two interfaces in sync but it would be messier. Another kwarg would then specify if a 1d or 3d trace is returned. 
* should we make the emitters themselves modular? I.e. emitter.py would only contain the voltage output of the pulser. Then we specify the emitting antenna and orientation and NuRadioMC automatically calculates the resulting efield. This can be achieved by a new NuRadioReco module that convolves the voltage with the antenna response. I think this would be the nicest solution. The exact signal chain (potentially there is another bandpass filter or amp in the setup), can be specified equivalent to the `def _detector_simulation(self):` method, lets call it `def _emitter_simulation(self)`. The only thing I'm not sure about is where to specify the emitter antenna configuration. At first maybe just manually in `_emitter_simulation`?


