### PR TITLE
Singleton metaclass no longer alters class signature

### DIFF
--- a/NuRadioReco/utilities/metaclasses.py
+++ b/NuRadioReco/utilities/metaclasses.py
@@ -1,21 +1,31 @@
 class Singleton(type):
     """
     Can be assigned to classes as a metaclass.
-    By default, only one instance of a Singleton can exist at a time, as the __call__ method is overwritten to
+
+    By default, only one instance of a Singleton can exist at a time,
+    as the ``__call__`` method is overwritten to
     return the existing instance if one exists.
     """
     _instances = {}
 
-    def __call__(cls, create_new=False, *args, **kwargs):
+    def __call__(cls, *args, **kwargs):
         """
-        Overwrites the __call__ method to check if an instance of the class already exists
-        and returns that instance instead of creating a new one.
+        Overwrites the __call__ method
+
+        Checks if an instance of the class already exists
+        and returns that instance instead of creating a new one, unless
+        ``create_new=True`` is specified.
 
         Parameters
         ----------
         create_new: bool (default:False)
-            If set to true, a new instance will always be created, event if one already exists.
+            If set to true, a new instance will always be created, even if one already exists.
         """
+        if 'create_new' in kwargs.keys():
+            create_new = kwargs['create_new']
+            kwargs.pop('create_new') # this kwarg should not be passed on to the class!
+        else:
+            create_new = False # the default
         if Singleton._instances.get(cls, None) is None or create_new:
             Singleton._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
         return Singleton._instances[cls]


### PR DESCRIPTION
The [Singleton](https://nu-radio.github.io/NuRadioMC/NuRadioReco/apidoc/NuRadioReco.utilities.metaclasses.html?highlight=singleton#NuRadioReco.utilities.metaclasses.Singleton) metaclass used to alter the signature of the classes it was applied to. In particular, calling a Singleton class with positional arguments resulted in the first positional argument being interpreted as the `create_new` boolean argument - this behaviour was (to me) unexpected, and is not reflected in the docstrings / documentation of the existing Singleton classes.

This pull request changes the behaviour of Singleton classes - now, `create_new` **must** be passed as a keyword argument, but the signature of the class stays the same. I think this is more intuitive and less error-prone when creating new Singleton classes than the old behaviour. Alternatively, one could consider (at minimum) to change all docstrings to accurately reflect that the first argument is `create_new`.