### PR TITLE
Fix example 05_pulser_calibration_measurement. Uncomment dummy proper…

### DIFF
--- a/NuRadioMC/examples/05_pulser_calibration_measurement/A01generate_pulser_events.py
+++ b/NuRadioMC/examples/05_pulser_calibration_measurement/A01generate_pulser_events.py
@@ -63,11 +63,11 @@ def generate_my_events(filename, n_events):
     data_sets["interaction_type"] = np.array(['had'] * n_events)
 
     # again these parameters are irrelevant for our simulation but still need to be set
-    # data_sets["flavors"] = np.array([12 for i in range(n_events)])
-    # data_sets["energies"] = np.ones(n_events) * 1 * units.eV
-    # data_sets["inelasticity"] = np.ones(n_events) * 0.5
-    # data_sets["shower_energies"] = data_sets["inelasticity"] * data_sets["energies"]
-    # data_sets["shower_type"] = np.array(['had'] * n_events)
+    data_sets["flavors"] = np.array([12 for i in range(n_events)])
+    data_sets["energies"] = np.ones(n_events) * 1 * units.eV
+    data_sets["inelasticity"] = np.ones(n_events) * 0.5
+    data_sets["shower_energies"] = data_sets["inelasticity"] * data_sets["energies"]
+    data_sets["shower_type"] = np.array(['had'] * n_events)
 
     # write events to file
     write_events_to_hdf5(filename, data_sets, attributes)


### PR DESCRIPTION
…ties for neutrino event
with this PR the example `05_pulser_calibration_measurement` is "fixed". Which means it runs through. However it splits out a lot of warnings which were/are already addressed with the issue #325. By the way this example is not in the automatic testing (CI).

Can we maybe avoid the warning by increasing the dummy energy? Is is dangerous to put a "reasonable" energy there? 