### PR TITLE
Remove automatic deployment to test-pypi on pushes to develop

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -9,6 +9,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2.4.0
+    - name: Get the master branch (for checks)
+      uses: actions/checkout@v2.4.0
+      with:
+        ref: 'refs/heads/master'
+
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
@@ -29,12 +34,22 @@ jobs:
         python -m pip install --upgrade pip
         pip install poetry 
       # poetry recommends using curl to install - probably doesn't make a difference though?
-    
+    - name: Check if version is updated
+      run: |
+        git checkout origin/master
+        export master_version=$(poetry version)
+        git checkout $GITHUB_REF_NAME
+        if [ "$master_version" = "$(poetry version)" ]
+        then
+          echo Version number is the same as existing release. Please update the version number!
+          exit 1
+        fi
+
     - name: Build NuRadioMC # let's always build - maybe this will occasionally catch errors
       run: poetry build
     
     - name: Publish distribution 📦 to Test PyPI
-      if: ${{ github.ref == 'refs/heads/develop'}} # only runs if the push is to develop
+      if: ${{ github.ref == 'refs/heads/master'}} # only runs if the push is to master
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}


### PR DESCRIPTION
The automatic deployment workflow I implemented fails on `develop` if the version number is not incremented with each push. As this would probably be a bit of a hassle, for now the automatic deployment from the `develop` branch is removed (it is still used on the `master` branch). See #359 for more details.