### PR TITLE
improve log output of C++ ray tracer

### DIFF
--- a/NuRadioMC/utilities/attenuation.h
+++ b/NuRadioMC/utilities/attenuation.h
@@ -202,7 +202,7 @@ double get_attenuation_length(double z, double frequency, int model){
 	} else if (model == 5) {
 	    return fit_GL3(z, frequency);
 	} else {
-		std::cout << "attenuation length model " << model << " unknown" << std::endl;
+		std::cout << "attenuation length model " << model << " unknown. Maybe you need to recompile the C++ ray tracer." << std::endl;
 		throw 0;
 	}
 }


### PR DESCRIPTION
If a new attenuation model is added, the C++ ray tracer needs to be recompiled. Otherwise, one gets a cryptic error message that a certain attenuation model is not present. I added this hint to the error message. 
