### PR TITLE
fix issue 387 by including reference_station to dictionary

### DIFF
--- a/NuRadioReco/modules/io/coreas/readCoREASShower.py
+++ b/NuRadioReco/modules/io/coreas/readCoREASShower.py
@@ -122,7 +122,8 @@ class readCoREASShower:
                             'station_id': station_id,
                             'pos_easting': antenna_position[0],
                             'pos_northing': antenna_position[1],
-                            'pos_altitude': antenna_position[2]
+                            'pos_altitude': antenna_position[2],
+                            'reference_station': self.__det.get_reference_station_ids()[0]
                         })
                     else:
                         self.__det.add_station_properties_for_event({


### PR DESCRIPTION
station in readCoREASShower.py was missing a reference station when it was added manually
