### PR TITLE
Hotfix/n interaction parameter

### DIFF
--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -1311,7 +1311,6 @@ class simulation():
     def _read_input_particle_properties(self, idx=None):
         if idx is None:
             idx = self._primary_index
-        self._fin['n_interaction'][self._shower_index] = self._fin['n_interaction'][idx]
         self._event_group_id = self._fin['event_group_ids'][idx]
 
         self.input_particle = NuRadioReco.framework.particle.Particle(0)

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -1319,13 +1319,13 @@ class simulation():
         self.input_particle[simp.interaction_type] = self._fin['interaction_type'][idx]
         self.input_particle[simp.inelasticity] = self._fin['inelasticity'][idx]
         self.input_particle[simp.vertex] = np.array([self._fin['xx'][idx],
-                                                  self._fin['yy'][idx],
-                                                  self._fin['zz'][idx]])
+                                                     self._fin['yy'][idx],
+                                                     self._fin['zz'][idx]])
         self.input_particle[simp.zenith] = self._fin['zeniths'][idx]
         self.input_particle[simp.azimuth] = self._fin['azimuths'][idx]
         self.input_particle[simp.inelasticity] = self._fin['inelasticity'][idx]
         self.input_particle[simp.n_interaction] = self._fin['n_interaction'][idx]
-        if self._fin['n_interaction'][self._shower_index] <= 1:
+        if self._fin['n_interaction'][idx] <= 1:
             # parents before the neutrino and outgoing daughters without shower are currently not
             # simulated. The parent_id is therefore at the moment only rudimentarily populated.
             self.input_particle[simp.parent_id] = None  # primary does not have a parent

--- a/NuRadioReco/modules/channelAntennaDedispersion.py
+++ b/NuRadioReco/modules/channelAntennaDedispersion.py
@@ -35,10 +35,6 @@ class channelAntennaDedispersion:
 
     @register_run()
     def run(self, evt, station, det, debug=False):
-        """
-        parameters
-        ----------
-        """
         for channel in station.iter_channels():
             ff = channel.get_frequencies()
             response = self._get_response(det, station.get_id(), channel.get_id(), tuple(ff))

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,16 @@ Changelog - to keep track of all relevant changes
 please update the categories "new features" and "bugfixes" before a pull request merge!
 
 
+version 2.1.6
+bugfixes:
+- the n_interaction parameter was accidentally overridden. n_interaction counts the number of interactions of taus and 
+muons generated in the corresponding CC interactions. The bug resulted in the following behaviour: The n_interaction value of the primary
+neutrino interaction was overridden with the n_interaction value of the last shower of the previous event group. If the previous event group
+was a CC interaction, the n_interaction value of the primary interaction was set to a value larger than 1. If that happened, and if the primary
+shower did not trigger the detector, this shower is not added to the output hdf5 file. This has consquences for analyzing hdf5 files for 
+secondary interactions. With this bug, the initial interaction needs to be idenfified with np.abs(flavor) == 14 or 16.  
+This bug does not effect any effective volume calculation. 
+
 version 2.1.5
 bugfixes:
 - the phased array trigger module did not calculate the trigger time.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "NuRadioMC"
-version = "2.1.5"
+version = "2.1.6"
 authors = ["Christian Glaser et al."]
 homepage = "https://github.com/nu-radio/NuRadioMC"
 documentation = "https://nu-radio.github.io/NuRadioMC/main.html"


### PR DESCRIPTION
the n_interaction parameter was accidentally overridden. n_interaction counts the number of interactions of taus and muons generated in the corresponding CC interactions. The bug resulted in the following behavior: The n_interaction value of the primary neutrino interaction was overridden with the n_interaction value of the last shower of the previous event group. If the previous event group was a CC interaction, the n_interaction value of the primary interaction was set to a value larger than 1. If that happened, and if the primary shower did not trigger the detector, this shower is not added to the output hdf5 file. This has consequences for analyzing hdf5 files for 
 secondary interactions. With this bug, the initial interaction needs to be identified with np.abs(flavor) == 14 or 16.  
This bug does not affect any effective volume calculation. 
