### PR TITLE
fix PROPOSAL min energy cut in correct units

### DIFF
--- a/NuRadioMC/EvtGen/NuRadioProposal.py
+++ b/NuRadioMC/EvtGen/NuRadioProposal.py
@@ -404,10 +404,10 @@ class ProposalFunctions(object):
         # Checking if the secondary type is greater than 1000000000, which means
         # that the secondary is an interaction particle.
         if (sec.type > 1000000000):
-            energy = (sec.parent_particle_energy - sec.energy) * units.MeV
+            energy = (sec.parent_particle_energy - sec.energy) * pp_MeV
         # Else, the secondary is a particle issued upon decay.
         else:
-            energy = sec.energy * units.MeV
+            energy = sec.energy * pp_MeV
 
         return energy
 
@@ -534,7 +534,7 @@ class ProposalFunctions(object):
                 distance += ((sec.position.z - lepton_position[2]) * units.cm) ** 2
                 distance = np.sqrt(distance)
 
-                energy = self.__secondary_energy(sec)
+                energy = self.__secondary_energy(sec) * units.MeV
 
                 shower_type, code, name = self.__shower_properties(sec)
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,11 +2,19 @@ Changelog - to keep track of all relevant changes
 
 please update the categories "new features" and "bugfixes" before a pull request merge!
 
-version 2.1.2-beta
+version 2.1.4-dev
+
 new features:
 
 bugfixes:
+
+version 2.1.3
+bugfixes:
 - PROPOSAL energy cut (min_energy_cut_nu) assumed wrong units (before: 1e-6*units.eV)
+
+version 2.1.2
+bugfixes:
+- Fixes that the generic detector crashes for certain detector files. 
 
 version 2.1.1
 new features:

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,7 @@ version 2.1.2-beta
 new features:
 
 bugfixes:
-
+- PROPOSAL energy cut (min_energy_cut_nu) assumed wrong units (before: 1e-6*units.eV)
 
 version 2.1.1
 new features:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "NuRadioMC"
-version = "2.1.3-dev"
+version = "2.1.3"
 authors = ["Christian Glaser et al."]
 homepage = "https://github.com/nu-radio/NuRadioMC"
 documentation = "https://nu-radio.github.io/NuRadioMC/main.html"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "NuRadioMC"
-version = "2.1.3"
+version = "2.1.4-beta"
 authors = ["Christian Glaser et al."]
 homepage = "https://github.com/nu-radio/NuRadioMC"
 documentation = "https://nu-radio.github.io/NuRadioMC/main.html"


### PR DESCRIPTION
In the NuRadioMC PROPOSAL class (secondary shower generation) all the private functions are in PROPOSAL units (MeV instead of NuRadioMC's eV). One of them accidentially used NuRadioMC units.

As a consequence, the `min_energy_cut_nu` needed to be given in NuRadioMC units x 1e6. This is fixed with this PR.
