### PR TITLE
Radiopropa/default ice

### DIFF
--- a/NuRadioMC/utilities/medium.py
+++ b/NuRadioMC/utilities/medium.py
@@ -247,22 +247,22 @@ class greenland_firn(medium_base.IceModel):
         return self._scalarfield.getGradient(pos) * (1 / (units.meter/RP.meter))
 
     
-    def get_ice_model_radiopropa(self):
+    def compute_default_ice_model_radiopropa(self):
         """
-        Returns an object holding the radiopropa scalarfield and necessary radiopropa moduldes 
-        that define the medium in radiopropa. It uses the parameters of the medium object to 
-        contruct some modules, like a discontinuity object for the air boundary. Additional modules
-        can be added in this function
+        Computes a default object holding the radiopropa scalarfield and necessary radiopropa 
+        moduldes that define the medium in radiopropa. It uses the parameters of the medium 
+        object to contruct some modules, like a discontinuity object for the air boundary. 
+        Additional modules can be added in this function
         
         Overwrites function of the mother class
 
         Returns
         -------
-        ice:    RadioPropaIceWrapper
-                object holding the radiopropa scalarfield and modules
+        ice_model_radiopropa:   RadioPropaIceWrapper
+                                object holding the radiopropa scalarfield and modules
         """
-        ice = medium_base.RadioPropaIceWrapper(self, self._scalarfield)
-        return ice
+        self._ice_model_radiopropa = medium_base.RadioPropaIceWrapper(self, self._scalarfield)
+        return self._ice_model_radiopropa
 
 class greenland_perturbation(greenland_firn):
     def __init__(self):
@@ -287,7 +287,6 @@ class uniform_ice(medium_base.IceModelSimple):
             z_0 = 1*units.meter, 
             delta_n = 0,
             )
-
 
 def get_ice_model(name):
     """

--- a/NuRadioMC/utilities/medium.py
+++ b/NuRadioMC/utilities/medium.py
@@ -251,8 +251,8 @@ class greenland_firn(medium_base.IceModel):
         """
         Computes a default object holding the radiopropa scalarfield and necessary radiopropa 
         moduldes that define the medium in radiopropa. It uses the parameters of the medium 
-        object to contruct some modules, like a discontinuity object for the air boundary. 
-        Additional modules can be added in this function
+        object to contruct the scalar field (using the firn ice model implementation 
+        in radiopropa) and some modules (like a discontinuity object for the air boundary). 
         
         Overwrites function of the mother class
 
@@ -261,15 +261,27 @@ class greenland_firn(medium_base.IceModel):
         ice_model_radiopropa:   RadioPropaIceWrapper
                                 object holding the radiopropa scalarfield and modules
         """
-        self._ice_model_radiopropa = medium_base.RadioPropaIceWrapper(self, self._scalarfield)
-        return self._ice_model_radiopropa
+        return medium_base.RadioPropaIceWrapper(self, self._scalarfield)
 
 class greenland_perturbation(greenland_firn):
     def __init__(self):
         greenland_firn.__init__(self)
         
-    def get_ice_model_radiopropa(self,discontinuity=False):
-        ice = greenland_firn.get_ice_model_radiopropa(self,discontinuity=discontinuity)
+    def compute_default_ice_model_radiopropa(self,discontinuity=False):
+        """
+        Computes a default object holding the radiopropa scalarfield and necessary radiopropa 
+        moduldes that define the medium in radiopropa. It uses the parameters of the medium 
+        object to contruct some modules using the default computation of the firn model.
+        An additional module for the perturbation layer is then added to the object.
+        
+        Overwrites function of the mother class
+
+        Returns
+        -------
+        ice_model_radiopropa:   RadioPropaIceWrapper
+                                object holding the radiopropa scalarfield and modules
+        """
+        ice = greenland_firn.compute_default_ice_model_radiopropa(self)
         #fraction from ArXiv 1805.12576 table IV last row
         perturbation_horz = RP.PerturbationHorizontal(-100*RP.meter,2*RP.meter, fraction=1)
         ice.add_module('horizontal perturbation',perturbation_horz)
@@ -287,6 +299,7 @@ class uniform_ice(medium_base.IceModelSimple):
             z_0 = 1*units.meter, 
             delta_n = 0,
             )
+
 
 def get_ice_model(name):
     """

--- a/NuRadioMC/utilities/medium.py
+++ b/NuRadioMC/utilities/medium.py
@@ -247,7 +247,7 @@ class greenland_firn(medium_base.IceModel):
         return self._scalarfield.getGradient(pos) * (1 / (units.meter/RP.meter))
 
     
-    def compute_default_ice_model_radiopropa(self):
+    def _compute_default_ice_model_radiopropa(self):
         """
         Computes a default object holding the radiopropa scalarfield and necessary radiopropa 
         moduldes that define the medium in radiopropa. It uses the parameters of the medium 
@@ -267,7 +267,7 @@ class greenland_perturbation(greenland_firn):
     def __init__(self):
         greenland_firn.__init__(self)
         
-    def compute_default_ice_model_radiopropa(self,discontinuity=False):
+    def _compute_default_ice_model_radiopropa(self,discontinuity=False):
         """
         Computes a default object holding the radiopropa scalarfield and necessary radiopropa 
         moduldes that define the medium in radiopropa. It uses the parameters of the medium 
@@ -281,7 +281,7 @@ class greenland_perturbation(greenland_firn):
         ice_model_radiopropa:   RadioPropaIceWrapper
                                 object holding the radiopropa scalarfield and modules
         """
-        ice = greenland_firn.compute_default_ice_model_radiopropa(self)
+        ice = greenland_firn._compute_default_ice_model_radiopropa(self)
         #fraction from ArXiv 1805.12576 table IV last row
         perturbation_horz = RP.PerturbationHorizontal(-100*RP.meter,2*RP.meter, fraction=1)
         ice.add_module('horizontal perturbation',perturbation_horz)

--- a/NuRadioMC/utilities/medium_base.py
+++ b/NuRadioMC/utilities/medium_base.py
@@ -139,6 +139,8 @@ class IceModel():
 
         # when implementing a new ice_model this part of the function should be ice model specific
         # if the new ice_model cannot be used in RadioPropa, this function should throw an error
+        logger.error('function not defined')
+        raise NotImplementedError('function not defined')
 
     def get_ice_model_radiopropa(self):
         """

--- a/NuRadioMC/utilities/medium_base.py
+++ b/NuRadioMC/utilities/medium_base.py
@@ -127,14 +127,15 @@ class IceModel():
         raise NotImplementedError('function not defined')
 
     
-    def compute_default_ice_model_radiopropa(self):
+    def _compute_default_ice_model_radiopropa(self):
         """
         Computes a default object holding the radiopropa scalarfield and necessary radiopropa 
         moduldes that define the medium in radiopropa. It uses the parameters of the medium 
         object to contruct some modules, like a discontinuity object for the air boundary. 
         Additional modules can be added in this function
-        
-        Overwrites function of the mother class
+
+        This is the default and should always be overriden/implemented in new ice model!
+
 
         Returns
         -------
@@ -153,7 +154,13 @@ class IceModel():
     def get_ice_model_radiopropa(self):
         """
         Returns an object holding the radiopropa scalarfield and necessary radiopropa moduldes 
-        that define the medium in radiopropa. 
+        that define the medium in radiopropa. If no specific model is set by the user it returns
+        the default implemented model using the '_compute_default_ice_model_radiopropa' function.
+
+        This seperation allows having the posibility to set a more specific/adjusted radiopropa 
+        ice model in case they need it, without losing the access to the default model. 
+
+        DO NOT OVERRIDE THIS FUNCTION
 
         Returns
         -------
@@ -165,7 +172,7 @@ class IceModel():
             raise ImportError('RadioPropa could not be imported')
 
         if self._ice_model_radiopropa is None:
-            self._ice_model_radiopropa = self.compute_default_ice_model_radiopropa()
+            self._ice_model_radiopropa = self._compute_default_ice_model_radiopropa()
         
         return self._ice_model_radiopropa
 
@@ -174,6 +181,8 @@ class IceModel():
         If radiopropa is installed, this function can be used
         to set a specific RadioPropaIceWrapper object as the
         ice model used for RadioPropa.
+
+        DO NOT OVERRIDE THIS FUNCTION
 
         Parameters:
         -----------
@@ -315,13 +324,13 @@ class IceModelSimple(IceModel):
             gradient[2] = -self.delta_n / self.z_0 * np.exp((position[2] - self.z_shift) / self.z_0)
         return gradient
 
-    def compute_default_ice_model_radiopropa(self):
+    def _compute_default_ice_model_radiopropa(self):
         """
         If radiopropa is installed this will compute and return a default object holding the 
         radiopropa scalarfield and necessary radiopropa moduldes that define the medium in 
         radiopropa. It uses the parameters of the medium object to contruct the scalar field 
         using the simple ice model implementation in radiopropa and some modules, like a 
-        discontinuity object for the air boundary
+        discontinuity object for the air boundary.
         
         Overwrites function of the mother class
 

--- a/NuRadioMC/utilities/medium_base.py
+++ b/NuRadioMC/utilities/medium_base.py
@@ -315,13 +315,13 @@ class IceModelSimple(IceModel):
             gradient[2] = -self.delta_n / self.z_0 * np.exp((position[2] - self.z_shift) / self.z_0)
         return gradient
 
-    def get_ice_model_radiopropa(self):
+    def compute_default_ice_model_radiopropa(self):
         """
-        If radiopropa is installed this will return an object holding the radiopropa
-        scalarfield and necessary radiopropa moduldes that define the medium in radiopropa. 
-        It uses the parameters of the medium object to contruct the scalar field using the 
-        simple ice model implementation in radiopropa and some modules, like a discontinuity 
-        object for the air boundary
+        If radiopropa is installed this will compute and return a default object holding the 
+        radiopropa scalarfield and necessary radiopropa moduldes that define the medium in 
+        radiopropa. It uses the parameters of the medium object to contruct the scalar field 
+        using the simple ice model implementation in radiopropa and some modules, like a 
+        discontinuity object for the air boundary
         
         Overwrites function of the mother class
 
@@ -330,16 +330,17 @@ class IceModelSimple(IceModel):
         ice:    RadioPropaIceWrapper
                 object holding the radiopropa scalarfield and modules
         """
-        if radiopropa_is_imported:
-            scalar_field = RP.IceModel_Simple(z_surface=self.z_air_boundary*RP.meter/units.meter, 
-                                            n_ice=self.n_ice, delta_n=self.delta_n, 
-                                            z_0=self.z_0*RP.meter/units.meter,
-                                            z_shift=self.z_shift*RP.meter/units.meter)
-            return RadioPropaIceWrapper(self, scalar_field)
-        else:
+        if not radiopropa_is_imported:
             logger.error('The radiopropa dependency was not import and can therefore not be used.'
                         +'\nMore info on https://github.com/nu-radio/RadioPropa')
             raise ImportError('RadioPropa could not be imported')
+
+        scalar_field = RP.IceModel_Simple(z_surface=self.z_air_boundary*RP.meter/units.meter, 
+                                        n_ice=self.n_ice, delta_n=self.delta_n, 
+                                        z_0=self.z_0*RP.meter/units.meter,
+                                        z_shift=self.z_shift*RP.meter/units.meter)
+        return RadioPropaIceWrapper(self, scalar_field)
+            
 
 
 

--- a/NuRadioMC/utilities/medium_base.py
+++ b/NuRadioMC/utilities/medium_base.py
@@ -37,6 +37,7 @@ class IceModel():
         self.reflection = None
         self.reflection_coefficient = None
         self.reflection_phase_shift = None
+        self._ice_model_radiopropa = None
 
     def add_reflective_bottom(self, refl_z, refl_coef, refl_phase_shift):
         """
@@ -126,20 +127,55 @@ class IceModel():
         raise NotImplementedError('function not defined')
 
     
-    def get_ice_model_radiopropa(self):
+    def compute_default_ice_model_radiopropa(self):
         """
         if radiopropa is installed this will a RadioPropaIceWrapper object
         which can then be used to insert in the radiopropa tracer
 
         """
-        if radiopropa_is_imported:
-            # when implementing a new ice_model this part of the function should be ice model specific
-            # if the new ice_model cannot be used in RadioPropa, this function should throw an error
-            logger.error('function not defined')
-            raise NotImplementedError('function not defined')
-        else:
+        if not radiopropa_is_imported:
             logger.error('The radiopropa dependancy was not import and can therefore not be used. \nMore info on https://github.com/nu-radio/RadioPropa')
             raise ImportError('RadioPropa could not be imported')
+
+        # when implementing a new ice_model this part of the function should be ice model specific
+        # if the new ice_model cannot be used in RadioPropa, this function should throw an error
+
+    def get_ice_model_radiopropa(self):
+        """
+        Returns an object holding the radiopropa scalarfield and necessary radiopropa moduldes 
+        that define the medium in radiopropa. 
+
+        Returns
+        -------
+        ice:    RadioPropaIceWrapper
+                object holding the radiopropa scalarfield and modules
+        """
+        if not radiopropa_is_imported:
+            logger.error('The radiopropa dependancy was not import and can therefore not be used. \nMore info on https://github.com/nu-radio/RadioPropa')
+            raise ImportError('RadioPropa could not be imported')
+
+        if self._ice_model_radiopropa is None:
+            self._ice_model_radiopropa = self.compute_default_ice_model_radiopropa()
+        
+        return self._ice_model_radiopropa
+
+    def set_ice_model_radiopropa(self, ice_model_radiopropa):
+        """
+        If radiopropa is installed, this function can be used
+        to set a specific RadioPropaIceWrapper object as the
+        ice model used for RadioPropa.
+
+        Parameters:
+        -----------
+        ice_model_radioprop:    RadioPropaIceWrapper
+                                object holding the radiopropa scalarfield and modules
+
+        """
+        if not radiopropa_is_imported:
+            logger.error('The radiopropa dependancy was not import and can therefore not be used. \nMore info on https://github.com/nu-radio/RadioPropa')
+            raise ImportError('RadioPropa could not be imported')
+
+        self._ice_model_radiopropa = ice_model_radiopropa
 
 
 class IceModelSimple(IceModel):

--- a/NuRadioMC/utilities/medium_base.py
+++ b/NuRadioMC/utilities/medium_base.py
@@ -129,9 +129,17 @@ class IceModel():
     
     def compute_default_ice_model_radiopropa(self):
         """
-        if radiopropa is installed this will a RadioPropaIceWrapper object
-        which can then be used to insert in the radiopropa tracer
+        Computes a default object holding the radiopropa scalarfield and necessary radiopropa 
+        moduldes that define the medium in radiopropa. It uses the parameters of the medium 
+        object to contruct some modules, like a discontinuity object for the air boundary. 
+        Additional modules can be added in this function
+        
+        Overwrites function of the mother class
 
+        Returns
+        -------
+        ice_model_radiopropa:   RadioPropaIceWrapper
+                                object holding the radiopropa scalarfield and modules
         """
         if not radiopropa_is_imported:
             logger.error('The radiopropa dependancy was not import and can therefore not be used. \nMore info on https://github.com/nu-radio/RadioPropa')

--- a/NuRadioMC/utilities/medium_base.py
+++ b/NuRadioMC/utilities/medium_base.py
@@ -184,8 +184,8 @@ class IceModel():
 
         DO NOT OVERRIDE THIS FUNCTION
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         ice_model_radioprop:    RadioPropaIceWrapper
                                 object holding the radiopropa scalarfield and modules
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,11 +5,11 @@ please update the categories "new features" and "bugfixes" before a pull request
 version 2.2.0
 new features:
 - add attenuation model from the 2021 measurements taken at Summit Station
-- print warning for positive z in attenuation, and set attenuation length to
-+inf for positive z
+- print warning for positive z in attenuation, and set attenuation length to +inf for positive z
 - adding minimize mode to the radiopropa propagation module & more configurable settings in config file
 - add uniform ice model with 1.78 refractive index
 - update ARA detector description and add a file to Print ARA detector json file
+- adding default RadioPropa ice model object to medium with the feature to set a personlised object as alternative
 bugfixes:
 
 


### PR DESCRIPTION
Make it possible to adjust the RadioPropa ice model imbedded in a medium and set it to this new object without losing the default RadioPropa ice model configuration in the medium

