### PR TITLE
Update noise.py

### DIFF
--- a/NuRadioReco/utilities/noise.py
+++ b/NuRadioReco/utilities/noise.py
@@ -190,10 +190,10 @@ class thermalNoiseGenerator():
                     if(True in triggered_bins):
                         t_bins[iCh] = triggered_bins
                         if(iCh == 0):
-                            n_traces[iCh] = np.roll(trace, self.trigger_bin - np.argwhere(triggered_bins is True)[0])
+                            n_traces[iCh] = np.roll(trace, self.trigger_bin - np.argwhere(triggered_bins == True)[0])
                         else:
                             tmp = np.random.randint(self.trigger_bin_low, self.trigger_bin)
-                            n_traces[iCh] = np.roll(trace, tmp - np.argwhere(triggered_bins is True)[0])
+                            n_traces[iCh] = np.roll(trace, tmp - np.argwhere(triggered_bins == True)[0])
         traces = np.zeros((self.n_channels, self.n_samples))
         rnd_iterator = list(range(self.n_channels))
         np.random.shuffle(rnd_iterator)


### PR DESCRIPTION
Changed occurrences of:
`np.argwhere(triggered_bins is True)`
to
`np.argwhere(triggered_bins == True)`

I don't know if this is a python version issue, but at least with the python I am using (3.8.9), using `is` incorrectly returns an empty list and raises an error, while using `==` works