### PR TITLE
Update NuRadioRecoio.py

### DIFF
--- a/NuRadioReco/modules/io/NuRadioRecoio.py
+++ b/NuRadioReco/modules/io/NuRadioRecoio.py
@@ -166,7 +166,9 @@ class NuRadioRecoio(object):
                                 time_strings = str(value).split(' ')
                                 station_time = astropy.time.Time('{}T{}'.format(time_strings[0], time_strings[1]), format='isot')
                             else:
-                                station_time = time
+                                value.in_subfmt = 'date_hms'
+                                value.out_subfmt = 'date_hms'
+                                station_time=value
                         else:
                             station_time = None
                         self.__event_headers[station_id][key].append(station_time)


### PR DESCRIPTION
Fixing station_time got from station_header.

In the old version:
`data=NuRadioRecoio.NuRadioRecoio(file)
  h=data.get_header()
  sh=h[station_id]
  station_time=sh[stnp.station_time]`

station_time is the built-in python module <time>.

This is because in NuRadioRecoio.py line 169:

`station_time = time`

where time is the imported python module.

It is fixed by the change
