### PR TITLE
Store non-triggered events if config save_all is true

### DIFF
--- a/NuRadioMC/simulation/config_default.yaml
+++ b/NuRadioMC/simulation/config_default.yaml
@@ -9,6 +9,8 @@ split_event_time_diff: 1e6  # the minimal time difference (in ns) between two vo
 
 seed: 1235
 
+save_all: False  # If True store all (also non-triggered) events
+
 speedup:
   minimum_weight_cut: 1.e-5
   delta_C_cut: 0.698  # 40 degree

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -967,7 +967,8 @@ class simulation():
                         self._detector_simulation_filter_amp(self._evt, self._station, self._det)
 
                         self._detector_simulation_trigger(self._evt, self._station, self._det)
-                    if(not self._station.has_triggered()):
+                    
+                    if not self._station.has_triggered() and not self._cfg['save_all']:
                         continue
 
                     event_group_has_triggered = True


### PR DESCRIPTION
Fixes #438 

This change seems to fix the issue. However, I have just re-run a simulation and saw that more events are written out! Also, event which skipped to speedup the simulation are still not stored. Is that desired? Is that information in the hdf5 files? I am not experience yet to judge whether the use case is strong enough, but  I would like to have possibilities to have all events stored (even if their signals are not properly simulated to speed up the simulation), this could be useful for efficiency calculation, right? 