### PR TITLE
hotfix for documentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ numba = "*"
 [tool.poetry.dev-dependencies]
 Sphinx = "*"
 sphinx-rtd-theme = "*"
-numpydoc = "*"
+numpydoc = "1.1.0"
 proposal = "6.1.6"
 pygdsm = {git = "https://github.com/telegraphic/pygdsm"}
 nifty5 = {git = "https://gitlab.mpcdf.mpg.de/ift/nifty.git", branch="NIFTy_5"}


### PR DESCRIPTION
The latest version of `numpydoc` (1.2) raises a new warning that makes the (slightly hacky) documentation building script fail. This means the documentation test fails on all PRs.

This hotfix fixes the `numpydoc` version to `1.1.0`, temporarily solving this issue. I will properly update the documentation building script in PR #368 