### PR TITLE
Fix indices in simulation.py

### DIFF
--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -31,7 +31,6 @@ import NuRadioReco.framework.electric_field
 import NuRadioReco.framework.particle
 import NuRadioReco.framework.event
 from NuRadioReco.detector import antennapattern
-from NuRadioReco.utilities import geometryUtilities as geo_utl
 from NuRadioReco.framework.parameters import channelParameters as chp
 from NuRadioReco.framework.parameters import electricFieldParameters as efp
 from NuRadioReco.framework.parameters import showerParameters as shp
@@ -49,6 +48,7 @@ from NuRadioMC.utilities.Veff import remove_duplicate_triggers
 
 STATUS = 31
 
+
 # logging.basicConfig(format='%(asctime)s %(levelname)s:%(name)s:%(message)s')
 
 
@@ -63,6 +63,8 @@ logging.setLoggerClass(NuRadioMCLogger)
 logging.addLevelName(STATUS, 'STATUS')
 logger = logging.getLogger("NuRadioMC")
 assert isinstance(logger, NuRadioMCLogger)
+
+
 # formatter = logging.Formatter('%(asctime)s %(levelname)s:%(name)s:%(message)s')
 # ch = logging.StreamHandler()
 # ch.setFormatter(formatter)
@@ -170,21 +172,21 @@ class simulation():
         logger.status('reading default config from {}'.format(config_file_default))
         with open(config_file_default, 'r') as ymlfile:
             self._cfg = yaml.load(ymlfile, Loader=yaml.FullLoader)
-        if(config_file is not None):
+        if (config_file is not None):
             logger.status('reading local config overrides from {}'.format(config_file))
             with open(config_file, 'r') as ymlfile:
                 local_config = yaml.load(ymlfile, Loader=yaml.FullLoader)
                 new_cfg = merge_config(local_config, self._cfg)
                 self._cfg = new_cfg
 
-        if(self._cfg['seed'] is None):
+        if (self._cfg['seed'] is None):
             # the config seeding None means a random seed. To have the simulation be reproducible, we generate a new
             # random seed once and save this seed to the config setting. If the simulation is rerun, we can get
             # the same random sequence.
             self._cfg['seed'] = np.random.randint(0, 2 ** 32 - 1)
 
         self._outputfilename = outputfilename
-        if(os.path.exists(self._outputfilename)):
+        if (os.path.exists(self._outputfilename)):
             msg = f"hdf5 output file {self._outputfilename} already exists"
             if file_overwrite == False:
                 logger.error(msg)
@@ -220,14 +222,16 @@ class simulation():
         # read in detector positions
         logger.status("Detectorfile {}".format(os.path.abspath(self._detectorfile)))
         self._det = None
-        if(default_detector_station is not None):
+        if (default_detector_station is not None):
             logger.warning(
                 'Deprecation warning: Passing the default detector station is deprecated. Default stations and default'
                 'channel should be specified in the detector description directly.'
             )
-            logger.status(f"Default detector station provided (station {default_detector_station}) -> Using generic detector")
-            self._det = gdetector.GenericDetector(json_filename=self._detectorfile, default_station=default_detector_station,
-                                                 default_channel=default_detector_channel, antenna_by_depth=False)
+            logger.status(
+                f"Default detector station provided (station {default_detector_station}) -> Using generic detector")
+            self._det = gdetector.GenericDetector(json_filename=self._detectorfile,
+                                                  default_station=default_detector_station,
+                                                  default_channel=default_detector_channel, antenna_by_depth=False)
         else:
             self._det = detector.Detector(json_filename=self._detectorfile, antenna_by_depth=False)
 
@@ -236,12 +240,13 @@ class simulation():
         self._station_ids = self._det.get_station_ids()
         self._event_ids_counter = {}
         for station_id in self._station_ids:
-            self._event_ids_counter[station_id] = -1  # we initialize with -1 because we increment the counter before we use it the first time
+            self._event_ids_counter[
+                station_id] = -1  # we initialize with -1 because we increment the counter before we use it the first time
 
         # print noise information
         logger.status("running with noise {}".format(bool(self._cfg['noise'])))
         logger.status("setting signal to zero {}".format(bool(self._cfg['signal']['zerosignal'])))
-        if(bool(self._cfg['propagation']['focusing'])):
+        if (bool(self._cfg['propagation']['focusing'])):
             logger.status("simulating signal amplification due to focusing of ray paths in the firn.")
 
         # read sampling rate from config (this sampling rate will be used internally)
@@ -264,7 +269,7 @@ class simulation():
                 self._generator_info[enum_entry] = self._fin_attrs[enum_entry.name]
 
         # check if the input file contains events, if not save empty output file (for book keeping) and terminate simulation
-        if(len(self._fin['xx']) == 0):
+        if (len(self._fin['xx']) == 0):
             logger.status(f"input file {self._inputfilename} is empty")
             return
 
@@ -282,8 +287,9 @@ class simulation():
             self._evt = NuRadioReco.framework.event.Event(0, self._primary_index)
 
             self._sampling_rate_detector = self._det.get_sampling_frequency(self._station_id, 0)
-#                 logger.warning('internal sampling rate is {:.3g}GHz, final detector sampling rate is {:.3g}GHz'.format(self.get_sampling_rate(), self._sampling_rate_detector))
-            self._n_samples = self._det.get_number_of_samples(self._station_id, 0) / self._sampling_rate_detector / self._dt
+            #                 logger.warning('internal sampling rate is {:.3g}GHz, final detector sampling rate is {:.3g}GHz'.format(self.get_sampling_rate(), self._sampling_rate_detector))
+            self._n_samples = self._det.get_number_of_samples(self._station_id,
+                                                              0) / self._sampling_rate_detector / self._dt
             self._n_samples = int(np.ceil(self._n_samples / 2.) * 2)  # round to nearest even integer
             self._ff = np.fft.rfftfreq(self._n_samples, self._dt)
             self._tt = np.arange(0, self._n_samples * self._dt, self._dt)
@@ -291,7 +297,10 @@ class simulation():
             self._create_sim_station()
             sta = self._det.get_station(self._station_id)
             for channel_id in self._det.get_channel_ids(self._station_id):
-                electric_field = NuRadioReco.framework.electric_field.ElectricField([channel_id], self._det.get_relative_position(self._sim_station.get_id(), channel_id))
+                electric_field = NuRadioReco.framework.electric_field.ElectricField([channel_id],
+                                                                                    self._det.get_relative_position(
+                                                                                        self._sim_station.get_id(),
+                                                                                        channel_id))
                 trace = np.zeros_like(self._tt)
                 trace[self._n_samples // 2] = 100 * units.V  # set a signal that will satisfy any high/low trigger
                 trace[self._n_samples // 2 + 1] = -100 * units.V
@@ -320,7 +329,8 @@ class simulation():
                 self._amplification_per_channel[self._station_id][channel_id] = np.abs(filt).max()
                 bandwidth = np.trapz(np.abs(filt) ** 2, ff)
                 self._bandwidth_per_channel[self._station_id][channel_id] = bandwidth
-                logger.status(f"bandwidth of station {self._station_id} channel {channel_id} is {bandwidth/units.MHz:.1f}MHz")
+                logger.status(
+                    f"bandwidth of station {self._station_id} channel {channel_id} is {bandwidth / units.MHz:.1f}MHz")
 
         ################################
 
@@ -328,10 +338,11 @@ class simulation():
         amplification = next(iter(next(iter(self._amplification_per_channel.values())).values()))
         noise_temp = self._cfg['trigger']['noise_temperature']
         Vrms = self._cfg['trigger']['Vrms']
-        if(noise_temp is not None and Vrms is not None):
-            raise AttributeError(f"Specifying noise temperature (set to {noise_temp}) and Vrms (set to {Vrms} is not allowed.")
-        if(noise_temp is not None):
-            if(noise_temp == "detector"):
+        if (noise_temp is not None and Vrms is not None):
+            raise AttributeError(
+                f"Specifying noise temperature (set to {noise_temp}) and Vrms (set to {Vrms} is not allowed.")
+        if (noise_temp is not None):
+            if (noise_temp == "detector"):
                 self._noise_temp = None  # the noise temperature is defined in the detector description
             else:
                 self._noise_temp = float(noise_temp)
@@ -341,7 +352,7 @@ class simulation():
                 self._Vrms_per_channel[station_id] = {}
                 self._noiseless_channels[station_id] = []
                 for channel_id in self._bandwidth_per_channel[station_id]:
-                    if(self._noise_temp is None):
+                    if (self._noise_temp is None):
                         noise_temp_channel = self._det.get_noise_temperature(station_id, channel_id)
                     else:
                         noise_temp_channel = self._noise_temp
@@ -349,11 +360,15 @@ class simulation():
                         self._noiseless_channels[station_id].append(channel_id)
 
                     self._Vrms_per_channel[station_id][channel_id] = (noise_temp_channel * 50 * constants.k *
-                           self._bandwidth_per_channel[station_id][channel_id] / units.Hz) ** 0.5  # from elog:1566 and https://en.wikipedia.org/wiki/Johnson%E2%80%93Nyquist_noise (last Eq. in "noise voltage and power" section
-                    logger.status(f'station {station_id} channel {channel_id} noise temperature = {noise_temp_channel}, bandwidth = {self._bandwidth_per_channel[station_id][channel_id]/ units.MHz:.2f} MHz -> Vrms = {self._Vrms_per_channel[station_id][channel_id]/ units.V / units.micro:.2f} muV')
+                                                                      self._bandwidth_per_channel[station_id][
+                                                                          channel_id] / units.Hz) ** 0.5  # from elog:1566 and https://en.wikipedia.org/wiki/Johnson%E2%80%93Nyquist_noise (last Eq. in "noise voltage and power" section
+                    logger.status(
+                        f'station {station_id} channel {channel_id} noise temperature = {noise_temp_channel}, bandwidth = {self._bandwidth_per_channel[station_id][channel_id] / units.MHz:.2f} MHz -> Vrms = {self._Vrms_per_channel[station_id][channel_id] / units.V / units.micro:.2f} muV')
             self._Vrms = next(iter(next(iter(self._Vrms_per_channel.values())).values()))
-            logger.status('(if same bandwidth for all stations/channels is assumed:) noise temperature = {}, bandwidth = {:.2f} MHz -> Vrms = {:.2f} muV'.format(self._noise_temp, self._bandwidth / units.MHz, self._Vrms / units.V / units.micro))
-        elif(Vrms is not None):
+            logger.status(
+                '(if same bandwidth for all stations/channels is assumed:) noise temperature = {}, bandwidth = {:.2f} MHz -> Vrms = {:.2f} muV'.format(
+                    self._noise_temp, self._bandwidth / units.MHz, self._Vrms / units.V / units.micro))
+        elif (Vrms is not None):
             self._Vrms = float(Vrms) * units.V
             self._noise_temp = None
         else:
@@ -363,10 +378,13 @@ class simulation():
         for station_id in self._bandwidth_per_channel:
             self._Vrms_efield_per_channel[station_id] = {}
             for channel_id in self._bandwidth_per_channel[station_id]:
-                self._Vrms_efield_per_channel[station_id][channel_id] = self._Vrms_per_channel[station_id][channel_id] / self._amplification_per_channel[station_id][channel_id] / units.m
+                self._Vrms_efield_per_channel[station_id][channel_id] = self._Vrms_per_channel[station_id][channel_id] / \
+                                                                        self._amplification_per_channel[station_id][
+                                                                            channel_id] / units.m
         self._Vrms_efield = next(iter(next(iter(self._Vrms_efield_per_channel.values())).values()))
         tmp_cut = float(self._cfg['speedup']['min_efield_amplitude'])
-        logger.status(f"final Vrms {self._Vrms/units.V:.2g}V corresponds to an efield of {self._Vrms_efield/units.V/units.m/units.micro:.2g} muV/m for a VEL = 1m (amplification factor of system is {amplification:.1f}).\n -> all signals with less then {tmp_cut:.1f} x Vrms_efield = {tmp_cut * self._Vrms_efield/units.m/units.V/units.micro:.2g}muV/m will be skipped")
+        logger.status(
+            f"final Vrms {self._Vrms / units.V:.2g}V corresponds to an efield of {self._Vrms_efield / units.V / units.m / units.micro:.2g} muV/m for a VEL = 1m (amplification factor of system is {amplification:.1f}).\n -> all signals with less then {tmp_cut:.1f} x Vrms_efield = {tmp_cut * self._Vrms_efield / units.m / units.V / units.micro:.2g}muV/m will be skipped")
 
         self._distance_cut_polynomial = None
         if self._cfg['speedup']['distance_cut']:
@@ -374,7 +392,7 @@ class simulation():
             self.__distance_cut_polynomial = np.polynomial.polynomial.Polynomial(coef)
 
             def get_distance_cut(shower_energy):
-                if(shower_energy <= 0):
+                if (shower_energy <= 0):
                     return 100 * units.m
                 return max(100 * units.m, 10 ** self.__distance_cut_polynomial(np.log10(shower_energy)))
 
@@ -384,7 +402,7 @@ class simulation():
         """
         run the NuRadioMC simulation
         """
-        if(len(self._fin['xx']) == 0):
+        if (len(self._fin['xx']) == 0):
             logger.status(f"writing empty hdf5 output file")
             self._write_output_file(empty=True)
             logger.status(f"terminating simulation")
@@ -403,7 +421,7 @@ class simulation():
         channelGenericNoiseAdder.begin(seed=self._cfg['seed'])
         channelResampler = NuRadioReco.modules.channelResampler.channelResampler()
         electricFieldResampler = NuRadioReco.modules.electricFieldResampler.electricFieldResampler()
-        if(self._outputfilenameNuRadioReco is not None):
+        if (self._outputfilenameNuRadioReco is not None):
             self._eventWriter.begin(self._outputfilenameNuRadioReco, log_level=self._log_level)
         unique_event_group_ids = np.unique(self._fin['event_group_ids'])
         self._n_showers = len(self._fin['event_group_ids'])
@@ -419,7 +437,7 @@ class simulation():
             detector=self._det
         )
         for shower_index, shower_id in enumerate(self._shower_ids):
-            self._shower_index_array[shower_id] = shower_index        
+            self._shower_index_array[shower_id] = shower_index
         self._create_meta_output_datastructures()
 
         # check if the same detector was simulated before (then we can save the ray tracing part)
@@ -450,11 +468,12 @@ class simulation():
         # loop over event groups
         for i_event_group_id, event_group_id in enumerate(unique_event_group_ids):
             logger.debug(f"simulating event group id {event_group_id}")
-            if(self._event_group_list is not None and event_group_id not in self._event_group_list):
-                logger.debug(f"skipping event group {event_group_id} because it is not in the event group list provided to the __init__ function")
+            if (self._event_group_list is not None and event_group_id not in self._event_group_list):
+                logger.debug(
+                    f"skipping event group {event_group_id} because it is not in the event group list provided to the __init__ function")
                 continue
             event_indices = np.atleast_1d(np.squeeze(np.argwhere(self._fin['event_group_ids'] == event_group_id)))
-            
+
             # the weight calculation is independent of the station, so we do this calculation only once
             # the weight also depends just on the "mother" particle, i.e. the incident neutrino which determines
             # the probability of arriving at our simulation volume. All subsequent showers have the same weight. So
@@ -464,24 +483,28 @@ class simulation():
             self._primary_index = event_indices[0]
             # determine if a particle (neutrinos, or a secondary interaction of a neutrino, or surface muons) is simulated
             particle_mode = "simulation_mode" not in self._fin_attrs or self._fin_attrs['simulation_mode'] != "emitter"
-            self._mout['weights'][event_indices] = np.ones(len(event_indices))  # for a pulser simulation, every event has the same weight
+            self._mout['weights'][event_indices] = np.ones(
+                len(event_indices))  # for a pulser simulation, every event has the same weight
             if particle_mode:
-                self._read_input_particle_properties(self._primary_index)  # this sets the self.input_particle for self._primary_index
+                self._read_input_particle_properties(
+                    self._primary_index)  # this sets the self.input_particle for self._primary_index
                 # calculate the weight for the primary particle
                 self.primary = self.input_particle
-                if(self._cfg['weights']['weight_mode'] == "existing"):
-                    if("weights" in self._fin):
+                if (self._cfg['weights']['weight_mode'] == "existing"):
+                    if ("weights" in self._fin):
                         self._mout['weights'] = self._fin["weights"]
                     else:
-                        logger.error("config file specifies to use weights from the input hdf5 file but the input file does not contain this information.")
-                elif(self._cfg['weights']['weight_mode'] is None):
+                        logger.error(
+                            "config file specifies to use weights from the input hdf5 file but the input file does not contain this information.")
+                elif (self._cfg['weights']['weight_mode'] is None):
                     self.primary[simp.weight] = 1.
                 else:
                     self.primary[simp.weight] = get_weight(self.primary[simp.zenith],
                                                            self.primary[simp.energy],
                                                            self.primary[simp.flavor],
                                                            mode=self._cfg['weights']['weight_mode'],
-                                                           cross_section_type=self._cfg['weights']['cross_section_type'],
+                                                           cross_section_type=self._cfg['weights'][
+                                                               'cross_section_type'],
                                                            vertex_position=self.primary[simp.vertex],
                                                            phi_nu=self.primary[simp.azimuth])
                 # all entries for the event for this primary get the calculated primary's weight
@@ -490,8 +513,9 @@ class simulation():
             weightTime += time.time() - t1
             # skip all events where neutrino weights is zero, i.e., do not
             # simulate neutrino that propagate through the Earth
-            if(self._mout['weights'][self._primary_index] < self._cfg['speedup']['minimum_weight_cut']):
-                logger.debug("neutrino weight is smaller than {}, skipping event".format(self._cfg['speedup']['minimum_weight_cut']))
+            if (self._mout['weights'][self._primary_index] < self._cfg['speedup']['minimum_weight_cut']):
+                logger.debug("neutrino weight is smaller than {}, skipping event".format(
+                    self._cfg['speedup']['minimum_weight_cut']))
                 continue
 
             # these quantities get computed to apply the distance cut as a function of shower energies
@@ -516,10 +540,13 @@ class simulation():
                 if self._cfg['speedup']['distance_cut']:
                     # perform a quick cut to reject event group completely if no shower is close enough to the station
                     t_tmp = time.time()
-                    vertex_distances_to_station = np.linalg.norm(vertex_positions - self._station_barycenter[iSt], axis=1)
-                    distance_cut = self._get_distance_cut(np.sum(shower_energies)) + 100 * units.m  # 100m safety margin is added to account for extent of station around bary center.
+                    vertex_distances_to_station = np.linalg.norm(vertex_positions - self._station_barycenter[iSt],
+                                                                 axis=1)
+                    distance_cut = self._get_distance_cut(np.sum(
+                        shower_energies)) + 100 * units.m  # 100m safety margin is added to account for extent of station around bary center.
                     if vertex_distances_to_station.min() > distance_cut:
-                        logger.debug(f"skipping station {self._station_id} because minimal distance {vertex_distances_to_station.min()/units.km:.1f}km > {distance_cut/units.km:.1f}km (shower energy = {shower_energies.max():.2g}eV) bary center of station {self._station_barycenter[iSt]}")
+                        logger.debug(
+                            f"skipping station {self._station_id} because minimal distance {vertex_distances_to_station.min() / units.km:.1f}km > {distance_cut / units.km:.1f}km (shower energy = {shower_energies.max():.2g}eV) bary center of station {self._station_barycenter[iSt]}")
                         distance_cut_time += time.time() - t_tmp
                         iCounter += len(shower_energies)
                         continue
@@ -527,15 +554,17 @@ class simulation():
 
                 candidate_station = False
                 self._sampling_rate_detector = self._det.get_sampling_frequency(self._station_id, 0)
-#                 logger.warning('internal sampling rate is {:.3g}GHz, final detector sampling rate is {:.3g}GHz'.format(self.get_sampling_rate(), self._sampling_rate_detector))
-                self._n_samples = self._det.get_number_of_samples(self._station_id, 0) / self._sampling_rate_detector / self._dt
+                #                 logger.warning('internal sampling rate is {:.3g}GHz, final detector sampling rate is {:.3g}GHz'.format(self.get_sampling_rate(), self._sampling_rate_detector))
+                self._n_samples = self._det.get_number_of_samples(self._station_id,
+                                                                  0) / self._sampling_rate_detector / self._dt
                 self._n_samples = int(np.ceil(self._n_samples / 2.) * 2)  # round to nearest even integer
                 self._ff = np.fft.rfftfreq(self._n_samples, self._dt)
                 self._tt = np.arange(0, self._n_samples * self._dt, self._dt)
 
                 ray_tracing_performed = False
-                if('station_{:d}'.format(self._station_id) in self._fin_stations):
-                    ray_tracing_performed = (self._raytracer.get_output_parameters()[0]['name'] in self._fin_stations['station_{:d}'.format(self._station_id)]) and (self._was_pre_simulated)
+                if ('station_{:d}'.format(self._station_id) in self._fin_stations):
+                    ray_tracing_performed = (self._raytracer.get_output_parameters()[0]['name'] in self._fin_stations[
+                        'station_{:d}'.format(self._station_id)]) and (self._was_pre_simulated)
                 self._evt_tmp = NuRadioReco.framework.event.Event(0, 0)
 
                 if particle_mode:
@@ -545,12 +574,13 @@ class simulation():
                 self._create_sim_station()
                 # loop over all showers in event group
                 # create output data structure for this channel
-                sg = self._create_station_output_structure(len(event_indices), self._det.get_number_of_channels(self._station_id)) #n_shower, n_antennas
+                sg = self._create_station_output_structure(len(event_indices), self._det.get_number_of_channels(
+                    self._station_id))  # n_shower, n_antennas
                 for iSh, self._shower_index in enumerate(event_indices):
                     sg['shower_id'][iSh] = self._shower_ids[self._shower_index]
                     iCounter += 1
-#                     if(iCounter % max(1, int(n_shower_station / 100.)) == 0):
-                    if((time.time() - t_last_update) > 60):
+                    #                     if(iCounter % max(1, int(n_shower_station / 100.)) == 0):
+                    if ((time.time() - t_last_update) > 60):
                         t_last_update = time.time()
                         eta = pretty_time_delta((time.time() - t_start) * (n_shower_station - iCounter) / iCounter)
                         total_time_sum = input_time + rayTracingTime + detSimTime + outputTime + weightTime + distance_cut_time  # askaryan time is part of the ray tracing time, so it is not counted here.
@@ -569,27 +599,32 @@ class simulation():
                                     100. * (rayTracingTime - askaryan_time) / total_time,
                                     100. * askaryan_time / total_time,
                                     100. * detSimTime / total_time,
-                                    100.*input_time / total_time,
+                                    100. * input_time / total_time,
                                     100. * weightTime / total_time,
                                     100 * distance_cut_time / total_time,
                                     100 * (total_time - total_time_sum) / total_time))
 
                     self._read_input_shower_properties()
                     if particle_mode:
-                        logger.debug(f"simulating shower {self._shower_index}: {self._fin['shower_type'][self._shower_index]} with E = {self._fin['shower_energies'][self._shower_index]/units.eV:.2g}eV")
+                        logger.debug(
+                            f"simulating shower {self._shower_index}: {self._fin['shower_type'][self._shower_index]} with E = {self._fin['shower_energies'][self._shower_index] / units.eV:.2g}eV")
                     x1 = self._shower_vertex  # the interaction point
 
                     if self._cfg['speedup']['distance_cut']:
                         t_tmp = time.time()
                         # calculate the sum of shower energies for all showers within self._cfg['speedup']['distance_cut_sum_length']
-                        mask_shower_sum = np.abs(vertex_distances - vertex_distances[iSh]) < self._cfg['speedup']['distance_cut_sum_length']
+                        mask_shower_sum = np.abs(vertex_distances - vertex_distances[iSh]) < self._cfg['speedup'][
+                            'distance_cut_sum_length']
                         shower_energy_sum = np.sum(shower_energies[mask_shower_sum])
                         # quick speedup cut using barycenter of station as position
                         distance_to_station = np.linalg.norm(x1 - self._station_barycenter[iSt])
-                        distance_cut = self._get_distance_cut(shower_energy_sum) + 100 * units.m  # 100m safety margin is added to account for extent of station around bary center.
-                        logger.debug(f"calculating distance cut. Current event has energy {self._fin['shower_energies'][self._shower_index]:.4g}, it is event number {iSh} and {np.sum(mask_shower_sum)} are within {self._cfg['speedup']['distance_cut_sum_length']/units.m:.1f}m -> {shower_energy_sum:.4g}")
+                        distance_cut = self._get_distance_cut(
+                            shower_energy_sum) + 100 * units.m  # 100m safety margin is added to account for extent of station around bary center.
+                        logger.debug(
+                            f"calculating distance cut. Current event has energy {self._fin['shower_energies'][self._shower_index]:.4g}, it is event number {iSh} and {np.sum(mask_shower_sum)} are within {self._cfg['speedup']['distance_cut_sum_length'] / units.m:.1f}m -> {shower_energy_sum:.4g}")
                         if distance_to_station > distance_cut:
-                            logger.debug(f"skipping station {self._station_id} because distance {distance_to_station/units.km:.1f}km > {distance_cut/units.km:.1f}km (shower energy = {self._fin['shower_energies'][self._shower_index]:.2g}eV) between vertex {x1} and bary center of station {self._station_barycenter[iSt]}")
+                            logger.debug(
+                                f"skipping station {self._station_id} because distance {distance_to_station / units.km:.1f}km > {distance_cut / units.km:.1f}km (shower energy = {self._fin['shower_energies'][self._shower_index]:.2g}eV) between vertex {x1} and bary center of station {self._station_barycenter[iSt]}")
                             distance_cut_time += time.time() - t_tmp
                             continue
                         distance_cut_time += time.time() - t_tmp
@@ -597,15 +632,16 @@ class simulation():
                     # skip vertices not in fiducial volume. This is required because 'mother' events are added to the event list
                     # if daughters (e.g. tau decay) have their vertex in the fiducial volume
                     if not self._is_in_fiducial_volume():
-                        logger.debug(f"event is not in fiducial volume, skipping simulation {self._fin['xx'][self._shower_index]}, {self._fin['yy'][self._shower_index]}, {self._fin['zz'][self._shower_index]}")
+                        logger.debug(
+                            f"event is not in fiducial volume, skipping simulation {self._fin['xx'][self._shower_index]}, {self._fin['yy'][self._shower_index]}, {self._fin['zz'][self._shower_index]}")
                         continue
 
                     # for special cases where only EM or HAD showers are simulated, skip all events that don't fulfill this criterion
-                    if(self._cfg['signal']['shower_type'] == "em"):
-                        if(self._fin['shower_type'][self._shower_index] != "em"):
+                    if (self._cfg['signal']['shower_type'] == "em"):
+                        if (self._fin['shower_type'][self._shower_index] != "em"):
                             continue
-                    if(self._cfg['signal']['shower_type'] == "had"):
-                        if(self._fin['shower_type'][self._shower_index] != "had"):
+                    if (self._cfg['signal']['shower_type'] == "had"):
+                        if (self._fin['shower_type'][self._shower_index] != "had"):
                             continue
 
                     if particle_mode:
@@ -620,7 +656,8 @@ class simulation():
                     # i.e., opposite to the direction of propagation. We need the propagation direction here,
                     # so we multiply the shower axis with '-1'
                     if 'zeniths' in self._fin:
-                        self._shower_axis = -1 * hp.spherical_to_cartesian(self._fin['zeniths'][self._shower_index], self._fin['azimuths'][self._shower_index])
+                        self._shower_axis = -1 * hp.spherical_to_cartesian(self._fin['zeniths'][self._shower_index],
+                                                                           self._fin['azimuths'][self._shower_index])
                     else:
                         self._shower_axis = np.array([0, 0, 1])
 
@@ -630,10 +667,12 @@ class simulation():
 
                     # first step: perform raytracing to see if solution exists
                     t2 = time.time()
-#                     input_time += (time.time() - t1)
+                    #                     input_time += (time.time() - t1)
 
                     for channel_id in self._det.get_channel_ids(self._station_id):
-                        x2 = self._det.get_relative_position(self._station_id, channel_id) + self._det.get_absolute_position(self._station_id)
+                        x2 = self._det.get_relative_position(self._station_id,
+                                                             channel_id) + self._det.get_absolute_position(
+                            self._station_id)
                         logger.debug(f"simulating channel {channel_id} at {x2}")
 
                         if self._cfg['speedup']['distance_cut']:
@@ -643,7 +682,8 @@ class simulation():
 
                             if distance > distance_cut:
                                 logger.debug('A distance speed up cut has been applied')
-                                logger.debug('Shower energy: {:.2e} eV'.format(self._fin['shower_energies'][self._shower_index] / units.eV))
+                                logger.debug('Shower energy: {:.2e} eV'.format(
+                                    self._fin['shower_energies'][self._shower_index] / units.eV))
                                 logger.debug('Distance cut: {:.2f} m'.format(distance_cut / units.m))
                                 logger.debug('Distance to vertex: {:.2f} m'.format(distance / units.m))
                                 distance_cut_time += time.time() - t_tmp
@@ -652,7 +692,8 @@ class simulation():
 
                         self._raytracer.set_start_and_end_point(x1, x2)
                         self._raytracer.use_optional_function('set_shower_axis', self._shower_axis)
-                        if(pre_simulated and ray_tracing_performed and not self._cfg['speedup']['redo_raytracing']):  # check if raytracing was already performed
+                        if (pre_simulated and ray_tracing_performed and not self._cfg['speedup'][
+                            'redo_raytracing']):  # check if raytracing was already performed
                             if self._cfg['propagation']['module'] == 'radiopropa':
                                 logger.error('Presimulation can not be used with the radiopropa ray tracer module')
                                 raise Exception('Presimulation can not be used with the radiopropa ray tracer module')
@@ -660,14 +701,16 @@ class simulation():
 
                             ray_tracing_solution = {}
                             for output_parameter in self._raytracer.get_output_parameters():
-                                ray_tracing_solution[output_parameter['name']] = sg_pre[output_parameter['name']][self._shower_index, channel_id]
+                                ray_tracing_solution[output_parameter['name']] = sg_pre[output_parameter['name']][
+                                    self._shower_index, channel_id]
                             self._raytracer.set_solution(ray_tracing_solution)
                         else:
                             self._raytracer.find_solutions()
 
-                        if(not self._raytracer.has_solution()):
-                            logger.debug("event {} and station {}, channel {} does not have any ray tracing solution ({} to {})".format(
-                                self._event_group_id, self._station_id, channel_id, x1, x2))
+                        if (not self._raytracer.has_solution()):
+                            logger.debug(
+                                "event {} and station {}, channel {} does not have any ray tracing solution ({} to {})".format(
+                                    self._event_group_id, self._station_id, channel_id, x1, x2))
                             continue
                         delta_Cs = []
                         viewing_angles = []
@@ -682,11 +725,12 @@ class simulation():
                             viewing_angles.append(viewing_angle)
                             delta_C = (viewing_angle - cherenkov_angle)
                             logger.debug('solution {} {}: viewing angle {:.1f} = delta_C = {:.1f}'.format(
-                                iS, propagation.solution_types[self._raytracer.get_solution_type(iS)], viewing_angle / units.deg, (viewing_angle - cherenkov_angle) / units.deg))
+                                iS, propagation.solution_types[self._raytracer.get_solution_type(iS)],
+                                viewing_angle / units.deg, (viewing_angle - cherenkov_angle) / units.deg))
                             delta_Cs.append(delta_C)
 
                         # discard event if delta_C (angle off cherenkov cone) is too large
-                        if(min(np.abs(delta_Cs)) > self._cfg['speedup']['delta_C_cut']):
+                        if (min(np.abs(delta_Cs)) > self._cfg['speedup']['delta_C_cut']):
                             logger.debug('delta_C too large, event unlikely to be observed, skipping event')
                             continue
 
@@ -694,10 +738,12 @@ class simulation():
                         for iS in range(n):  # loop through all ray tracing solution
                             # skip individual channels where the viewing angle difference is too large
                             # discard event if delta_C (angle off cherenkov cone) is too large
-                            if(np.abs(delta_Cs[iS]) > self._cfg['speedup']['delta_C_cut']):
-                                logger.debug('delta_C too large, ray tracing solution unlikely to be observed, skipping event')
+                            if (np.abs(delta_Cs[iS]) > self._cfg['speedup']['delta_C_cut']):
+                                logger.debug(
+                                    'delta_C too large, ray tracing solution unlikely to be observed, skipping event')
                                 continue
-                            if(pre_simulated and ray_tracing_performed and not self._cfg['speedup']['redo_raytracing']):
+                            if (pre_simulated and ray_tracing_performed and not self._cfg['speedup'][
+                                'redo_raytracing']):
                                 sg_pre = self._fin_stations["station_{:d}".format(self._station_id)]
                                 R = sg_pre['travel_distances'][self._shower_index, channel_id, iS]
                                 T = sg_pre['travel_times'][self._shower_index, channel_id, iS]
@@ -717,75 +763,98 @@ class simulation():
                             # get neutrino pulse from Askaryan module
                             t_ask = time.time()
 
-                            if("simulation_mode" not in self._fin_attrs or self._fin_attrs['simulation_mode'] == "neutrino"):
+                            if ("simulation_mode" not in self._fin_attrs or self._fin_attrs[
+                                'simulation_mode'] == "neutrino"):
                                 # first consider in-ice showers
                                 kwargs = {}
                                 # if the input file specifies a specific shower realization, use that realization
-                                if(self._cfg['signal']['model'] in ["ARZ2019", "ARZ2020"] and "shower_realization_ARZ" in self._fin):
+                                if (self._cfg['signal']['model'] in ["ARZ2019",
+                                                                     "ARZ2020"] and "shower_realization_ARZ" in self._fin):
                                     kwargs['iN'] = self._fin['shower_realization_ARZ'][self._shower_index]
                                     logger.debug(f"reusing shower {kwargs['iN']} ARZ shower library")
-                                elif(self._cfg['signal']['model'] == "Alvarez2009" and "shower_realization_Alvarez2009" in self._fin):
+                                elif (self._cfg['signal'][
+                                          'model'] == "Alvarez2009" and "shower_realization_Alvarez2009" in self._fin):
                                     kwargs['k_L'] = self._fin['shower_realization_Alvarez2009'][self._shower_index]
-                                    logger.debug(f"reusing k_L parameter of Alvarez2009 model of k_L = {kwargs['k_L']:.4g}")
+                                    logger.debug(
+                                        f"reusing k_L parameter of Alvarez2009 model of k_L = {kwargs['k_L']:.4g}")
                                 else:
                                     # check if the shower was already simulated (e.g. for a different channel or ray tracing solution)
-                                    if(self._cfg['signal']['model'] in ["ARZ2019", "ARZ2020"]):
-                                        if(self._sim_shower.has_parameter(shp.charge_excess_profile_id)):
-                                            kwargs = {'iN': self._sim_shower.get_parameter(shp.charge_excess_profile_id)}
-                                    if(self._cfg['signal']['model'] == "Alvarez2009"):
-                                        if(self._sim_shower.has_parameter(shp.k_L)):
+                                    if (self._cfg['signal']['model'] in ["ARZ2019", "ARZ2020"]):
+                                        if (self._sim_shower.has_parameter(shp.charge_excess_profile_id)):
+                                            kwargs = {
+                                                'iN': self._sim_shower.get_parameter(shp.charge_excess_profile_id)}
+                                    if (self._cfg['signal']['model'] == "Alvarez2009"):
+                                        if (self._sim_shower.has_parameter(shp.k_L)):
                                             kwargs = {'k_L': self._sim_shower.get_parameter(shp.k_L)}
-                                            logger.debug(f"reusing k_L parameter of Alvarez2009 model of k_L = {kwargs['k_L']:.4g}")
+                                            logger.debug(
+                                                f"reusing k_L parameter of Alvarez2009 model of k_L = {kwargs['k_L']:.4g}")
 
-                                spectrum, additional_output = askaryan.get_frequency_spectrum(self._fin['shower_energies'][self._shower_index], viewing_angles[iS],
-                                                self._n_samples, self._dt, self._fin['shower_type'][self._shower_index], n_index, R,
-                                                self._cfg['signal']['model'], seed=self._cfg['seed'], full_output=True, **kwargs)
+                                spectrum, additional_output = askaryan.get_frequency_spectrum(
+                                    self._fin['shower_energies'][self._shower_index], viewing_angles[iS],
+                                    self._n_samples, self._dt, self._fin['shower_type'][self._shower_index], n_index, R,
+                                    self._cfg['signal']['model'], seed=self._cfg['seed'], full_output=True, **kwargs)
                                 # save shower realization to SimShower and hdf5 file
-                                if(self._cfg['signal']['model'] in ["ARZ2019", "ARZ2020"]):
-                                    if('shower_realization_ARZ' not in self._mout):
+                                if (self._cfg['signal']['model'] in ["ARZ2019", "ARZ2020"]):
+                                    if ('shower_realization_ARZ' not in self._mout):
                                         self._mout['shower_realization_ARZ'] = np.zeros(self._n_showers)
-                                    if(not self._sim_shower.has_parameter(shp.charge_excess_profile_id)):
-                                        self._sim_shower.set_parameter(shp.charge_excess_profile_id, additional_output['iN'])
-                                        self._mout['shower_realization_ARZ'][self._shower_index] = additional_output['iN']
-                                        logger.debug(f"setting shower profile for ARZ shower library to i = {additional_output['iN']}")
-                                if(self._cfg['signal']['model'] == "Alvarez2009"):
-                                    if('shower_realization_Alvarez2009' not in self._mout):
+                                    if (not self._sim_shower.has_parameter(shp.charge_excess_profile_id)):
+                                        self._sim_shower.set_parameter(shp.charge_excess_profile_id,
+                                                                       additional_output['iN'])
+                                        self._mout['shower_realization_ARZ'][self._shower_index] = additional_output[
+                                            'iN']
+                                        logger.debug(
+                                            f"setting shower profile for ARZ shower library to i = {additional_output['iN']}")
+                                if (self._cfg['signal']['model'] == "Alvarez2009"):
+                                    if ('shower_realization_Alvarez2009' not in self._mout):
                                         self._mout['shower_realization_Alvarez2009'] = np.zeros(self._n_showers)
-                                    if(not self._sim_shower.has_parameter(shp.k_L)):
+                                    if (not self._sim_shower.has_parameter(shp.k_L)):
                                         self._sim_shower.set_parameter(shp.k_L, additional_output['k_L'])
-                                        self._mout['shower_realization_Alvarez2009'][self._shower_index] = additional_output['k_L']
-                                        logger.debug(f"setting k_L parameter of Alvarez2009 model to k_L = {additional_output['k_L']:.4g}")
+                                        self._mout['shower_realization_Alvarez2009'][self._shower_index] = \
+                                            additional_output['k_L']
+                                        logger.debug(
+                                            f"setting k_L parameter of Alvarez2009 model to k_L = {additional_output['k_L']:.4g}")
                                 askaryan_time += (time.time() - t_ask)
 
                                 polarization_direction_onsky = self._calculate_polarization_vector()
                                 cs_at_antenna = cstrans.cstrafo(*hp.cartesian_to_spherical(*receive_vector))
-                                polarization_direction_at_antenna = cs_at_antenna.transform_from_onsky_to_ground(polarization_direction_onsky)
-                                logger.debug('receive zenith {:.0f} azimuth {:.0f} polarization on sky {:.2f} {:.2f} {:.2f}, on ground @ antenna {:.2f} {:.2f} {:.2f}'.format(
-                                    zenith / units.deg, azimuth / units.deg, polarization_direction_onsky[0],
-                                    polarization_direction_onsky[1], polarization_direction_onsky[2],
-                                    *polarization_direction_at_antenna))
+                                polarization_direction_at_antenna = cs_at_antenna.transform_from_onsky_to_ground(
+                                    polarization_direction_onsky)
+                                logger.debug(
+                                    'receive zenith {:.0f} azimuth {:.0f} polarization on sky {:.2f} {:.2f} {:.2f}, on ground @ antenna {:.2f} {:.2f} {:.2f}'.format(
+                                        zenith / units.deg, azimuth / units.deg, polarization_direction_onsky[0],
+                                        polarization_direction_onsky[1], polarization_direction_onsky[2],
+                                        *polarization_direction_at_antenna))
                                 sg['polarization'][iSh, channel_id, iS] = polarization_direction_at_antenna
                                 eR, eTheta, ePhi = np.outer(polarization_direction_onsky, spectrum)
 
-                            elif(self._fin_attrs['simulation_mode'] == "emitter"):
+                            elif (self._fin_attrs['simulation_mode'] == "emitter"):
                                 # NuRadioMC also supports the simulation of emitters. In this case, the signal model specifies the electric field polarization
                                 amplitude = self._fin['emitter_amplitudes'][self._shower_index]
                                 # following two lines used only for few models( not for all)
-                                emitter_frequency = self._fin['emitter_frequency'][self._shower_index]  # the frequency of cw and tone_burst signal
-                                half_width = self._fin['emitter_half_width'][self._shower_index]  # defines width of square and tone_burst signals
+                                emitter_frequency = self._fin['emitter_frequency'][
+                                    self._shower_index]  # the frequency of cw and tone_burst signal
+                                half_width = self._fin['emitter_half_width'][
+                                    self._shower_index]  # defines width of square and tone_burst signals
                                 # get emitting antenna properties
                                 antenna_model = self._fin['emitter_antenna_type'][self._shower_index]
                                 antenna_pattern = self._antenna_pattern_provider.load_antenna_pattern(antenna_model)
-                                ori = [self._fin['emitter_orientation_theta'][self._shower_index], self._fin['emitter_orientation_phi'][self._shower_index],
-                                       self._fin['emitter_rotation_theta'][self._shower_index], self._fin['emitter_rotation_phi'][self._shower_index]]
+                                ori = [self._fin['emitter_orientation_theta'][self._shower_index],
+                                       self._fin['emitter_orientation_phi'][self._shower_index],
+                                       self._fin['emitter_rotation_theta'][self._shower_index],
+                                       self._fin['emitter_rotation_phi'][self._shower_index]]
 
                                 # source voltage given to the emitter
-                                voltage_spectrum_emitter = emitter.get_frequency_spectrum(amplitude, self._n_samples, self._dt,
-                                                                                          self._fin['emitter_model'][self._shower_index], half_width=half_width, emitter_frequency=emitter_frequency)
+                                voltage_spectrum_emitter = emitter.get_frequency_spectrum(amplitude, self._n_samples,
+                                                                                          self._dt,
+                                                                                          self._fin['emitter_model'][
+                                                                                              self._shower_index],
+                                                                                          half_width=half_width,
+                                                                                          emitter_frequency=emitter_frequency)
                                 # convolve voltage output with antenna response to obtain emitted electric field
                                 frequencies = np.fft.rfftfreq(self._n_samples, d=self._dt)
                                 zenith_emitter, azimuth_emitter = hp.cartesian_to_spherical(*self._launch_vector)
-                                VEL = antenna_pattern.get_antenna_response_vectorized(frequencies, zenith_emitter, azimuth_emitter, *ori)
+                                VEL = antenna_pattern.get_antenna_response_vectorized(frequencies, zenith_emitter,
+                                                                                      azimuth_emitter, *ori)
                                 c = constants.c * units.m / units.s
                                 eTheta = VEL['theta'] * (-1j) * voltage_spectrum_emitter * frequencies * n_index / (c)
                                 ePhi = VEL['phi'] * (-1j) * voltage_spectrum_emitter * frequencies * n_index / (c)
@@ -797,11 +866,12 @@ class simulation():
                                 logger.error(f"simulation mode {self._fin_attrs['simulation_mode']} unknown.")
                                 raise AttributeError(f"simulation mode {self._fin_attrs['simulation_mode']} unknown.")
 
-                            if(self._debug):
+                            if (self._debug):
                                 from matplotlib import pyplot as plt
                                 fig, (ax, ax2) = plt.subplots(1, 2)
                                 ax.plot(self._ff, np.abs(eTheta) / units.micro / units.V * units.m)
-                                ax2.plot(self._tt, fft.freq2time(eTheta, 1. / self._dt) / units.micro / units.V * units.m)
+                                ax2.plot(self._tt,
+                                         fft.freq2time(eTheta, 1. / self._dt) / units.micro / units.V * units.m)
                                 ax2.set_ylabel("amplitude [$\mu$V/m]")
                                 fig.tight_layout()
                                 fig.suptitle("$E_C$ = {:.1g}eV $\Delta \Omega$ = {:.1f}deg, R = {:.0f}m".format(
@@ -810,10 +880,14 @@ class simulation():
                                 plt.show()
 
                             electric_field = NuRadioReco.framework.electric_field.ElectricField([channel_id],
-                                                position=self._det.get_relative_position(self._sim_station.get_id(), channel_id),
-                                                shower_id=self._shower_ids[self._shower_index], ray_tracing_id=iS)
-                            if(iS is None):
-                                a = 1 / 0
+                                                                                                position=self._det.get_relative_position(
+                                                                                                    self._sim_station.get_id(),
+                                                                                                    channel_id),
+                                                                                                shower_id=
+                                                                                                self._shower_ids[
+                                                                                                    self._shower_index],
+                                                                                                ray_tracing_id=iS)
+                            if (iS is None):
                             electric_field.set_frequency_spectrum(np.array([eR, eTheta, ePhi]), 1. / self._dt)
                             electric_field = self._raytracer.apply_propagation_effects(electric_field, iS)
                             # Trace start time is equal to the interaction time relative to the first
@@ -832,7 +906,8 @@ class simulation():
                             electric_field.set_trace_start_time(trace_start_time)
                             electric_field[efp.azimuth] = azimuth
                             electric_field[efp.zenith] = zenith
-                            electric_field[efp.ray_path_type] = propagation.solution_types[self._raytracer.get_solution_type(iS)]
+                            electric_field[efp.ray_path_type] = propagation.solution_types[
+                                self._raytracer.get_solution_type(iS)]
                             electric_field[efp.nu_vertex_distance] = sg['travel_distances'][iSh, channel_id, iS]
                             electric_field[efp.nu_viewing_angle] = viewing_angles[iS]
                             self._sim_station.add_electric_field(electric_field)
@@ -840,7 +915,9 @@ class simulation():
                             # apply a simple threshold cut to speed up the simulation,
                             # application of antenna response will just decrease the
                             # signal amplitude
-                            if(np.max(np.abs(electric_field.get_trace())) > float(self._cfg['speedup']['min_efield_amplitude']) * self._Vrms_efield_per_channel[self._station_id][channel_id]):
+                            if (np.max(np.abs(electric_field.get_trace())) > float(
+                                    self._cfg['speedup']['min_efield_amplitude']) *
+                                    self._Vrms_efield_per_channel[self._station_id][channel_id]):
                                 candidate_station = True
                         # end of ray tracing solutions loop
                     t3 = time.time()
@@ -850,7 +927,7 @@ class simulation():
                 # now perform first part of detector simulation -> convert each efield to voltage
                 # (i.e. apply antenna response) and apply additional simulation of signal chain (such as cable delays,
                 # amp response etc.)
-                if(not candidate_station):
+                if (not candidate_station):
                     logger.debug("electric field amplitude too small in all channels, skipping to next event")
                     continue
                 t1 = time.time()
@@ -858,20 +935,25 @@ class simulation():
                 self._station.set_sim_station(self._sim_station)
 
                 # convert efields to voltages at digitizer
-                if(hasattr(self, '_detector_simulation_part1')):
+                if (hasattr(self, '_detector_simulation_part1')):
                     # we give the user the opportunity to define a custom detector simulation
                     self._detector_simulation_part1()
                 else:
-                    efieldToVoltageConverterPerEfield.run(self._evt, self._station, self._det)  # convolve efield with antenna pattern
+                    efieldToVoltageConverterPerEfield.run(self._evt, self._station,
+                                                          self._det)  # convolve efield with antenna pattern
                     self._detector_simulation_filter_amp(self._evt, self._station.get_sim_station(), self._det)
                     channelAddCableDelay.run(self._evt, self._sim_station, self._det)
 
-                if(self._cfg['speedup']['amp_per_ray_solution']):
+                if (self._cfg['speedup']['amp_per_ray_solution']):
                     self._channelSignalReconstructor.run(self._evt, self._station.get_sim_station(), self._det)
                     for channel in self._station.get_sim_station().iter_channels():
                         tmp_index = np.argwhere(event_indices == self._get_shower_index(channel.get_shower_id()))[0]
-                        sg['max_amp_shower_and_ray'][tmp_index, channel.get_id(), channel.get_ray_tracing_solution_id()] = channel.get_parameter(chp.maximum_amplitude_envelope)
-                        sg['time_shower_and_ray'][tmp_index, channel.get_id(), channel.get_ray_tracing_solution_id()] = channel.get_parameter(chp.signal_time)
+                        sg['max_amp_shower_and_ray'][
+                            tmp_index, channel.get_id(), channel.get_ray_tracing_solution_id()] = channel.get_parameter(
+                            chp.maximum_amplitude_envelope)
+                        sg['time_shower_and_ray'][
+                            tmp_index, channel.get_id(), channel.get_ray_tracing_solution_id()] = channel.get_parameter(
+                            chp.signal_time)
                 start_times = []
                 channel_identifiers = []
                 for channel in self._sim_station.iter_channels():
@@ -879,15 +961,16 @@ class simulation():
                     start_times.append(channel.get_trace_start_time())
                 start_times = np.array(start_times)
                 start_times_sort = np.argsort(start_times)
-                delta_start_times = start_times[start_times_sort][1:] - start_times[start_times_sort][:-1]  # this array is sorted in time
+                delta_start_times = start_times[start_times_sort][1:] - start_times[start_times_sort][
+                                                                        :-1]  # this array is sorted in time
                 split_event_time_diff = float(self._cfg['split_event_time_diff'])
                 iSplit = np.atleast_1d(np.squeeze(np.argwhere(delta_start_times > split_event_time_diff)))
-#                 print(f"start times {start_times}")
-#                 print(f"sort array {start_times_sort}")
-#                 print(f"delta times {delta_start_times}")
-#                 print(f"split at indices {iSplit}")
+                #                 print(f"start times {start_times}")
+                #                 print(f"sort array {start_times_sort}")
+                #                 print(f"delta times {delta_start_times}")
+                #                 print(f"split at indices {iSplit}")
                 n_sub_events = len(iSplit) + 1
-                if(n_sub_events > 1):
+                if (n_sub_events > 1):
                     logger.info(f"splitting event group id {self._event_group_id} into {n_sub_events} sub events")
 
                 tmp_station = copy.deepcopy(self._station)
@@ -895,18 +978,19 @@ class simulation():
                 for iEvent in range(n_sub_events):
                     iStart = 0
                     iStop = len(channel_identifiers)
-                    if(n_sub_events > 1):
-                        if(iEvent > 0):
+                    if (n_sub_events > 1):
+                        if (iEvent > 0):
                             iStart = iSplit[iEvent - 1] + 1
-                    if(iEvent < n_sub_events - 1):
+                    if (iEvent < n_sub_events - 1):
                         iStop = iSplit[iEvent] + 1
                     indices = start_times_sort[iStart: iStop]
-                    if(n_sub_events > 1):
+                    if (n_sub_events > 1):
                         tmp = ""
                         for start_time in start_times[indices]:
-                            tmp += f"{start_time/units.ns:.0f}, "
+                            tmp += f"{start_time / units.ns:.0f}, "
                         tmp = tmp[:-2] + " ns"
-                        logger.info(f"creating event {iEvent} of event group {self._event_group_id} ranging rom {iStart} to {iStop} with indices {indices} corresponding to signal times of {tmp}")
+                        logger.info(
+                            f"creating event {iEvent} of event group {self._event_group_id} ranging rom {iStart} to {iStop} with indices {indices} corresponding to signal times of {tmp}")
                     self._evt = NuRadioReco.framework.event.Event(self._event_group_id, iEvent)  # create new event
 
                     if particle_mode:
@@ -924,12 +1008,13 @@ class simulation():
                     for iCh in indices:
                         ch_uid = channel_identifiers[iCh]
                         shower_id = ch_uid[1]
-                        if(shower_id not in self._shower_ids_of_sub_event):
+                        if (shower_id not in self._shower_ids_of_sub_event):
                             self._shower_ids_of_sub_event.append(shower_id)
                         sim_station.add_channel(tmp_sim_station.get_channel(ch_uid))
-                        efield_uid = ([ch_uid[0]], ch_uid[1], ch_uid[2])  # the efield unique identifier has as first parameter an array of the channels it is valid for
+                        efield_uid = ([ch_uid[0]], ch_uid[1], ch_uid[
+                            2])  # the efield unique identifier has as first parameter an array of the channels it is valid for
                         for efield in tmp_sim_station.get_electric_fields():
-                            if(efield.get_unique_identifier() == efield_uid):
+                            if (efield.get_unique_identifier() == efield_uid):
                                 sim_station.add_electric_field(efield)
 
                     if particle_mode:
@@ -939,17 +1024,18 @@ class simulation():
                     self._station.set_sim_station(sim_station)
                     self._station.set_station_time(self._evt_time)
                     self._evt.set_station(self._station)
-                    if(bool(self._cfg['signal']['zerosignal'])):
+                    if (bool(self._cfg['signal']['zerosignal'])):
                         self._increase_signal(None, 0)
 
                     logger.debug("performing detector simulation")
-                    if(hasattr(self, '_detector_simulation_part2')):
+                    if (hasattr(self, '_detector_simulation_part2')):
                         # we give the user the opportunity to specify a custom detector simulation module sequence
                         # which might be needed for certain analyses
                         self._detector_simulation_part2()
                     else:
                         # start detector simulation
-                        efieldToVoltageConverter.run(self._evt, self._station, self._det)  # convolve efield with antenna pattern
+                        efieldToVoltageConverter.run(self._evt, self._station,
+                                                     self._det)  # convolve efield with antenna pattern
                         # downsample trace to internal simulation sampling rate (the efieldToVoltageConverter upsamples the trace to
                         # 20 GHz by default to achieve a good time resolution when the two signals from the two signal paths are added)
                         channelResampler.run(self._evt, self._station, self._det, sampling_rate=1. / self._dt)
@@ -960,35 +1046,39 @@ class simulation():
                             Vrms = {}
                             for channel_id in channel_ids:
                                 norm = self._bandwidth_per_channel[self._station.get_id()][channel_id]
-                                Vrms[channel_id] = self._Vrms_per_channel[self._station.get_id()][channel_id] / (norm / (max_freq)) ** 0.5  # normalize noise level to the bandwidth its generated for
-                            channelGenericNoiseAdder.run(self._evt, self._station, self._det, amplitude=Vrms, min_freq=0 * units.MHz,
-                                                         max_freq=max_freq, type='rayleigh', excluded_channels=self._noiseless_channels[station_id])
+                                Vrms[channel_id] = self._Vrms_per_channel[self._station.get_id()][channel_id] / (
+                                        norm / (
+                                    max_freq)) ** 0.5  # normalize noise level to the bandwidth its generated for
+                            channelGenericNoiseAdder.run(self._evt, self._station, self._det, amplitude=Vrms,
+                                                         min_freq=0 * units.MHz,
+                                                         max_freq=max_freq, type='rayleigh',
+                                                         excluded_channels=self._noiseless_channels[station_id])
 
                         self._detector_simulation_filter_amp(self._evt, self._station, self._det)
 
                         self._detector_simulation_trigger(self._evt, self._station, self._det)
-                    if(not self._station.has_triggered()):
+                    if (not self._station.has_triggered()):
                         continue
 
                     event_group_has_triggered = True
                     triggered_showers[self._station_id].extend(self._get_shower_index(self._shower_ids_of_sub_event))
                     self._calculate_signal_properties()
 
-                    def find_indices(shower_indices_of_triggered_showers, event_indices):
-                  
-                        return  np.atleast_1d(np.squeeze([np.argwhere(event_indices==gix) for gix in shower_indices_of_triggered_showers]))
-
-
-                    
                     shower_indices_of_triggered_showers = self._get_shower_index(self._shower_ids_of_sub_event)
-                    event_indices_of_triggered_shower_in_eventgroup = find_indices(shower_indices_of_triggered_showers, event_indices)
-                    self._save_triggers_to_hdf5(sg, event_indices_of_triggered_shower_in_eventgroup, shower_indices_of_triggered_showers)
+                    event_indices_of_triggered_shower_in_eventgroup = np.atleast_1d(np.squeeze(
+                            [np.argwhere(event_indices == gix) for gix in shower_indices_of_triggered_showers]))
 
-                    if(self._outputfilenameNuRadioReco is not None):
+                    self._save_triggers_to_hdf5(sg, event_indices_of_triggered_shower_in_eventgroup,
+                                                shower_indices_of_triggered_showers)
+
+                    if (self._outputfilenameNuRadioReco is not None):
                         # downsample traces to detector sampling rate to save file size
-                        channelResampler.run(self._evt, self._station, self._det, sampling_rate=self._sampling_rate_detector)
-                        channelResampler.run(self._evt, self._station.get_sim_station(), self._det, sampling_rate=self._sampling_rate_detector)
-                        electricFieldResampler.run(self._evt, self._station.get_sim_station(), self._det, sampling_rate=self._sampling_rate_detector)
+                        channelResampler.run(self._evt, self._station, self._det,
+                                             sampling_rate=self._sampling_rate_detector)
+                        channelResampler.run(self._evt, self._station.get_sim_station(), self._det,
+                                             sampling_rate=self._sampling_rate_detector)
+                        electricFieldResampler.run(self._evt, self._station.get_sim_station(), self._det,
+                                                   sampling_rate=self._sampling_rate_detector)
 
                         output_mode = {'Channels': self._cfg['output']['channel_traces'],
                                        'ElectricFields': self._cfg['output']['electric_field_traces'],
@@ -1003,10 +1093,10 @@ class simulation():
 
                 # add local sg array to output data structure if any
                 if event_group_has_triggered:
-                    if(self._station_id not in self._mout_groups):
+                    if (self._station_id not in self._mout_groups):
                         self._mout_groups[self._station_id] = {}
                     for key in sg:
-                        if(key not in self._mout_groups[self._station_id]):
+                        if (key not in self._mout_groups[self._station_id]):
                             self._mout_groups[self._station_id][key] = list(sg[key])
                         else:
                             self._mout_groups[self._station_id][key].extend(sg[key])
@@ -1020,12 +1110,12 @@ class simulation():
         # Create trigger structures if there are no triggering events.
         # This is done to ensure that files with no triggering n_events
         # merge properly.
-#         self._create_empty_multiple_triggers()
+        #         self._create_empty_multiple_triggers()
 
         # save simulation run in hdf5 format (only triggered events)
         t5 = time.time()
         self._write_output_file()
-        if(self._outputfilenameNuRadioReco is not None):
+        if (self._outputfilenameNuRadioReco is not None):
             self._eventWriter.end()
             logger.debug("closing nur file")
 
@@ -1044,18 +1134,20 @@ class simulation():
         ttot = np.sum(np.array(ts))
         for i, (name, instance, kwargs) in enumerate(self._evt.iter_modules(self._station.get_id())):
             t = pretty_time_delta(ts[i])
-            trel = 100.*ts[i] / ttot
+            trel = 100. * ts[i] / ttot
             output_NuRadioRecoTime += f"{name}: {t} {trel:.1f}%\n"
         logger.status(output_NuRadioRecoTime)
 
-        logger.status("{:d} events processed in {} = {:.2f}ms/event ({:.1f}% input, {:.1f}% ray tracing, {:.1f}% askaryan, {:.1f}% detector simulation, {:.1f}% output, {:.1f}% weights calculation)".format(self._n_showers,
-                                                                                         pretty_time_delta(t_total), 1.e3 * t_total / self._n_showers,
-                                                                                         100 * input_time / t_total,
-                                                                                         100 * (rayTracingTime - askaryan_time) / t_total,
-                                                                                         100 * askaryan_time / t_total,
-                                                                                         100 * detSimTime / t_total,
-                                                                                         100 * outputTime / t_total,
-                                                                                         100 * weightTime / t_total))
+        logger.status(
+            "{:d} events processed in {} = {:.2f}ms/event ({:.1f}% input, {:.1f}% ray tracing, {:.1f}% askaryan, {:.1f}% detector simulation, {:.1f}% output, {:.1f}% weights calculation)".format(
+                self._n_showers,
+                pretty_time_delta(t_total), 1.e3 * t_total / self._n_showers,
+                                            100 * input_time / t_total,
+                                            100 * (rayTracingTime - askaryan_time) / t_total,
+                                            100 * askaryan_time / t_total,
+                                            100 * detSimTime / t_total,
+                                            100 * outputTime / t_total,
+                                            100 * weightTime / t_total))
         triggered = remove_duplicate_triggers(self._mout['triggered'], self._fin['event_group_ids'])
         n_triggered = np.sum(triggered)
         return n_triggered
@@ -1064,7 +1156,7 @@ class simulation():
         pass
 
     def _get_shower_index(self, shower_id):
-        if(hasattr(shower_id, "__len__")):
+        if (hasattr(shower_id, "__len__")):
             return np.array([self._shower_index_array[x] for x in shower_id])
         else:
             return self._shower_index_array[shower_id]
@@ -1085,14 +1177,15 @@ class simulation():
         tt = ['fiducial_rmin', 'fiducial_rmax', 'fiducial_zmin', 'fiducial_zmax']
         has_fiducial = True
         for t in tt:
-            if(not t in self._fin_attrs):
+            if (not t in self._fin_attrs):
                 has_fiducial = False
-        if(not has_fiducial):
+        if (not has_fiducial):
             return True
 
         r = (self._shower_vertex[0] ** 2 + self._shower_vertex[1] ** 2) ** 0.5
-        if(r >= self._fin_attrs['fiducial_rmin'] and r <= self._fin_attrs['fiducial_rmax']):
-            if(self._shower_vertex[2] >= self._fin_attrs['fiducial_zmin'] and self._shower_vertex[2] <= self._fin_attrs['fiducial_zmax']):
+        if (r >= self._fin_attrs['fiducial_rmin'] and r <= self._fin_attrs['fiducial_rmax']):
+            if (self._shower_vertex[2] >= self._fin_attrs['fiducial_zmin'] and self._shower_vertex[2] <=
+                    self._fin_attrs['fiducial_zmax']):
                 return True
         return False
 
@@ -1106,9 +1199,10 @@ class simulation():
         channel_id: int or None
             if None, all available channels will be modified
         """
-        if(channel_id is None):
+        if (channel_id is None):
             for electric_field in self._station.get_sim_station().get_electric_fields():
-                electric_field.set_trace(electric_field.get_trace() * factor, sampling_rate=electric_field.get_sampling_rate())
+                electric_field.set_trace(electric_field.get_trace() * factor,
+                                         sampling_rate=electric_field.get_sampling_rate())
 
         else:
             sim_channels = self._station.get_sim_station().get_electric_fields_for_channels([channel_id])
@@ -1149,7 +1243,7 @@ class simulation():
             return False
 
     def _calculate_signal_properties(self):
-        if(self._station.has_triggered()):
+        if (self._station.has_triggered()):
             self._channelSignalReconstructor.run(self._evt, self._station, self._det)
             amplitudes = np.zeros(self._station.get_number_of_channels())
             amplitudes_envelope = np.zeros(self._station.get_number_of_channels())
@@ -1171,44 +1265,46 @@ class simulation():
 
     def _create_trigger_structures(self):
 
-        if('trigger_names' not in self._mout_attrs):
+        if ('trigger_names' not in self._mout_attrs):
             self._mout_attrs['trigger_names'] = []
         extend_array = False
         for trigger in six.itervalues(self._station.get_triggers()):
-            if(trigger.get_name() not in self._mout_attrs['trigger_names']):
+            if (trigger.get_name() not in self._mout_attrs['trigger_names']):
                 self._mout_attrs['trigger_names'].append((trigger.get_name()))
                 extend_array = True
         # the 'multiple_triggers' output array is not initialized in the constructor because the number of
         # simulated triggers is unknown at the beginning. So we check if the key already exists and if not,
         # we first create this data structure
-        if('multiple_triggers' not in self._mout):
-            self._mout['multiple_triggers'] = np.zeros((self._n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
-#             for station_id in self._station_ids:
-#                 sg = self._mout_groups[station_id]
-#                 sg['multiple_triggers'] = np.zeros((self._n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
-        elif(extend_array):
+        if ('multiple_triggers' not in self._mout):
+            self._mout['multiple_triggers'] = np.zeros((self._n_showers, len(self._mout_attrs['trigger_names'])),
+                                                       dtype=np.bool)
+        #             for station_id in self._station_ids:
+        #                 sg = self._mout_groups[station_id]
+        #                 sg['multiple_triggers'] = np.zeros((self._n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
+        elif (extend_array):
             tmp = np.zeros((self._n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
             nx, ny = self._mout['multiple_triggers'].shape
             tmp[:, 0:ny] = self._mout['multiple_triggers']
             self._mout['multiple_triggers'] = tmp
-#             for station_id in self._station_ids:
-#                 sg = self._mout_groups[station_id]
-#                 tmp = np.zeros((self._n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
-#                 nx, ny = sg['multiple_triggers'].shape
-#                 tmp[:, 0:ny] = sg['multiple_triggers']
-#                 sg['multiple_triggers'] = tmp
+        #             for station_id in self._station_ids:
+        #                 sg = self._mout_groups[station_id]
+        #                 tmp = np.zeros((self._n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
+        #                 nx, ny = sg['multiple_triggers'].shape
+        #                 tmp[:, 0:ny] = sg['multiple_triggers']
+        #                 sg['multiple_triggers'] = tmp
         return extend_array
 
-    def _save_triggers_to_hdf5(self, sg, event_indices_of_triggered_shower_in_eventgroup, shower_indices_of_triggered_showers):
-        
+    def _save_triggers_to_hdf5(self, sg, event_indices_of_triggered_shower_in_eventgroup,
+                               shower_indices_of_triggered_showers):
+
         extend_array = self._create_trigger_structures()
         # now we also need to create the trigger structure also in the sg (station group) dictionary that contains
         # the information fo the current station and event group
         # n_showers refers to the number of triggered showers within one event group, e.g. events with the same event_group_id
         n_showers = sg['launch_vectors'].shape[0]
-        if('multiple_triggers' not in sg):
+        if ('multiple_triggers' not in sg):
             sg['multiple_triggers'] = np.zeros((n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
-        elif(extend_array):
+        elif (extend_array):
             tmp = np.zeros((n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
             nx, ny = sg['multiple_triggers'].shape
             tmp[:, 0:ny] = sg['multiple_triggers']
@@ -1218,7 +1314,7 @@ class simulation():
         self._output_sub_event_ids[self._station_id].append(self._evt.get_id())
         multiple_triggers = np.zeros(len(self._mout_attrs['trigger_names']), dtype=np.bool)
         for iT, trigger_name in enumerate(self._mout_attrs['trigger_names']):
-            if(self._station.has_trigger(trigger_name)):
+            if (self._station.has_trigger(trigger_name)):
                 multiple_triggers[iT] = self._station.get_trigger(trigger_name).has_triggered()
                 for iSh in event_indices_of_triggered_shower_in_eventgroup:
                     sg['multiple_triggers'][iSh][iT] = self._station.get_trigger(trigger_name).has_triggered()
@@ -1226,6 +1322,7 @@ class simulation():
             sg['triggered'][iSh] = np.any(sg['multiple_triggers'][iSh])
             self._mout['triggered'][iSh2] |= sg['triggered'][iSh]
             self._mout['multiple_triggers'][iSh2] |= sg['multiple_triggers'][iSh]
+        sg['event_id_per_shower'][event_indices_of_triggered_shower_in_eventgroup] = self._evt.get_id()
         self._output_multiple_triggers_station[self._station_id].append(multiple_triggers)
         self._output_triggered_station[self._station_id].append(np.any(multiple_triggers))
 
@@ -1243,9 +1340,9 @@ class simulation():
         checks if the same detector was simulated before (then we can save the ray tracing part)
         """
         self._was_pre_simulated = False
-        if('detector' in self._fin_attrs):
+        if ('detector' in self._fin_attrs):
             with open(self._detectorfile, 'r') as fdet:
-                if(fdet.read() == self._fin_attrs['detector']):
+                if (fdet.read() == self._fin_attrs['detector']):
                     self._was_pre_simulated = True
                     logger.status("the simulation was already performed with the same detector")
         return self._was_pre_simulated
@@ -1258,7 +1355,7 @@ class simulation():
         self._mout_attributes = {}
         self._mout['weights'] = np.zeros(self._n_showers)
         self._mout['triggered'] = np.zeros(self._n_showers, dtype=np.bool)
-#         self._mout['multiple_triggers'] = np.zeros((self._n_showers, self._number_of_triggers), dtype=np.bool)
+        #         self._mout['multiple_triggers'] = np.zeros((self._n_showers, self._number_of_triggers), dtype=np.bool)
         self._mout_attributes['trigger_names'] = None
         self._amplitudes = {}
         self._amplitudes_envelope = {}
@@ -1283,13 +1380,15 @@ class simulation():
         nS = self._raytracer.get_number_of_raytracing_solutions()  # number of possible ray-tracing solutions
         sg = {}
         sg['triggered'] = np.zeros(n_showers, dtype=np.bool)
-        sg['shower_id'] = np.zeros(n_showers, dtype=int) * -1  # we need the reference to the shower id to be able to find the correct shower in the upper level hdf5 file
+        sg['shower_id'] = np.zeros(n_showers,
+                                   dtype=int) * -1  # we need the reference to the shower id to be able to find the correct shower in the upper level hdf5 file
+        sg['event_id_per_shower'] = np.zeros(n_showers, dtype=int) * -1
         sg['launch_vectors'] = np.zeros((n_showers, n_antennas, nS, 3)) * np.nan
         sg['receive_vectors'] = np.zeros((n_showers, n_antennas, nS, 3)) * np.nan
         sg['polarization'] = np.zeros((n_showers, n_antennas, nS, 3)) * np.nan
         sg['travel_times'] = np.zeros((n_showers, n_antennas, nS)) * np.nan
         sg['travel_distances'] = np.zeros((n_showers, n_antennas, nS)) * np.nan
-        if(self._cfg['speedup']['amp_per_ray_solution']):
+        if (self._cfg['speedup']['amp_per_ray_solution']):
             sg['max_amp_shower_and_ray'] = np.zeros((n_showers, n_antennas, nS))
             sg['time_shower_and_ray'] = np.zeros((n_showers, n_antennas, nS))
         for parameter_entry in self._raytracer.get_output_parameters():
@@ -1366,7 +1465,7 @@ class simulation():
 
     def _write_output_file(self, empty=False):
         folder = os.path.dirname(self._outputfilename)
-        if(not os.path.exists(folder) and folder != ''):
+        if (not os.path.exists(folder) and folder != ''):
             logger.warning(f"output folder {folder} does not exist, creating folder...")
             os.makedirs(folder)
         fout = h5py.File(self._outputfilename, 'w')
@@ -1379,7 +1478,7 @@ class simulation():
             # a reference! saved indicates the interactions to be saved, while
             # triggered should indicate if an interaction has produced a trigger
             saved = np.copy(self._mout['triggered'])
-            if('n_interactions' in self._fin):  # if n_interactions is not specified, there are not parents
+            if ('n_interactions' in self._fin):  # if n_interactions is not specified, there are not parents
                 parent_mask = self._fin['n_interaction'] == 1
                 for event_id in np.unique(self._fin['event_group_ids']):
                     event_mask = self._fin['event_group_ids'] == event_id
@@ -1398,17 +1497,17 @@ class simulation():
                     sg[key2] = np.array(value2)[np.array(value['triggered'])]
 
             # save "per event" quantities
-            if('trigger_names' in self._mout_attrs):
+            if ('trigger_names' in self._mout_attrs):
                 n_triggers = len(self._mout_attrs['trigger_names'])
                 for station_id in self._mout_groups:
                     n_events_for_station = len(self._output_triggered_station[station_id])
-                    if(n_events_for_station > 0):
-                        n_channels = self._det.get_number_of_channels(station_id)
+                    if (n_events_for_station > 0):
                         sg = fout["station_{:d}".format(station_id)]
                         sg['event_group_ids'] = np.array(self._output_event_group_ids[station_id])
                         sg['event_ids'] = np.array(self._output_sub_event_ids[station_id])
                         sg['maximum_amplitudes'] = np.array(self._output_maximum_amplitudes[station_id])
-                        sg['maximum_amplitudes_envelope'] = np.array(self._output_maximum_amplitudes_envelope[station_id])
+                        sg['maximum_amplitudes_envelope'] = np.array(
+                            self._output_maximum_amplitudes_envelope[station_id])
                         sg['triggered_per_event'] = np.array(self._output_triggered_station[station_id])
 
                         # the multiple triggers 2d array might have different number of entries per event
@@ -1432,10 +1531,14 @@ class simulation():
                 n_channels = self._det.get_number_of_channels(station_id)
                 positions = np.zeros((n_channels, 3))
                 for i_ch, channel_id in enumerate(self._det.get_channel_ids(self._station_id)):
-                    positions[i_ch] = self._det.get_relative_position(station_id, channel_id) + self._det.get_absolute_position(station_id)
+                    positions[i_ch] = self._det.get_relative_position(station_id,
+                                                                      channel_id) + self._det.get_absolute_position(
+                        station_id)
                 fout["station_{:d}".format(station_id)].attrs['antenna_positions'] = positions
-                fout["station_{:d}".format(station_id)].attrs['Vrms'] = list(self._Vrms_per_channel[station_id].values())
-                fout["station_{:d}".format(station_id)].attrs['bandwidth'] = list(self._bandwidth_per_channel[station_id].values())
+                fout["station_{:d}".format(station_id)].attrs['Vrms'] = list(
+                    self._Vrms_per_channel[station_id].values())
+                fout["station_{:d}".format(station_id)].attrs['bandwidth'] = list(
+                    self._bandwidth_per_channel[station_id].values())
 
             fout.attrs.create("Tnoise", self._noise_temp, dtype=np.float)
             fout.attrs.create("Vrms", self._Vrms, dtype=np.float)
@@ -1453,9 +1556,9 @@ class simulation():
         if not empty:
             # now we also save all input parameters back into the out file
             for key in self._fin.keys():
-                if(key.startswith("station_")):
+                if (key.startswith("station_")):
                     continue
-                if(not key in fout.keys()):  # only save data sets that haven't been recomputed and saved already
+                if (not key in fout.keys()):  # only save data sets that haven't been recomputed and saved already
                     if np.array(self._fin[key]).dtype.char == 'U':
                         fout[key] = np.array(self._fin[key], dtype=h5py.string_dtype(encoding='utf-8'))[saved]
 
@@ -1463,8 +1566,10 @@ class simulation():
                         fout[key] = np.array(self._fin[key])[saved]
 
         for key in self._fin_attrs.keys():
-            if(not key in fout.attrs.keys()):  # only save attributes sets that haven't been recomputed and saved already
-                if(key not in ["trigger_names", "Tnoise", "Vrms", "bandwidth", "n_samples", "dt", "detector", "config"]):  # don't write trigger names from input to output file, this will lead to problems with incompatible trigger names when merging output files
+            if (
+                    not key in fout.attrs.keys()):  # only save attributes sets that haven't been recomputed and saved already
+                if (key not in ["trigger_names", "Tnoise", "Vrms", "bandwidth", "n_samples", "dt", "detector",
+                                "config"]):  # don't write trigger names from input to output file, this will lead to problems with incompatible trigger names when merging output files
                     fout.attrs[key] = self._fin_attrs[key]
         fout.close()
 
@@ -1474,21 +1579,23 @@ class simulation():
         n_triggered = np.sum(triggered)
         n_triggered_weighted = np.sum(self._mout['weights'][triggered])
         n_events = self._fin_attrs['n_events']
-        logger.status(f'fraction of triggered events = {n_triggered:.0f}/{n_events:.0f} = {n_triggered / self._n_showers:.3f} (sum of weights = {n_triggered_weighted:.2f})')
+        logger.status(
+            f'fraction of triggered events = {n_triggered:.0f}/{n_events:.0f} = {n_triggered / self._n_showers:.3f} (sum of weights = {n_triggered_weighted:.2f})')
 
         V = self._fin_attrs['volume']
         Veff = V * n_triggered_weighted / n_events
-        logger.status(f"Veff = {Veff / units.km ** 3:.4g} km^3, Veffsr = {Veff * 4 * np.pi/units.km**3:.4g} km^3 sr")
+        logger.status(
+            f"Veff = {Veff / units.km ** 3:.4g} km^3, Veffsr = {Veff * 4 * np.pi / units.km ** 3:.4g} km^3 sr")
 
     def _calculate_polarization_vector(self):
         """ calculates the polarization vector in spherical coordinates (eR, eTheta, ePhi)
         """
-        if(self._cfg['signal']['polarization'] == 'auto'):
+        if (self._cfg['signal']['polarization'] == 'auto'):
             polarization_direction = np.cross(self._launch_vector, np.cross(self._shower_axis, self._launch_vector))
             polarization_direction /= np.linalg.norm(polarization_direction)
             cs = cstrans.cstrafo(*hp.cartesian_to_spherical(*self._launch_vector))
             return cs.transform_from_ground_to_onsky(polarization_direction)
-        elif(self._cfg['signal']['polarization'] == 'custom'):
+        elif (self._cfg['signal']['polarization'] == 'custom'):
             ePhi = float(self._cfg['signal']['ePhi'])
             eTheta = (1 - ePhi ** 2) ** 0.5
             v = np.array([0, eTheta, ePhi])

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -47,6 +47,8 @@ import collections
 from NuRadioMC.utilities.Veff import remove_duplicate_triggers
 
 STATUS = 31
+
+
 # logging.basicConfig(format='%(asctime)s %(levelname)s:%(name)s:%(message)s')
 
 class NuRadioMCLogger(logging.Logger):
@@ -169,21 +171,21 @@ class simulation():
         logger.status('reading default config from {}'.format(config_file_default))
         with open(config_file_default, 'r') as ymlfile:
             self._cfg = yaml.load(ymlfile, Loader=yaml.FullLoader)
-        if (config_file is not None):
+        if config_file is not None:
             logger.status('reading local config overrides from {}'.format(config_file))
             with open(config_file, 'r') as ymlfile:
                 local_config = yaml.load(ymlfile, Loader=yaml.FullLoader)
                 new_cfg = merge_config(local_config, self._cfg)
                 self._cfg = new_cfg
 
-        if (self._cfg['seed'] is None):
+        if self._cfg['seed'] is None:
             # the config seeding None means a random seed. To have the simulation be reproducible, we generate a new
             # random seed once and save this seed to the config setting. If the simulation is rerun, we can get
             # the same random sequence.
             self._cfg['seed'] = np.random.randint(0, 2 ** 32 - 1)
 
         self._outputfilename = outputfilename
-        if (os.path.exists(self._outputfilename)):
+        if os.path.exists(self._outputfilename):
             msg = f"hdf5 output file {self._outputfilename} already exists"
             if file_overwrite == False:
                 logger.error(msg)
@@ -204,7 +206,7 @@ class simulation():
         # initialize propagation module
         self._prop = propagation.get_propagation_module(self._cfg['propagation']['module'])
 
-        if (self._cfg['propagation']['ice_model'] == "custom"):
+        if self._cfg['propagation']['ice_model'] == "custom":
             if ice_model is None:
                 logger.error("ice model is set to 'custom' in config file but no custom ice model is provided.")
                 raise AttributeError("ice model is set to 'custom' in config file but no custom ice model is provided.")
@@ -219,12 +221,12 @@ class simulation():
         # read in detector positions
         logger.status("Detectorfile {}".format(os.path.abspath(self._detectorfile)))
         self._det = None
-        if (default_detector_station is not None):
+        if default_detector_station is not None:
             logger.warning(
                 'Deprecation warning: Passing the default detector station is deprecated. Default stations and default'
-                'channel should be specified in the detector description directly.'
-            )
-            logger.status(f"Default detector station provided (station {default_detector_station}) -> Using generic detector")
+                'channel should be specified in the detector description directly.')
+            logger.status(
+                f"Default detector station provided (station {default_detector_station}) -> Using generic detector")
             self._det = gdetector.GenericDetector(json_filename=self._detectorfile,
                                                   default_station=default_detector_station,
                                                   default_channel=default_detector_channel, antenna_by_depth=False)
@@ -242,7 +244,7 @@ class simulation():
         # print noise information
         logger.status("running with noise {}".format(bool(self._cfg['noise'])))
         logger.status("setting signal to zero {}".format(bool(self._cfg['signal']['zerosignal'])))
-        if (bool(self._cfg['propagation']['focusing'])):
+        if bool(self._cfg['propagation']['focusing']):
             logger.status("simulating signal amplification due to focusing of ray paths in the firn.")
 
         # read sampling rate from config (this sampling rate will be used internally)
@@ -264,8 +266,8 @@ class simulation():
             if enum_entry.name in self._fin_attrs:
                 self._generator_info[enum_entry] = self._fin_attrs[enum_entry.name]
 
-        # check if the input file contains events, if not save empty output file (for book keeping) and terminate simulation
-        if (len(self._fin['xx']) == 0):
+        # check if the input file contains events, if not save empty output file (for bookkeeping) and terminate simulation
+        if len(self._fin['xx']) == 0:
             logger.status(f"input file {self._inputfilename} is empty")
             return
 
@@ -290,7 +292,6 @@ class simulation():
             self._tt = np.arange(0, self._n_samples * self._dt, self._dt)
 
             self._create_sim_station()
-            sta = self._det.get_station(self._station_id)
             for channel_id in self._det.get_channel_ids(self._station_id):
                 electric_field = NuRadioReco.framework.electric_field.ElectricField([channel_id], self._det.get_relative_position(self._sim_station.get_id(), channel_id))
                 trace = np.zeros_like(self._tt)
@@ -321,7 +322,8 @@ class simulation():
                 self._amplification_per_channel[self._station_id][channel_id] = np.abs(filt).max()
                 bandwidth = np.trapz(np.abs(filt) ** 2, ff)
                 self._bandwidth_per_channel[self._station_id][channel_id] = bandwidth
-                logger.status(f"bandwidth of station {self._station_id} channel {channel_id} is {bandwidth / units.MHz:.1f}MHz")
+                logger.status(
+                    f"bandwidth of station {self._station_id} channel {channel_id} is {bandwidth / units.MHz:.1f}MHz")
 
         ################################
 
@@ -329,10 +331,11 @@ class simulation():
         amplification = next(iter(next(iter(self._amplification_per_channel.values())).values()))
         noise_temp = self._cfg['trigger']['noise_temperature']
         Vrms = self._cfg['trigger']['Vrms']
-        if (noise_temp is not None and Vrms is not None):
-            raise AttributeError(f"Specifying noise temperature (set to {noise_temp}) and Vrms (set to {Vrms} is not allowed.")
-        if (noise_temp is not None):
-            if (noise_temp == "detector"):
+        if noise_temp is not None and Vrms is not None:
+            raise AttributeError(
+                f"Specifying noise temperature (set to {noise_temp}) and Vrms (set to {Vrms} is not allowed.")
+        if noise_temp is not None:
+            if noise_temp == "detector":
                 self._noise_temp = None  # the noise temperature is defined in the detector description
             else:
                 self._noise_temp = float(noise_temp)
@@ -342,7 +345,7 @@ class simulation():
                 self._Vrms_per_channel[station_id] = {}
                 self._noiseless_channels[station_id] = []
                 for channel_id in self._bandwidth_per_channel[station_id]:
-                    if (self._noise_temp is None):
+                    if self._noise_temp is None:
                         noise_temp_channel = self._det.get_noise_temperature(station_id, channel_id)
                     else:
                         noise_temp_channel = self._noise_temp
@@ -355,7 +358,7 @@ class simulation():
             self._Vrms = next(iter(next(iter(self._Vrms_per_channel.values())).values()))
             logger.status('(if same bandwidth for all stations/channels is assumed:) noise temperature = {}, bandwidth = {:.2f} MHz -> Vrms = {:.2f} muV'.format(
                     self._noise_temp, self._bandwidth / units.MHz, self._Vrms / units.V / units.micro))
-        elif (Vrms is not None):
+        elif Vrms is not None:
             self._Vrms = float(Vrms) * units.V
             self._noise_temp = None
         else:
@@ -365,7 +368,9 @@ class simulation():
         for station_id in self._bandwidth_per_channel:
             self._Vrms_efield_per_channel[station_id] = {}
             for channel_id in self._bandwidth_per_channel[station_id]:
-                self._Vrms_efield_per_channel[station_id][channel_id] = self._Vrms_per_channel[station_id][channel_id] / self._amplification_per_channel[station_id][channel_id] / units.m
+                self._Vrms_efield_per_channel[station_id][channel_id] = self._Vrms_per_channel[station_id][channel_id] / \
+                                                                        self._amplification_per_channel[station_id][
+                                                                            channel_id] / units.m
         self._Vrms_efield = next(iter(next(iter(self._Vrms_efield_per_channel.values())).values()))
         tmp_cut = float(self._cfg['speedup']['min_efield_amplitude'])
         logger.status(f"final Vrms {self._Vrms / units.V:.2g}V corresponds to an efield of {self._Vrms_efield / units.V / units.m / units.micro:.2g} muV/m for a VEL = 1m (amplification factor of system is {amplification:.1f}).\n -> all signals with less then {tmp_cut:.1f} x Vrms_efield = {tmp_cut * self._Vrms_efield / units.m / units.V / units.micro:.2g}muV/m will be skipped")
@@ -376,7 +381,7 @@ class simulation():
             self.__distance_cut_polynomial = np.polynomial.polynomial.Polynomial(coef)
 
             def get_distance_cut(shower_energy):
-                if (shower_energy <= 0):
+                if shower_energy <= 0:
                     return 100 * units.m
                 return max(100 * units.m, 10 ** self.__distance_cut_polynomial(np.log10(shower_energy)))
 
@@ -386,7 +391,7 @@ class simulation():
         """
         run the NuRadioMC simulation
         """
-        if (len(self._fin['xx']) == 0):
+        if len(self._fin['xx']) == 0:
             logger.status(f"writing empty hdf5 output file")
             self._write_output_file(empty=True)
             logger.status(f"terminating simulation")
@@ -405,12 +410,13 @@ class simulation():
         channelGenericNoiseAdder.begin(seed=self._cfg['seed'])
         channelResampler = NuRadioReco.modules.channelResampler.channelResampler()
         electricFieldResampler = NuRadioReco.modules.electricFieldResampler.electricFieldResampler()
-        if (self._outputfilenameNuRadioReco is not None):
+        if self._outputfilenameNuRadioReco is not None:
             self._eventWriter.begin(self._outputfilenameNuRadioReco, log_level=self._log_level)
         unique_event_group_ids = np.unique(self._fin['event_group_ids'])
         self._n_showers = len(self._fin['event_group_ids'])
         self._shower_ids = np.array(self._fin['shower_ids'])
-        self._shower_index_array = {}  # this array allows to convert the shower id to an index that starts from 0 to be used to access the arrays in the hdf5 file.
+        # this array allows to convert the shower id to an index that starts from 0 to be used to access the arrays in the hdf5 file.
+        self._shower_index_array = {}
 
         self._raytracer = self._prop(
             self._ice, self._cfg['propagation']['attenuation_model'],
@@ -452,8 +458,9 @@ class simulation():
         # loop over event groups
         for i_event_group_id, event_group_id in enumerate(unique_event_group_ids):
             logger.debug(f"simulating event group id {event_group_id}")
-            if (self._event_group_list is not None and event_group_id not in self._event_group_list):
-                logger.debug(f"skipping event group {event_group_id} because it is not in the event group list provided to the __init__ function")
+            if self._event_group_list is not None and event_group_id not in self._event_group_list:
+                logger.debug(
+                    f"skipping event group {event_group_id} because it is not in the event group list provided to the __init__ function")
                 continue
             event_indices = np.atleast_1d(np.squeeze(np.argwhere(self._fin['event_group_ids'] == event_group_id)))
 
@@ -473,12 +480,13 @@ class simulation():
                 self._read_input_particle_properties(self._primary_index)
                 # calculate the weight for the primary particle
                 self.primary = self.input_particle
-                if (self._cfg['weights']['weight_mode'] == "existing"):
-                    if ("weights" in self._fin):
+                if self._cfg['weights']['weight_mode'] == "existing":
+                    if "weights" in self._fin:
                         self._mout['weights'] = self._fin["weights"]
                     else:
-                        logger.error("config file specifies to use weights from the input hdf5 file but the input file does not contain this information.")
-                elif (self._cfg['weights']['weight_mode'] is None):
+                        logger.error(
+                            "config file specifies to use weights from the input hdf5 file but the input file does not contain this information.")
+                elif self._cfg['weights']['weight_mode'] is None:
                     self.primary[simp.weight] = 1.
                 else:
                     self.primary[simp.weight] = get_weight(self.primary[simp.zenith],
@@ -494,8 +502,9 @@ class simulation():
             weightTime += time.time() - t1
             # skip all events where neutrino weights is zero, i.e., do not
             # simulate neutrino that propagate through the Earth
-            if (self._mout['weights'][self._primary_index] < self._cfg['speedup']['minimum_weight_cut']):
-                logger.debug("neutrino weight is smaller than {}, skipping event".format(self._cfg['speedup']['minimum_weight_cut']))
+            if self._mout['weights'][self._primary_index] < self._cfg['speedup']['minimum_weight_cut']:
+                logger.debug("neutrino weight is smaller than {}, skipping event".format(
+                    self._cfg['speedup']['minimum_weight_cut']))
                 continue
 
             # these quantities get computed to apply the distance cut as a function of shower energies
@@ -513,7 +522,6 @@ class simulation():
 
             # loop over all stations (each station is treated independently)
             for iSt, self._station_id in enumerate(self._station_ids):
-                t1 = time.time()
                 triggered_showers[self._station_id] = []
                 logger.debug(f"simulating station {self._station_id}")
 
@@ -539,8 +547,8 @@ class simulation():
                 self._tt = np.arange(0, self._n_samples * self._dt, self._dt)
 
                 ray_tracing_performed = False
-                if ('station_{:d}'.format(self._station_id) in self._fin_stations):
-                    ray_tracing_performed = (self._raytracer.get_output_parameters()[0]['name'] in self._fin_stations['station_{:d}'.format(self._station_id)]) and (self._was_pre_simulated)
+                if 'station_{:d}'.format(self._station_id) in self._fin_stations:
+                    ray_tracing_performed = (self._raytracer.get_output_parameters()[0]['name'] in self._fin_stations['station_{:d}'.format(self._station_id)]) and self._was_pre_simulated
                 self._evt_tmp = NuRadioReco.framework.event.Event(0, 0)
 
                 if particle_mode:
@@ -550,34 +558,32 @@ class simulation():
                 self._create_sim_station()
                 # loop over all showers in event group
                 # create output data structure for this channel
-                sg = self._create_station_output_structure(len(event_indices), self._det.get_number_of_channels(
-                    self._station_id))  # n_shower, n_antennas
+                sg = self._create_station_output_structure(len(event_indices), self._det.get_number_of_channels(self._station_id))  # n_shower, n_antennas
                 for iSh, self._shower_index in enumerate(event_indices):
                     sg['shower_id'][iSh] = self._shower_ids[self._shower_index]
                     iCounter += 1
                     # if(iCounter % max(1, int(n_shower_station / 100.)) == 0):
-                    if ((time.time() - t_last_update) > 60):
+                    if (time.time() - t_last_update) > 60:
                         t_last_update = time.time()
                         eta = pretty_time_delta((time.time() - t_start) * (n_shower_station - iCounter) / iCounter)
                         total_time_sum = input_time + rayTracingTime + detSimTime + outputTime + weightTime + distance_cut_time  # askaryan time is part of the ray tracing time, so it is not counted here.
                         total_time = time.time() - t_start
-                        tmp_att = 0
                         if total_time > 0:
                             logger.status("processing event group {}/{} and shower {}/{} ({} showers triggered) = {:.1f}%, ETA {}, time consumption: ray tracing = {:.0f}%, askaryan = {:.0f}%, detector simulation = {:.0f}% reading input = {:.0f}%, calculating weights = {:.0f}%, distance cut {:.0f}%, unaccounted = {:.0f}% ".format(
-                                    i_event_group_id,
-                                    len(unique_event_group_ids),
-                                    iCounter,
-                                    n_shower_station,
-                                    np.sum(self._mout['triggered']),
-                                    100. * iCounter / n_shower_station,
-                                    eta,
-                                    100. * (rayTracingTime - askaryan_time) / total_time,
-                                    100. * askaryan_time / total_time,
-                                    100. * detSimTime / total_time,
-                                    100. * input_time / total_time,
-                                    100. * weightTime / total_time,
-                                    100 * distance_cut_time / total_time,
-                                    100 * (total_time - total_time_sum) / total_time))
+                                            i_event_group_id,
+                                            len(unique_event_group_ids),
+                                            iCounter,
+                                            n_shower_station,
+                                            np.sum(self._mout['triggered']),
+                                            100. * iCounter / n_shower_station,
+                                            eta,
+                                            100. * (rayTracingTime - askaryan_time) / total_time,
+                                            100. * askaryan_time / total_time,
+                                            100. * detSimTime / total_time,
+                                            100. * input_time / total_time,
+                                            100. * weightTime / total_time,
+                                            100 * distance_cut_time / total_time,
+                                            100 * (total_time - total_time_sum) / total_time))
 
                     self._read_input_shower_properties()
                     if particle_mode:
@@ -607,11 +613,11 @@ class simulation():
                         continue
 
                     # for special cases where only EM or HAD showers are simulated, skip all events that don't fulfill this criterion
-                    if (self._cfg['signal']['shower_type'] == "em"):
-                        if (self._fin['shower_type'][self._shower_index] != "em"):
+                    if self._cfg['signal']['shower_type'] == "em":
+                        if self._fin['shower_type'][self._shower_index] != "em":
                             continue
-                    if (self._cfg['signal']['shower_type'] == "had"):
-                        if (self._fin['shower_type'][self._shower_index] != "had"):
+                    if self._cfg['signal']['shower_type'] == "had":
+                        if self._fin['shower_type'][self._shower_index] != "had":
                             continue
 
                     if particle_mode:
@@ -650,7 +656,8 @@ class simulation():
 
                             if distance > distance_cut:
                                 logger.debug('A distance speed up cut has been applied')
-                                logger.debug('Shower energy: {:.2e} eV'.format(self._fin['shower_energies'][self._shower_index] / units.eV))
+                                logger.debug('Shower energy: {:.2e} eV'.format(
+                                    self._fin['shower_energies'][self._shower_index] / units.eV))
                                 logger.debug('Distance cut: {:.2f} m'.format(distance_cut / units.m))
                                 logger.debug('Distance to vertex: {:.2f} m'.format(distance / units.m))
                                 distance_cut_time += time.time() - t_tmp
@@ -660,7 +667,7 @@ class simulation():
                         self._raytracer.set_start_and_end_point(x1, x2)
                         self._raytracer.use_optional_function('set_shower_axis', self._shower_axis)
                         # check if raytracing was already performed
-                        if (pre_simulated and ray_tracing_performed and not self._cfg['speedup']['redo_raytracing']):
+                        if pre_simulated and ray_tracing_performed and not self._cfg['speedup']['redo_raytracing']:
                             if self._cfg['propagation']['module'] == 'radiopropa':
                                 logger.error('Presimulation can not be used with the radiopropa ray tracer module')
                                 raise Exception('Presimulation can not be used with the radiopropa ray tracer module')
@@ -673,8 +680,9 @@ class simulation():
                         else:
                             self._raytracer.find_solutions()
 
-                        if (not self._raytracer.has_solution()):
-                            logger.debug("event {} and station {}, channel {} does not have any ray tracing solution ({} to {})".format(
+                        if not self._raytracer.has_solution():
+                            logger.debug(
+                                "event {} and station {}, channel {} does not have any ray tracing solution ({} to {})".format(
                                     self._event_group_id, self._station_id, channel_id, x1, x2))
                             continue
                         delta_Cs = []
@@ -695,7 +703,7 @@ class simulation():
                             delta_Cs.append(delta_C)
 
                         # discard event if delta_C (angle off cherenkov cone) is too large
-                        if (min(np.abs(delta_Cs)) > self._cfg['speedup']['delta_C_cut']):
+                        if min(np.abs(delta_Cs)) > self._cfg['speedup']['delta_C_cut']:
                             logger.debug('delta_C too large, event unlikely to be observed, skipping event')
                             continue
 
@@ -703,17 +711,18 @@ class simulation():
                         for iS in range(n):  # loop through all ray tracing solution
                             # skip individual channels where the viewing angle difference is too large
                             # discard event if delta_C (angle off cherenkov cone) is too large
-                            if (np.abs(delta_Cs[iS]) > self._cfg['speedup']['delta_C_cut']):
-                                logger.debug('delta_C too large, ray tracing solution unlikely to be observed, skipping event')
+                            if np.abs(delta_Cs[iS]) > self._cfg['speedup']['delta_C_cut']:
+                                logger.debug(
+                                    'delta_C too large, ray tracing solution unlikely to be observed, skipping event')
                                 continue
-                            if (pre_simulated and ray_tracing_performed and not self._cfg['speedup']['redo_raytracing']):
+                            if pre_simulated and ray_tracing_performed and not self._cfg['speedup']['redo_raytracing']:
                                 sg_pre = self._fin_stations["station_{:d}".format(self._station_id)]
                                 R = sg_pre['travel_distances'][self._shower_index, channel_id, iS]
                                 T = sg_pre['travel_times'][self._shower_index, channel_id, iS]
                             else:
                                 R = self._raytracer.get_path_length(iS)  # calculate path length
                                 T = self._raytracer.get_travel_time(iS)  # calculate travel time
-                                if (R is None or T is None):
+                                if R is None or T is None:
                                     continue
                             sg['travel_distances'][iSh, channel_id, iS] = R
                             sg['travel_times'][iSh, channel_id, iS] = T
@@ -726,63 +735,73 @@ class simulation():
                             # get neutrino pulse from Askaryan module
                             t_ask = time.time()
 
-                            if ("simulation_mode" not in self._fin_attrs or self._fin_attrs['simulation_mode'] == "neutrino"):
+                            if "simulation_mode" not in self._fin_attrs or self._fin_attrs['simulation_mode'] == "neutrino":
                                 # first consider in-ice showers
                                 kwargs = {}
                                 # if the input file specifies a specific shower realization, use that realization
-                                if (self._cfg['signal']['model'] in ["ARZ2019", "ARZ2020"] and "shower_realization_ARZ" in self._fin):
+                                if self._cfg['signal']['model'] in ["ARZ2019", "ARZ2020"] and "shower_realization_ARZ" in self._fin:
                                     kwargs['iN'] = self._fin['shower_realization_ARZ'][self._shower_index]
                                     logger.debug(f"reusing shower {kwargs['iN']} ARZ shower library")
-                                elif (self._cfg['signal']['model'] == "Alvarez2009" and "shower_realization_Alvarez2009" in self._fin):
+                                elif self._cfg['signal']['model'] == "Alvarez2009" and "shower_realization_Alvarez2009" in self._fin:
                                     kwargs['k_L'] = self._fin['shower_realization_Alvarez2009'][self._shower_index]
-                                    logger.debug(f"reusing k_L parameter of Alvarez2009 model of k_L = {kwargs['k_L']:.4g}")
+                                    logger.debug(
+                                        f"reusing k_L parameter of Alvarez2009 model of k_L = {kwargs['k_L']:.4g}")
                                 else:
                                     # check if the shower was already simulated (e.g. for a different channel or ray tracing solution)
-                                    if (self._cfg['signal']['model'] in ["ARZ2019", "ARZ2020"]):
-                                        if (self._sim_shower.has_parameter(shp.charge_excess_profile_id)):
-                                            kwargs = {'iN': self._sim_shower.get_parameter(shp.charge_excess_profile_id)}
-                                    if (self._cfg['signal']['model'] == "Alvarez2009"):
-                                        if (self._sim_shower.has_parameter(shp.k_L)):
+                                    if self._cfg['signal']['model'] in ["ARZ2019", "ARZ2020"]:
+                                        if self._sim_shower.has_parameter(shp.charge_excess_profile_id):
+                                            kwargs = {
+                                                'iN': self._sim_shower.get_parameter(shp.charge_excess_profile_id)}
+                                    if self._cfg['signal']['model'] == "Alvarez2009":
+                                        if self._sim_shower.has_parameter(shp.k_L):
                                             kwargs = {'k_L': self._sim_shower.get_parameter(shp.k_L)}
-                                            logger.debug(f"reusing k_L parameter of Alvarez2009 model of k_L = {kwargs['k_L']:.4g}")
+                                            logger.debug(
+                                                f"reusing k_L parameter of Alvarez2009 model of k_L = {kwargs['k_L']:.4g}")
 
                                 spectrum, additional_output = askaryan.get_frequency_spectrum(
                                     self._fin['shower_energies'][self._shower_index], viewing_angles[iS],
                                     self._n_samples, self._dt, self._fin['shower_type'][self._shower_index], n_index, R,
                                     self._cfg['signal']['model'], seed=self._cfg['seed'], full_output=True, **kwargs)
                                 # save shower realization to SimShower and hdf5 file
-                                if (self._cfg['signal']['model'] in ["ARZ2019", "ARZ2020"]):
-                                    if ('shower_realization_ARZ' not in self._mout):
+                                if self._cfg['signal']['model'] in ["ARZ2019", "ARZ2020"]:
+                                    if 'shower_realization_ARZ' not in self._mout:
                                         self._mout['shower_realization_ARZ'] = np.zeros(self._n_showers)
-                                    if (not self._sim_shower.has_parameter(shp.charge_excess_profile_id)):
-                                        self._sim_shower.set_parameter(shp.charge_excess_profile_id, additional_output['iN'])
-                                        self._mout['shower_realization_ARZ'][self._shower_index] = additional_output['iN']
-                                        logger.debug(f"setting shower profile for ARZ shower library to i = {additional_output['iN']}")
-                                if (self._cfg['signal']['model'] == "Alvarez2009"):
-                                    if ('shower_realization_Alvarez2009' not in self._mout):
+                                    if not self._sim_shower.has_parameter(shp.charge_excess_profile_id):
+                                        self._sim_shower.set_parameter(shp.charge_excess_profile_id,
+                                                                       additional_output['iN'])
+                                        self._mout['shower_realization_ARZ'][self._shower_index] = additional_output[
+                                            'iN']
+                                        logger.debug(
+                                            f"setting shower profile for ARZ shower library to i = {additional_output['iN']}")
+                                if self._cfg['signal']['model'] == "Alvarez2009":
+                                    if 'shower_realization_Alvarez2009' not in self._mout:
                                         self._mout['shower_realization_Alvarez2009'] = np.zeros(self._n_showers)
-                                    if (not self._sim_shower.has_parameter(shp.k_L)):
+                                    if not self._sim_shower.has_parameter(shp.k_L):
                                         self._sim_shower.set_parameter(shp.k_L, additional_output['k_L'])
-                                        self._mout['shower_realization_Alvarez2009'][self._shower_index] = additional_output['k_L']
-                                        logger.debug(f"setting k_L parameter of Alvarez2009 model to k_L = {additional_output['k_L']:.4g}")
+                                        self._mout['shower_realization_Alvarez2009'][self._shower_index] = \
+                                        additional_output['k_L']
+                                        logger.debug(
+                                            f"setting k_L parameter of Alvarez2009 model to k_L = {additional_output['k_L']:.4g}")
                                 askaryan_time += (time.time() - t_ask)
 
                                 polarization_direction_onsky = self._calculate_polarization_vector()
                                 cs_at_antenna = cstrans.cstrafo(*hp.cartesian_to_spherical(*receive_vector))
                                 polarization_direction_at_antenna = cs_at_antenna.transform_from_onsky_to_ground(polarization_direction_onsky)
                                 logger.debug('receive zenith {:.0f} azimuth {:.0f} polarization on sky {:.2f} {:.2f} {:.2f}, on ground @ antenna {:.2f} {:.2f} {:.2f}'.format(
-                                        zenith / units.deg, azimuth / units.deg, polarization_direction_onsky[0],
-                                        polarization_direction_onsky[1], polarization_direction_onsky[2],
-                                        *polarization_direction_at_antenna))
+                                                zenith / units.deg, azimuth / units.deg, polarization_direction_onsky[0],
+                                                polarization_direction_onsky[1], polarization_direction_onsky[2],
+                                                *polarization_direction_at_antenna))
                                 sg['polarization'][iSh, channel_id, iS] = polarization_direction_at_antenna
                                 eR, eTheta, ePhi = np.outer(polarization_direction_onsky, spectrum)
 
-                            elif (self._fin_attrs['simulation_mode'] == "emitter"):
+                            elif self._fin_attrs['simulation_mode'] == "emitter":
                                 # NuRadioMC also supports the simulation of emitters. In this case, the signal model specifies the electric field polarization
                                 amplitude = self._fin['emitter_amplitudes'][self._shower_index]
                                 # following two lines used only for few models( not for all)
-                                emitter_frequency = self._fin['emitter_frequency'][self._shower_index]  # the frequency of cw and tone_burst signal
-                                half_width = self._fin['emitter_half_width'][self._shower_index]  # defines width of square and tone_burst signals
+                                # the frequency of cw and tone_burst signal
+                                emitter_frequency = self._fin['emitter_frequency'][self._shower_index]
+                                # defines width of square and tone_burst signals
+                                half_width = self._fin['emitter_half_width'][self._shower_index]
                                 # get emitting antenna properties
                                 antenna_model = self._fin['emitter_antenna_type'][self._shower_index]
                                 antenna_pattern = self._antenna_pattern_provider.load_antenna_pattern(antenna_model)
@@ -794,16 +813,18 @@ class simulation():
                                 # source voltage given to the emitter
                                 voltage_spectrum_emitter = emitter.get_frequency_spectrum(amplitude, self._n_samples,
                                                                                           self._dt,
-                                                                                          self._fin['emitter_model'][self._shower_index],
+                                                                                          self._fin['emitter_model'][
+                                                                                              self._shower_index],
                                                                                           half_width=half_width,
                                                                                           emitter_frequency=emitter_frequency)
                                 # convolve voltage output with antenna response to obtain emitted electric field
                                 frequencies = np.fft.rfftfreq(self._n_samples, d=self._dt)
                                 zenith_emitter, azimuth_emitter = hp.cartesian_to_spherical(*self._launch_vector)
-                                VEL = antenna_pattern.get_antenna_response_vectorized(frequencies, zenith_emitter, azimuth_emitter, *ori)
+                                VEL = antenna_pattern.get_antenna_response_vectorized(frequencies, zenith_emitter,
+                                                                                      azimuth_emitter, *ori)
                                 c = constants.c * units.m / units.s
-                                eTheta = VEL['theta'] * (-1j) * voltage_spectrum_emitter * frequencies * n_index / (c)
-                                ePhi = VEL['phi'] * (-1j) * voltage_spectrum_emitter * frequencies * n_index / (c)
+                                eTheta = VEL['theta'] * (-1j) * voltage_spectrum_emitter * frequencies * n_index / c
+                                ePhi = VEL['phi'] * (-1j) * voltage_spectrum_emitter * frequencies * n_index / c
                                 eR = np.zeros_like(eTheta)
                                 # rescale amplitudes by 1/R, for emitters this is not part of the "SignalGen" class
                                 eTheta *= 1 / R
@@ -812,11 +833,12 @@ class simulation():
                                 logger.error(f"simulation mode {self._fin_attrs['simulation_mode']} unknown.")
                                 raise AttributeError(f"simulation mode {self._fin_attrs['simulation_mode']} unknown.")
 
-                            if (self._debug):
+                            if self._debug:
                                 from matplotlib import pyplot as plt
                                 fig, (ax, ax2) = plt.subplots(1, 2)
                                 ax.plot(self._ff, np.abs(eTheta) / units.micro / units.V * units.m)
-                                ax2.plot(self._tt, fft.freq2time(eTheta, 1. / self._dt) / units.micro / units.V * units.m)
+                                ax2.plot(self._tt,
+                                         fft.freq2time(eTheta, 1. / self._dt) / units.micro / units.V * units.m)
                                 ax2.set_ylabel("amplitude [$\mu$V/m]")
                                 fig.tight_layout()
                                 fig.suptitle("$E_C$ = {:.1g}eV $\Delta \Omega$ = {:.1f}deg, R = {:.0f}m".format(
@@ -826,9 +848,9 @@ class simulation():
 
                             electric_field = NuRadioReco.framework.electric_field.ElectricField([channel_id],
                                                                                                 position=self._det.get_relative_position(self._sim_station.get_id(), channel_id),
-                                                                                                shower_id= self._shower_ids[self._shower_index], ray_tracing_id=iS)
-                            if (iS is None):
-                                a = 1 / 0
+                                                                                                shower_id=self._shower_ids[self._shower_index],
+                                                                                                ray_tracing_id=iS)
+
                             electric_field.set_frequency_spectrum(np.array([eR, eTheta, ePhi]), 1. / self._dt)
                             electric_field = self._raytracer.apply_propagation_effects(electric_field, iS)
                             # Trace start time is equal to the interaction time relative to the first
@@ -865,7 +887,7 @@ class simulation():
                 # now perform first part of detector simulation -> convert each efield to voltage
                 # (i.e. apply antenna response) and apply additional simulation of signal chain (such as cable delays,
                 # amp response etc.)
-                if (not candidate_station):
+                if not candidate_station:
                     logger.debug("electric field amplitude too small in all channels, skipping to next event")
                     continue
                 t1 = time.time()
@@ -873,7 +895,7 @@ class simulation():
                 self._station.set_sim_station(self._sim_station)
 
                 # convert efields to voltages at digitizer
-                if (hasattr(self, '_detector_simulation_part1')):
+                if hasattr(self, '_detector_simulation_part1'):
                     # we give the user the opportunity to define a custom detector simulation
                     self._detector_simulation_part1()
                 else:
@@ -882,7 +904,7 @@ class simulation():
                     self._detector_simulation_filter_amp(self._evt, self._station.get_sim_station(), self._det)
                     channelAddCableDelay.run(self._evt, self._sim_station, self._det)
 
-                if (self._cfg['speedup']['amp_per_ray_solution']):
+                if self._cfg['speedup']['amp_per_ray_solution']:
                     self._channelSignalReconstructor.run(self._evt, self._station.get_sim_station(), self._det)
                     for channel in self._station.get_sim_station().iter_channels():
                         tmp_index = np.argwhere(event_indices == self._get_shower_index(channel.get_shower_id()))[0]
@@ -904,7 +926,7 @@ class simulation():
                 # print(f"delta times {delta_start_times}")
                 # print(f"split at indices {iSplit}")
                 n_sub_events = len(iSplit) + 1
-                if (n_sub_events > 1):
+                if n_sub_events > 1:
                     logger.info(f"splitting event group id {self._event_group_id} into {n_sub_events} sub events")
 
                 tmp_station = copy.deepcopy(self._station)
@@ -912,18 +934,19 @@ class simulation():
                 for iEvent in range(n_sub_events):
                     iStart = 0
                     iStop = len(channel_identifiers)
-                    if (n_sub_events > 1):
-                        if (iEvent > 0):
+                    if n_sub_events > 1:
+                        if iEvent > 0:
                             iStart = iSplit[iEvent - 1] + 1
-                    if (iEvent < n_sub_events - 1):
+                    if iEvent < n_sub_events - 1:
                         iStop = iSplit[iEvent] + 1
                     indices = start_times_sort[iStart: iStop]
-                    if (n_sub_events > 1):
+                    if n_sub_events > 1:
                         tmp = ""
                         for start_time in start_times[indices]:
                             tmp += f"{start_time / units.ns:.0f}, "
                         tmp = tmp[:-2] + " ns"
-                        logger.info(f"creating event {iEvent} of event group {self._event_group_id} ranging rom {iStart} to {iStop} with indices {indices} corresponding to signal times of {tmp}")
+                        logger.info(
+                            f"creating event {iEvent} of event group {self._event_group_id} ranging rom {iStart} to {iStop} with indices {indices} corresponding to signal times of {tmp}")
                     self._evt = NuRadioReco.framework.event.Event(self._event_group_id, iEvent)  # create new event
 
                     if particle_mode:
@@ -941,13 +964,13 @@ class simulation():
                     for iCh in indices:
                         ch_uid = channel_identifiers[iCh]
                         shower_id = ch_uid[1]
-                        if (shower_id not in self._shower_ids_of_sub_event):
+                        if shower_id not in self._shower_ids_of_sub_event:
                             self._shower_ids_of_sub_event.append(shower_id)
                         sim_station.add_channel(tmp_sim_station.get_channel(ch_uid))
                         # the efield unique identifier has as first parameter an array of the channels it is valid for
                         efield_uid = ([ch_uid[0]], ch_uid[1], ch_uid[2])
                         for efield in tmp_sim_station.get_electric_fields():
-                            if (efield.get_unique_identifier() == efield_uid):
+                            if efield.get_unique_identifier() == efield_uid:
                                 sim_station.add_electric_field(efield)
 
                     if particle_mode:
@@ -957,11 +980,11 @@ class simulation():
                     self._station.set_sim_station(sim_station)
                     self._station.set_station_time(self._evt_time)
                     self._evt.set_station(self._station)
-                    if (bool(self._cfg['signal']['zerosignal'])):
+                    if bool(self._cfg['signal']['zerosignal']):
                         self._increase_signal(None, 0)
 
                     logger.debug("performing detector simulation")
-                    if (hasattr(self, '_detector_simulation_part2')):
+                    if hasattr(self, '_detector_simulation_part2'):
                         # we give the user the opportunity to specify a custom detector simulation module sequence
                         # which might be needed for certain analyses
                         self._detector_simulation_part2()
@@ -980,7 +1003,8 @@ class simulation():
                             for channel_id in channel_ids:
                                 norm = self._bandwidth_per_channel[self._station.get_id()][channel_id]
                                 # normalize noise level to the bandwidth its generated for
-                                Vrms[channel_id] = self._Vrms_per_channel[self._station.get_id()][channel_id] / (norm / (max_freq)) ** 0.5
+                                Vrms[channel_id] = self._Vrms_per_channel[self._station.get_id()][channel_id] / (
+                                        norm / max_freq) ** 0.5
                             channelGenericNoiseAdder.run(self._evt, self._station, self._det, amplitude=Vrms,
                                                          min_freq=0 * units.MHz,
                                                          max_freq=max_freq, type='rayleigh',
@@ -989,7 +1013,7 @@ class simulation():
                         self._detector_simulation_filter_amp(self._evt, self._station, self._det)
 
                         self._detector_simulation_trigger(self._evt, self._station, self._det)
-                    if (not self._station.has_triggered()):
+                    if not self._station.has_triggered():
                         continue
 
                     event_group_has_triggered = True
@@ -998,16 +1022,19 @@ class simulation():
 
                     shower_indices_of_triggered_showers = self._get_shower_index(self._shower_ids_of_sub_event)
                     event_indices_of_triggered_shower_in_eventgroup = np.atleast_1d(np.squeeze(
-                            [np.argwhere(event_indices == gix) for gix in shower_indices_of_triggered_showers]))
+                        [np.argwhere(event_indices == gix) for gix in shower_indices_of_triggered_showers]))
 
                     self._save_triggers_to_hdf5(sg, event_indices_of_triggered_shower_in_eventgroup,
                                                 shower_indices_of_triggered_showers)
 
-                    if (self._outputfilenameNuRadioReco is not None):
+                    if self._outputfilenameNuRadioReco is not None:
                         # downsample traces to detector sampling rate to save file size
-                        channelResampler.run(self._evt, self._station, self._det, sampling_rate=self._sampling_rate_detector)
-                        channelResampler.run(self._evt, self._station.get_sim_station(), self._det, sampling_rate=self._sampling_rate_detector)
-                        electricFieldResampler.run(self._evt, self._station.get_sim_station(), self._det, sampling_rate=self._sampling_rate_detector)
+                        channelResampler.run(self._evt, self._station, self._det,
+                                             sampling_rate=self._sampling_rate_detector)
+                        channelResampler.run(self._evt, self._station.get_sim_station(), self._det,
+                                             sampling_rate=self._sampling_rate_detector)
+                        electricFieldResampler.run(self._evt, self._station.get_sim_station(), self._det,
+                                                   sampling_rate=self._sampling_rate_detector)
 
                         output_mode = {'Channels': self._cfg['output']['channel_traces'],
                                        'ElectricFields': self._cfg['output']['electric_field_traces'],
@@ -1022,10 +1049,10 @@ class simulation():
 
                 # add local sg array to output data structure if any
                 if event_group_has_triggered:
-                    if (self._station_id not in self._mout_groups):
+                    if self._station_id not in self._mout_groups:
                         self._mout_groups[self._station_id] = {}
                     for key in sg:
-                        if (key not in self._mout_groups[self._station_id]):
+                        if key not in self._mout_groups[self._station_id]:
                             self._mout_groups[self._station_id][key] = list(sg[key])
                         else:
                             self._mout_groups[self._station_id][key].extend(sg[key])
@@ -1045,7 +1072,7 @@ class simulation():
         # save simulation run in hdf5 format (only triggered events)
         t5 = time.time()
         self._write_output_file()
-        if (self._outputfilenameNuRadioReco is not None):
+        if self._outputfilenameNuRadioReco is not None:
             self._eventWriter.end()
             logger.debug("closing nur file")
 
@@ -1068,15 +1095,17 @@ class simulation():
             output_NuRadioRecoTime += f"{name}: {t} {trel:.1f}%\n"
         logger.status(output_NuRadioRecoTime)
 
-        logger.status("{:d} events processed in {} = {:.2f}ms/event ({:.1f}% input, {:.1f}% ray tracing, {:.1f}% askaryan, {:.1f}% detector simulation, {:.1f}% output, {:.1f}% weights calculation)".format(
+        logger.status(
+            "{:d} events processed in {} = {:.2f}ms/event ({:.1f}% input, {:.1f}% ray tracing, {:.1f}% askaryan, {:.1f}% detector simulation, {:.1f}% output, {:.1f}% weights calculation)".format(
                 self._n_showers,
-                pretty_time_delta(t_total), 1.e3 * t_total / self._n_showers,
-                                            100 * input_time / t_total,
-                                            100 * (rayTracingTime - askaryan_time) / t_total,
-                                            100 * askaryan_time / t_total,
-                                            100 * detSimTime / t_total,
-                                            100 * outputTime / t_total,
-                                            100 * weightTime / t_total))
+                pretty_time_delta(t_total),
+                1.e3 * t_total / self._n_showers,
+                100 * input_time / t_total,
+                100 * (rayTracingTime - askaryan_time) / t_total,
+                100 * askaryan_time / t_total,
+                100 * detSimTime / t_total,
+                100 * outputTime / t_total,
+                100 * weightTime / t_total))
         triggered = remove_duplicate_triggers(self._mout['triggered'], self._fin['event_group_ids'])
         n_triggered = np.sum(triggered)
         return n_triggered
@@ -1085,7 +1114,7 @@ class simulation():
         pass
 
     def _get_shower_index(self, shower_id):
-        if (hasattr(shower_id, "__len__")):
+        if hasattr(shower_id, "__len__"):
             return np.array([self._shower_index_array[x] for x in shower_id])
         else:
             return self._shower_index_array[shower_id]
@@ -1106,14 +1135,14 @@ class simulation():
         tt = ['fiducial_rmin', 'fiducial_rmax', 'fiducial_zmin', 'fiducial_zmax']
         has_fiducial = True
         for t in tt:
-            if (not t in self._fin_attrs):
+            if not t in self._fin_attrs:
                 has_fiducial = False
-        if (not has_fiducial):
+        if not has_fiducial:
             return True
 
         r = (self._shower_vertex[0] ** 2 + self._shower_vertex[1] ** 2) ** 0.5
-        if (r >= self._fin_attrs['fiducial_rmin'] and r <= self._fin_attrs['fiducial_rmax']):
-            if (self._shower_vertex[2] >= self._fin_attrs['fiducial_zmin'] and self._shower_vertex[2] <= self._fin_attrs['fiducial_zmax']):
+        if self._fin_attrs['fiducial_rmin'] <= r <= self._fin_attrs['fiducial_rmax']:
+            if self._fin_attrs['fiducial_zmin'] <= self._shower_vertex[2] <= self._fin_attrs['fiducial_zmax']:
                 return True
         return False
 
@@ -1127,7 +1156,7 @@ class simulation():
         channel_id: int or None
             if None, all available channels will be modified
         """
-        if (channel_id is None):
+        if channel_id is None:
             for electric_field in self._station.get_sim_station().get_electric_fields():
                 electric_field.set_trace(electric_field.get_trace() * factor,
                                          sampling_rate=electric_field.get_sampling_rate())
@@ -1171,7 +1200,7 @@ class simulation():
             return False
 
     def _calculate_signal_properties(self):
-        if (self._station.has_triggered()):
+        if self._station.has_triggered():
             self._channelSignalReconstructor.run(self._evt, self._station, self._det)
             amplitudes = np.zeros(self._station.get_number_of_channels())
             amplitudes_envelope = np.zeros(self._station.get_number_of_channels())
@@ -1182,7 +1211,7 @@ class simulation():
             self._output_maximum_amplitudes_envelope[self._station.get_id()].append(amplitudes_envelope)
 
     def _create_empty_multiple_triggers(self):
-        if ('trigger_names' not in self._mout_attrs):
+        if 'trigger_names' not in self._mout_attrs:
             self._mout_attrs['trigger_names'] = np.array([])
             self._mout['multiple_triggers'] = np.zeros((self._n_showers, 1), dtype=np.bool)
             for station_id in self._station_ids:
@@ -1192,33 +1221,33 @@ class simulation():
                 sg['triggered'] = np.zeros(n_showers, dtype=np.bool)
 
     def _create_trigger_structures(self):
-        if ('trigger_names' not in self._mout_attrs):
+        if 'trigger_names' not in self._mout_attrs:
             self._mout_attrs['trigger_names'] = []
         extend_array = False
         for trigger in six.itervalues(self._station.get_triggers()):
-            if (trigger.get_name() not in self._mout_attrs['trigger_names']):
+            if trigger.get_name() not in self._mout_attrs['trigger_names']:
                 self._mout_attrs['trigger_names'].append((trigger.get_name()))
                 extend_array = True
         # the 'multiple_triggers' output array is not initialized in the constructor because the number of
         # simulated triggers is unknown at the beginning. So we check if the key already exists and if not,
         # we first create this data structure
-        if ('multiple_triggers' not in self._mout):
+        if 'multiple_triggers' not in self._mout:
             self._mout['multiple_triggers'] = np.zeros((self._n_showers, len(self._mout_attrs['trigger_names'])),
                                                        dtype=np.bool)
         # for station_id in self._station_ids:
         #     sg = self._mout_groups[station_id]
         #     sg['multiple_triggers'] = np.zeros((self._n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
-        elif (extend_array):
+        elif extend_array:
             tmp = np.zeros((self._n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
             nx, ny = self._mout['multiple_triggers'].shape
             tmp[:, 0:ny] = self._mout['multiple_triggers']
             self._mout['multiple_triggers'] = tmp
-                # for station_id in self._station_ids:
-                #     sg = self._mout_groups[station_id]
-                #     tmp = np.zeros((self._n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
-                #     nx, ny = sg['multiple_triggers'].shape
-                #     tmp[:, 0:ny] = sg['multiple_triggers']
-                #     sg['multiple_triggers'] = tmp
+            # for station_id in self._station_ids:
+            #     sg = self._mout_groups[station_id]
+            #     tmp = np.zeros((self._n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
+            #     nx, ny = sg['multiple_triggers'].shape
+            #     tmp[:, 0:ny] = sg['multiple_triggers']
+            #     sg['multiple_triggers'] = tmp
         return extend_array
 
     def _save_triggers_to_hdf5(self, sg, event_indices_of_triggered_shower_in_eventgroup,
@@ -1229,9 +1258,9 @@ class simulation():
         # the information fo the current station and event group
         # n_showers refers to the number of triggered showers within one event group, e.g. events with the same event_group_id
         n_showers = sg['launch_vectors'].shape[0]
-        if ('multiple_triggers' not in sg):
+        if 'multiple_triggers' not in sg:
             sg['multiple_triggers'] = np.zeros((n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
-        elif (extend_array):
+        elif extend_array:
             tmp = np.zeros((n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
             nx, ny = sg['multiple_triggers'].shape
             tmp[:, 0:ny] = sg['multiple_triggers']
@@ -1241,7 +1270,7 @@ class simulation():
         self._output_sub_event_ids[self._station_id].append(self._evt.get_id())
         multiple_triggers = np.zeros(len(self._mout_attrs['trigger_names']), dtype=np.bool)
         for iT, trigger_name in enumerate(self._mout_attrs['trigger_names']):
-            if (self._station.has_trigger(trigger_name)):
+            if self._station.has_trigger(trigger_name):
                 multiple_triggers[iT] = self._station.get_trigger(trigger_name).has_triggered()
                 for iSh in event_indices_of_triggered_shower_in_eventgroup:
                     sg['multiple_triggers'][iSh][iT] = self._station.get_trigger(trigger_name).has_triggered()
@@ -1250,6 +1279,7 @@ class simulation():
             self._mout['triggered'][iSh2] |= sg['triggered'][iSh]
             self._mout['multiple_triggers'][iSh2] |= sg['multiple_triggers'][iSh]
         sg['event_id_per_shower'][event_indices_of_triggered_shower_in_eventgroup] = self._evt.get_id()
+        sg['event_group_id_per_shower'][event_indices_of_triggered_shower_in_eventgroup] = self._evt.get_run_number()
         self._output_multiple_triggers_station[self._station_id].append(multiple_triggers)
         self._output_triggered_station[self._station_id].append(np.any(multiple_triggers))
 
@@ -1267,9 +1297,9 @@ class simulation():
         checks if the same detector was simulated before (then we can save the ray tracing part)
         """
         self._was_pre_simulated = False
-        if ('detector' in self._fin_attrs):
+        if 'detector' in self._fin_attrs:
             with open(self._detectorfile, 'r') as fdet:
-                if (fdet.read() == self._fin_attrs['detector']):
+                if fdet.read() == self._fin_attrs['detector']:
                     self._was_pre_simulated = True
                     logger.status("the simulation was already performed with the same detector")
         return self._was_pre_simulated
@@ -1295,7 +1325,6 @@ class simulation():
 
         for station_id in self._station_ids:
             self._mout_groups[station_id] = {}
-            sg = self._mout_groups[station_id]
             self._output_event_group_ids[station_id] = []
             self._output_sub_event_ids[station_id] = []
             self._output_triggered_station[station_id] = []
@@ -1310,12 +1339,13 @@ class simulation():
         # we need the reference to the shower id to be able to find the correct shower in the upper level hdf5 file
         sg['shower_id'] = np.zeros(n_showers, dtype=int) * -1
         sg['event_id_per_shower'] = np.zeros(n_showers, dtype=int) * -1
+        sg['event_group_id_per_shower'] = np.zeros(n_showers, dtype=int) * -1
         sg['launch_vectors'] = np.zeros((n_showers, n_antennas, nS, 3)) * np.nan
         sg['receive_vectors'] = np.zeros((n_showers, n_antennas, nS, 3)) * np.nan
         sg['polarization'] = np.zeros((n_showers, n_antennas, nS, 3)) * np.nan
         sg['travel_times'] = np.zeros((n_showers, n_antennas, nS)) * np.nan
         sg['travel_distances'] = np.zeros((n_showers, n_antennas, nS)) * np.nan
-        if (self._cfg['speedup']['amp_per_ray_solution']):
+        if self._cfg['speedup']['amp_per_ray_solution']:
             sg['max_amp_shower_and_ray'] = np.zeros((n_showers, n_antennas, nS))
             sg['time_shower_and_ray'] = np.zeros((n_showers, n_antennas, nS))
         for parameter_entry in self._raytracer.get_output_parameters():
@@ -1392,7 +1422,7 @@ class simulation():
 
     def _write_output_file(self, empty=False):
         folder = os.path.dirname(self._outputfilename)
-        if (not os.path.exists(folder) and folder != ''):
+        if not os.path.exists(folder) and folder != '':
             logger.warning(f"output folder {folder} does not exist, creating folder...")
             os.makedirs(folder)
         fout = h5py.File(self._outputfilename, 'w')
@@ -1405,11 +1435,11 @@ class simulation():
             # a reference! saved indicates the interactions to be saved, while
             # triggered should indicate if an interaction has produced a trigger
             saved = np.copy(self._mout['triggered'])
-            if ('n_interactions' in self._fin):  # if n_interactions is not specified, there are not parents
+            if 'n_interactions' in self._fin:  # if n_interactions is not specified, there are no parents
                 parent_mask = self._fin['n_interaction'] == 1
                 for event_id in np.unique(self._fin['event_group_ids']):
                     event_mask = self._fin['event_group_ids'] == event_id
-                    if (True in self._mout['triggered'][event_mask]):
+                    if True in self._mout['triggered'][event_mask]:
                         saved[parent_mask & event_mask] = True
 
             logger.status("start saving events")
@@ -1424,11 +1454,11 @@ class simulation():
                     sg[key2] = np.array(value2)[np.array(value['triggered'])]
 
             # save "per event" quantities
-            if ('trigger_names' in self._mout_attrs):
+            if 'trigger_names' in self._mout_attrs:
                 n_triggers = len(self._mout_attrs['trigger_names'])
                 for station_id in self._mout_groups:
                     n_events_for_station = len(self._output_triggered_station[station_id])
-                    if (n_events_for_station > 0):
+                    if n_events_for_station > 0:
                         sg = fout["station_{:d}".format(station_id)]
                         sg['event_group_ids'] = np.array(self._output_event_group_ids[station_id])
                         sg['event_ids'] = np.array(self._output_sub_event_ids[station_id])
@@ -1460,10 +1490,8 @@ class simulation():
                 for i_ch, channel_id in enumerate(self._det.get_channel_ids(self._station_id)):
                     positions[i_ch] = self._det.get_relative_position(station_id, channel_id) + self._det.get_absolute_position(station_id)
                 fout["station_{:d}".format(station_id)].attrs['antenna_positions'] = positions
-                fout["station_{:d}".format(station_id)].attrs['Vrms'] = list(
-                    self._Vrms_per_channel[station_id].values())
-                fout["station_{:d}".format(station_id)].attrs['bandwidth'] = list(
-                    self._bandwidth_per_channel[station_id].values())
+                fout["station_{:d}".format(station_id)].attrs['Vrms'] = list(self._Vrms_per_channel[station_id].values())
+                fout["station_{:d}".format(station_id)].attrs['bandwidth'] = list(self._bandwidth_per_channel[station_id].values())
 
             fout.attrs.create("Tnoise", self._noise_temp, dtype=np.float)
             fout.attrs.create("Vrms", self._Vrms, dtype=np.float)
@@ -1481,9 +1509,9 @@ class simulation():
         if not empty:
             # now we also save all input parameters back into the out file
             for key in self._fin.keys():
-                if (key.startswith("station_")):
+                if key.startswith("station_"):
                     continue
-                if (not key in fout.keys()):  # only save data sets that haven't been recomputed and saved already
+                if not key in fout.keys():  # only save data sets that haven't been recomputed and saved already
                     if np.array(self._fin[key]).dtype.char == 'U':
                         fout[key] = np.array(self._fin[key], dtype=h5py.string_dtype(encoding='utf-8'))[saved]
 
@@ -1492,9 +1520,10 @@ class simulation():
 
         for key in self._fin_attrs.keys():
             # only save attributes sets that haven't been recomputed and saved already
-            if (not key in fout.attrs.keys()):
+            if not key in fout.attrs.keys():
                 # don't write trigger names from input to output file, this will lead to problems with incompatible trigger names when merging output files
-                if (key not in ["trigger_names", "Tnoise", "Vrms", "bandwidth", "n_samples", "dt", "detector", "config"]):
+                if (key not in ["trigger_names", "Tnoise", "Vrms", "bandwidth", "n_samples", "dt", "detector",
+                                "config"]):
                     fout.attrs[key] = self._fin_attrs[key]
         fout.close()
 
@@ -1504,20 +1533,22 @@ class simulation():
         n_triggered = np.sum(triggered)
         n_triggered_weighted = np.sum(self._mout['weights'][triggered])
         n_events = self._fin_attrs['n_events']
-        logger.status(f'fraction of triggered events = {n_triggered:.0f}/{n_events:.0f} = {n_triggered / self._n_showers:.3f} (sum of weights = {n_triggered_weighted:.2f})')
+        logger.status(
+            f'fraction of triggered events = {n_triggered:.0f}/{n_events:.0f} = {n_triggered / self._n_showers:.3f} (sum of weights = {n_triggered_weighted:.2f})')
         V = self._fin_attrs['volume']
         Veff = V * n_triggered_weighted / n_events
-        logger.status(f"Veff = {Veff / units.km ** 3:.4g} km^3, Veffsr = {Veff * 4 * np.pi / units.km ** 3:.4g} km^3 sr")
+        logger.status(
+            f"Veff = {Veff / units.km ** 3:.4g} km^3, Veffsr = {Veff * 4 * np.pi / units.km ** 3:.4g} km^3 sr")
 
     def _calculate_polarization_vector(self):
         """ calculates the polarization vector in spherical coordinates (eR, eTheta, ePhi)
         """
-        if (self._cfg['signal']['polarization'] == 'auto'):
+        if self._cfg['signal']['polarization'] == 'auto':
             polarization_direction = np.cross(self._launch_vector, np.cross(self._shower_axis, self._launch_vector))
             polarization_direction /= np.linalg.norm(polarization_direction)
             cs = cstrans.cstrafo(*hp.cartesian_to_spherical(*self._launch_vector))
             return cs.transform_from_ground_to_onsky(polarization_direction)
-        elif (self._cfg['signal']['polarization'] == 'custom'):
+        elif self._cfg['signal']['polarization'] == 'custom':
             ePhi = float(self._cfg['signal']['ePhi'])
             eTheta = (1 - ePhi ** 2) ** 0.5
             v = np.array([0, eTheta, ePhi])

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -224,8 +224,7 @@ class simulation():
                 'Deprecation warning: Passing the default detector station is deprecated. Default stations and default'
                 'channel should be specified in the detector description directly.'
             )
-            logger.status(
-                f"Default detector station provided (station {default_detector_station}) -> Using generic detector")
+            logger.status(f"Default detector station provided (station {default_detector_station}) -> Using generic detector")
             self._det = gdetector.GenericDetector(json_filename=self._detectorfile,
                                                   default_station=default_detector_station,
                                                   default_channel=default_detector_channel, antenna_by_depth=False)
@@ -285,9 +284,8 @@ class simulation():
 
             self._sampling_rate_detector = self._det.get_sampling_frequency(self._station_id, 0)
             #  logger.warning('internal sampling rate is {:.3g}GHz, final detector sampling rate is {:.3g}GHz'.format(self.get_sampling_rate(), self._sampling_rate_detector))
-            self._n_samples = self._det.get_number_of_samples(self._station_id,
-                                                              0) / self._sampling_rate_detector / self._dt
-            self._n_samples = int(np.ceil(self._n_samples / 2.) * 2)  # round to nearest even integer
+            self._n_samples = self._det.get_number_of_samples(self._station_id, 0) / self._sampling_rate_detector / self._dt
+            self._n_samples = int(np.ceil(self._n_samples / 2.) * 2)  # round to the nearest even integer
             self._ff = np.fft.rfftfreq(self._n_samples, self._dt)
             self._tt = np.arange(0, self._n_samples * self._dt, self._dt)
 
@@ -323,8 +321,7 @@ class simulation():
                 self._amplification_per_channel[self._station_id][channel_id] = np.abs(filt).max()
                 bandwidth = np.trapz(np.abs(filt) ** 2, ff)
                 self._bandwidth_per_channel[self._station_id][channel_id] = bandwidth
-                logger.status(
-                    f"bandwidth of station {self._station_id} channel {channel_id} is {bandwidth / units.MHz:.1f}MHz")
+                logger.status(f"bandwidth of station {self._station_id} channel {channel_id} is {bandwidth / units.MHz:.1f}MHz")
 
         ################################
 
@@ -333,8 +330,7 @@ class simulation():
         noise_temp = self._cfg['trigger']['noise_temperature']
         Vrms = self._cfg['trigger']['Vrms']
         if (noise_temp is not None and Vrms is not None):
-            raise AttributeError(
-                f"Specifying noise temperature (set to {noise_temp}) and Vrms (set to {Vrms} is not allowed.")
+            raise AttributeError(f"Specifying noise temperature (set to {noise_temp}) and Vrms (set to {Vrms} is not allowed.")
         if (noise_temp is not None):
             if (noise_temp == "detector"):
                 self._noise_temp = None  # the noise temperature is defined in the detector description
@@ -481,8 +477,7 @@ class simulation():
                     if ("weights" in self._fin):
                         self._mout['weights'] = self._fin["weights"]
                     else:
-                        logger.error(
-                            "config file specifies to use weights from the input hdf5 file but the input file does not contain this information.")
+                        logger.error("config file specifies to use weights from the input hdf5 file but the input file does not contain this information.")
                 elif (self._cfg['weights']['weight_mode'] is None):
                     self.primary[simp.weight] = 1.
                 else:
@@ -490,8 +485,7 @@ class simulation():
                                                            self.primary[simp.energy],
                                                            self.primary[simp.flavor],
                                                            mode=self._cfg['weights']['weight_mode'],
-                                                           cross_section_type=self._cfg['weights'][
-                                                               'cross_section_type'],
+                                                           cross_section_type=self._cfg['weights']['cross_section_type'],
                                                            vertex_position=self.primary[simp.vertex],
                                                            phi_nu=self.primary[simp.azimuth])
                 # all entries for the event for this primary get the calculated primary's weight
@@ -501,8 +495,7 @@ class simulation():
             # skip all events where neutrino weights is zero, i.e., do not
             # simulate neutrino that propagate through the Earth
             if (self._mout['weights'][self._primary_index] < self._cfg['speedup']['minimum_weight_cut']):
-                logger.debug("neutrino weight is smaller than {}, skipping event".format(
-                    self._cfg['speedup']['minimum_weight_cut']))
+                logger.debug("neutrino weight is smaller than {}, skipping event".format(self._cfg['speedup']['minimum_weight_cut']))
                 continue
 
             # these quantities get computed to apply the distance cut as a function of shower energies
@@ -527,13 +520,11 @@ class simulation():
                 if self._cfg['speedup']['distance_cut']:
                     # perform a quick cut to reject event group completely if no shower is close enough to the station
                     t_tmp = time.time()
-                    vertex_distances_to_station = np.linalg.norm(vertex_positions - self._station_barycenter[iSt],
-                                                                 axis=1)
+                    vertex_distances_to_station = np.linalg.norm(vertex_positions - self._station_barycenter[iSt], axis=1)
                     distance_cut = self._get_distance_cut(np.sum(shower_energies)) + 100 * units.m
                     # 100m safety margin is added to account for extent of station around bary center.
                     if vertex_distances_to_station.min() > distance_cut:
-                        logger.debug(
-                            f"skipping station {self._station_id} because minimal distance {vertex_distances_to_station.min() / units.km:.1f}km > {distance_cut / units.km:.1f}km (shower energy = {shower_energies.max():.2g}eV) bary center of station {self._station_barycenter[iSt]}")
+                        logger.debug(f"skipping station {self._station_id} because minimal distance {vertex_distances_to_station.min() / units.km:.1f}km > {distance_cut / units.km:.1f}km (shower energy = {shower_energies.max():.2g}eV) bary center of station {self._station_barycenter[iSt]}")
                         distance_cut_time += time.time() - t_tmp
                         iCounter += len(shower_energies)
                         continue
@@ -549,8 +540,7 @@ class simulation():
 
                 ray_tracing_performed = False
                 if ('station_{:d}'.format(self._station_id) in self._fin_stations):
-                    ray_tracing_performed = (self._raytracer.get_output_parameters()[0]['name'] in self._fin_stations[
-                        'station_{:d}'.format(self._station_id)]) and (self._was_pre_simulated)
+                    ray_tracing_performed = (self._raytracer.get_output_parameters()[0]['name'] in self._fin_stations['station_{:d}'.format(self._station_id)]) and (self._was_pre_simulated)
                 self._evt_tmp = NuRadioReco.framework.event.Event(0, 0)
 
                 if particle_mode:
@@ -573,8 +563,7 @@ class simulation():
                         total_time = time.time() - t_start
                         tmp_att = 0
                         if total_time > 0:
-                            logger.status(
-                                "processing event group {}/{} and shower {}/{} ({} showers triggered) = {:.1f}%, ETA {}, time consumption: ray tracing = {:.0f}%, askaryan = {:.0f}%, detector simulation = {:.0f}% reading input = {:.0f}%, calculating weights = {:.0f}%, distance cut {:.0f}%, unaccounted = {:.0f}% ".format(
+                            logger.status("processing event group {}/{} and shower {}/{} ({} showers triggered) = {:.1f}%, ETA {}, time consumption: ray tracing = {:.0f}%, askaryan = {:.0f}%, detector simulation = {:.0f}% reading input = {:.0f}%, calculating weights = {:.0f}%, distance cut {:.0f}%, unaccounted = {:.0f}% ".format(
                                     i_event_group_id,
                                     len(unique_event_group_ids),
                                     iCounter,
@@ -648,7 +637,7 @@ class simulation():
 
                     # first step: perform raytracing to see if solution exists
                     t2 = time.time()
-                    #                     input_time += (time.time() - t1)
+                    # input_time += (time.time() - t1)
 
                     for channel_id in self._det.get_channel_ids(self._station_id):
                         x2 = self._det.get_relative_position(self._station_id, channel_id) + self._det.get_absolute_position(self._station_id)
@@ -679,8 +668,7 @@ class simulation():
 
                             ray_tracing_solution = {}
                             for output_parameter in self._raytracer.get_output_parameters():
-                                ray_tracing_solution[output_parameter['name']] = sg_pre[output_parameter['name']][
-                                    self._shower_index, channel_id]
+                                ray_tracing_solution[output_parameter['name']] = sg_pre[output_parameter['name']][self._shower_index, channel_id]
                             self._raytracer.set_solution(ray_tracing_solution)
                         else:
                             self._raytracer.find_solutions()
@@ -806,15 +794,13 @@ class simulation():
                                 # source voltage given to the emitter
                                 voltage_spectrum_emitter = emitter.get_frequency_spectrum(amplitude, self._n_samples,
                                                                                           self._dt,
-                                                                                          self._fin['emitter_model'][
-                                                                                              self._shower_index],
+                                                                                          self._fin['emitter_model'][self._shower_index],
                                                                                           half_width=half_width,
                                                                                           emitter_frequency=emitter_frequency)
                                 # convolve voltage output with antenna response to obtain emitted electric field
                                 frequencies = np.fft.rfftfreq(self._n_samples, d=self._dt)
                                 zenith_emitter, azimuth_emitter = hp.cartesian_to_spherical(*self._launch_vector)
-                                VEL = antenna_pattern.get_antenna_response_vectorized(frequencies, zenith_emitter,
-                                                                                      azimuth_emitter, *ori)
+                                VEL = antenna_pattern.get_antenna_response_vectorized(frequencies, zenith_emitter, azimuth_emitter, *ori)
                                 c = constants.c * units.m / units.s
                                 eTheta = VEL['theta'] * (-1j) * voltage_spectrum_emitter * frequencies * n_index / (c)
                                 ePhi = VEL['phi'] * (-1j) * voltage_spectrum_emitter * frequencies * n_index / (c)
@@ -839,14 +825,10 @@ class simulation():
                                 plt.show()
 
                             electric_field = NuRadioReco.framework.electric_field.ElectricField([channel_id],
-                                                                                                position=self._det.get_relative_position(
-                                                                                                    self._sim_station.get_id(),
-                                                                                                    channel_id),
-                                                                                                shower_id=
-                                                                                                self._shower_ids[
-                                                                                                    self._shower_index],
-                                                                                                ray_tracing_id=iS)
+                                                                                                position=self._det.get_relative_position(self._sim_station.get_id(), channel_id),
+                                                                                                shower_id= self._shower_ids[self._shower_index], ray_tracing_id=iS)
                             if (iS is None):
+                                a = 1 / 0
                             electric_field.set_frequency_spectrum(np.array([eR, eTheta, ePhi]), 1. / self._dt)
                             electric_field = self._raytracer.apply_propagation_effects(electric_field, iS)
                             # Trace start time is equal to the interaction time relative to the first
@@ -1023,12 +1005,9 @@ class simulation():
 
                     if (self._outputfilenameNuRadioReco is not None):
                         # downsample traces to detector sampling rate to save file size
-                        channelResampler.run(self._evt, self._station, self._det,
-                                             sampling_rate=self._sampling_rate_detector)
-                        channelResampler.run(self._evt, self._station.get_sim_station(), self._det,
-                                             sampling_rate=self._sampling_rate_detector)
-                        electricFieldResampler.run(self._evt, self._station.get_sim_station(), self._det,
-                                                   sampling_rate=self._sampling_rate_detector)
+                        channelResampler.run(self._evt, self._station, self._det, sampling_rate=self._sampling_rate_detector)
+                        channelResampler.run(self._evt, self._station.get_sim_station(), self._det, sampling_rate=self._sampling_rate_detector)
+                        electricFieldResampler.run(self._evt, self._station.get_sim_station(), self._det, sampling_rate=self._sampling_rate_detector)
 
                         output_mode = {'Channels': self._cfg['output']['channel_traces'],
                                        'ElectricFields': self._cfg['output']['electric_field_traces'],
@@ -1234,12 +1213,12 @@ class simulation():
             nx, ny = self._mout['multiple_triggers'].shape
             tmp[:, 0:ny] = self._mout['multiple_triggers']
             self._mout['multiple_triggers'] = tmp
-        # for station_id in self._station_ids:
-        #     sg = self._mout_groups[station_id]
-        #     tmp = np.zeros((self._n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
-        #     nx, ny = sg['multiple_triggers'].shape
-        #     tmp[:, 0:ny] = sg['multiple_triggers']
-        #     sg['multiple_triggers'] = tmp
+                # for station_id in self._station_ids:
+                #     sg = self._mout_groups[station_id]
+                #     tmp = np.zeros((self._n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
+                #     nx, ny = sg['multiple_triggers'].shape
+                #     tmp[:, 0:ny] = sg['multiple_triggers']
+                #     sg['multiple_triggers'] = tmp
         return extend_array
 
     def _save_triggers_to_hdf5(self, sg, event_indices_of_triggered_shower_in_eventgroup,
@@ -1303,7 +1282,7 @@ class simulation():
         self._mout_attributes = {}
         self._mout['weights'] = np.zeros(self._n_showers)
         self._mout['triggered'] = np.zeros(self._n_showers, dtype=np.bool)
-        #         self._mout['multiple_triggers'] = np.zeros((self._n_showers, self._number_of_triggers), dtype=np.bool)
+        # self._mout['multiple_triggers'] = np.zeros((self._n_showers, self._number_of_triggers), dtype=np.bool)
         self._mout_attributes['trigger_names'] = None
         self._amplitudes = {}
         self._amplitudes_envelope = {}

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -354,9 +354,11 @@ class simulation():
 
                     # from elog:1566 and https://en.wikipedia.org/wiki/Johnson%E2%80%93Nyquist_noise (last Eq. in "noise voltage and power" section
                     self._Vrms_per_channel[station_id][channel_id] = (noise_temp_channel * 50 * constants.k * self._bandwidth_per_channel[station_id][channel_id] / units.Hz) ** 0.5
-                    logger.status(f'station {station_id} channel {channel_id} noise temperature = {noise_temp_channel}, bandwidth = {self._bandwidth_per_channel[station_id][channel_id] / units.MHz:.2f} MHz -> Vrms = {self._Vrms_per_channel[station_id][channel_id] / units.V / units.micro:.2f} muV')
+                    logger.status(
+                        f'station {station_id} channel {channel_id} noise temperature = {noise_temp_channel}, bandwidth = {self._bandwidth_per_channel[station_id][channel_id] / units.MHz:.2f} MHz -> Vrms = {self._Vrms_per_channel[station_id][channel_id] / units.V / units.micro:.2f} muV')
             self._Vrms = next(iter(next(iter(self._Vrms_per_channel.values())).values()))
-            logger.status('(if same bandwidth for all stations/channels is assumed:) noise temperature = {}, bandwidth = {:.2f} MHz -> Vrms = {:.2f} muV'.format(
+            logger.status(
+                '(if same bandwidth for all stations/channels is assumed:) noise temperature = {}, bandwidth = {:.2f} MHz -> Vrms = {:.2f} muV'.format(
                     self._noise_temp, self._bandwidth / units.MHz, self._Vrms / units.V / units.micro))
         elif Vrms is not None:
             self._Vrms = float(Vrms) * units.V
@@ -368,12 +370,11 @@ class simulation():
         for station_id in self._bandwidth_per_channel:
             self._Vrms_efield_per_channel[station_id] = {}
             for channel_id in self._bandwidth_per_channel[station_id]:
-                self._Vrms_efield_per_channel[station_id][channel_id] = self._Vrms_per_channel[station_id][channel_id] / \
-                                                                        self._amplification_per_channel[station_id][
-                                                                            channel_id] / units.m
+                self._Vrms_efield_per_channel[station_id][channel_id] = self._Vrms_per_channel[station_id][channel_id] / self._amplification_per_channel[station_id][channel_id] / units.m
         self._Vrms_efield = next(iter(next(iter(self._Vrms_efield_per_channel.values())).values()))
         tmp_cut = float(self._cfg['speedup']['min_efield_amplitude'])
-        logger.status(f"final Vrms {self._Vrms / units.V:.2g}V corresponds to an efield of {self._Vrms_efield / units.V / units.m / units.micro:.2g} muV/m for a VEL = 1m (amplification factor of system is {amplification:.1f}).\n -> all signals with less then {tmp_cut:.1f} x Vrms_efield = {tmp_cut * self._Vrms_efield / units.m / units.V / units.micro:.2g}muV/m will be skipped")
+        logger.status(
+            f"final Vrms {self._Vrms / units.V:.2g}V corresponds to an efield of {self._Vrms_efield / units.V / units.m / units.micro:.2g} muV/m for a VEL = 1m (amplification factor of system is {amplification:.1f}).\n -> all signals with less then {tmp_cut:.1f} x Vrms_efield = {tmp_cut * self._Vrms_efield / units.m / units.V / units.micro:.2g}muV/m will be skipped")
 
         self._distance_cut_polynomial = None
         if self._cfg['speedup']['distance_cut']:
@@ -532,7 +533,8 @@ class simulation():
                     distance_cut = self._get_distance_cut(np.sum(shower_energies)) + 100 * units.m
                     # 100m safety margin is added to account for extent of station around bary center.
                     if vertex_distances_to_station.min() > distance_cut:
-                        logger.debug(f"skipping station {self._station_id} because minimal distance {vertex_distances_to_station.min() / units.km:.1f}km > {distance_cut / units.km:.1f}km (shower energy = {shower_energies.max():.2g}eV) bary center of station {self._station_barycenter[iSt]}")
+                        logger.debug(
+                            f"skipping station {self._station_id} because minimal distance {vertex_distances_to_station.min() / units.km:.1f}km > {distance_cut / units.km:.1f}km (shower energy = {shower_energies.max():.2g}eV) bary center of station {self._station_barycenter[iSt]}")
                         distance_cut_time += time.time() - t_tmp
                         iCounter += len(shower_energies)
                         continue
@@ -569,25 +571,27 @@ class simulation():
                         total_time_sum = input_time + rayTracingTime + detSimTime + outputTime + weightTime + distance_cut_time  # askaryan time is part of the ray tracing time, so it is not counted here.
                         total_time = time.time() - t_start
                         if total_time > 0:
-                            logger.status("processing event group {}/{} and shower {}/{} ({} showers triggered) = {:.1f}%, ETA {}, time consumption: ray tracing = {:.0f}%, askaryan = {:.0f}%, detector simulation = {:.0f}% reading input = {:.0f}%, calculating weights = {:.0f}%, distance cut {:.0f}%, unaccounted = {:.0f}% ".format(
-                                            i_event_group_id,
-                                            len(unique_event_group_ids),
-                                            iCounter,
-                                            n_shower_station,
-                                            np.sum(self._mout['triggered']),
-                                            100. * iCounter / n_shower_station,
-                                            eta,
-                                            100. * (rayTracingTime - askaryan_time) / total_time,
-                                            100. * askaryan_time / total_time,
-                                            100. * detSimTime / total_time,
-                                            100. * input_time / total_time,
-                                            100. * weightTime / total_time,
-                                            100 * distance_cut_time / total_time,
-                                            100 * (total_time - total_time_sum) / total_time))
+                            logger.status(
+                                "processing event group {}/{} and shower {}/{} ({} showers triggered) = {:.1f}%, ETA {}, time consumption: ray tracing = {:.0f}%, askaryan = {:.0f}%, detector simulation = {:.0f}% reading input = {:.0f}%, calculating weights = {:.0f}%, distance cut {:.0f}%, unaccounted = {:.0f}% ".format(
+                                    i_event_group_id,
+                                    len(unique_event_group_ids),
+                                    iCounter,
+                                    n_shower_station,
+                                    np.sum(self._mout['triggered']),
+                                    100. * iCounter / n_shower_station,
+                                    eta,
+                                    100. * (rayTracingTime - askaryan_time) / total_time,
+                                    100. * askaryan_time / total_time,
+                                    100. * detSimTime / total_time,
+                                    100. * input_time / total_time,
+                                    100. * weightTime / total_time,
+                                    100 * distance_cut_time / total_time,
+                                    100 * (total_time - total_time_sum) / total_time))
 
                     self._read_input_shower_properties()
                     if particle_mode:
-                        logger.debug(f"simulating shower {self._shower_index}: {self._fin['shower_type'][self._shower_index]} with E = {self._fin['shower_energies'][self._shower_index] / units.eV:.2g}eV")
+                        logger.debug(
+                            f"simulating shower {self._shower_index}: {self._fin['shower_type'][self._shower_index]} with E = {self._fin['shower_energies'][self._shower_index] / units.eV:.2g}eV")
                     x1 = self._shower_vertex  # the interaction point
 
                     if self._cfg['speedup']['distance_cut']:
@@ -599,9 +603,11 @@ class simulation():
                         distance_to_station = np.linalg.norm(x1 - self._station_barycenter[iSt])
                         # 100m safety margin is added to account for extent of station around bary center.
                         distance_cut = self._get_distance_cut(shower_energy_sum) + 100 * units.m
-                        logger.debug(f"calculating distance cut. Current event has energy {self._fin['shower_energies'][self._shower_index]:.4g}, it is event number {iSh} and {np.sum(mask_shower_sum)} are within {self._cfg['speedup']['distance_cut_sum_length'] / units.m:.1f}m -> {shower_energy_sum:.4g}")
+                        logger.debug(
+                            f"calculating distance cut. Current event has energy {self._fin['shower_energies'][self._shower_index]:.4g}, it is event number {iSh} and {np.sum(mask_shower_sum)} are within {self._cfg['speedup']['distance_cut_sum_length'] / units.m:.1f}m -> {shower_energy_sum:.4g}")
                         if distance_to_station > distance_cut:
-                            logger.debug(f"skipping station {self._station_id} because distance {distance_to_station / units.km:.1f}km > {distance_cut / units.km:.1f}km (shower energy = {self._fin['shower_energies'][self._shower_index]:.2g}eV) between vertex {x1} and bary center of station {self._station_barycenter[iSt]}")
+                            logger.debug(
+                                f"skipping station {self._station_id} because distance {distance_to_station / units.km:.1f}km > {distance_cut / units.km:.1f}km (shower energy = {self._fin['shower_energies'][self._shower_index]:.2g}eV) between vertex {x1} and bary center of station {self._station_barycenter[iSt]}")
                             distance_cut_time += time.time() - t_tmp
                             continue
                         distance_cut_time += time.time() - t_tmp
@@ -609,7 +615,8 @@ class simulation():
                     # skip vertices not in fiducial volume. This is required because 'mother' events are added to the event list
                     # if daughters (e.g. tau decay) have their vertex in the fiducial volume
                     if not self._is_in_fiducial_volume():
-                        logger.debug(f"event is not in fiducial volume, skipping simulation {self._fin['xx'][self._shower_index]}, {self._fin['yy'][self._shower_index]}, {self._fin['zz'][self._shower_index]}")
+                        logger.debug(
+                            f"event is not in fiducial volume, skipping simulation {self._fin['xx'][self._shower_index]}, {self._fin['yy'][self._shower_index]}, {self._fin['zz'][self._shower_index]}")
                         continue
 
                     # for special cases where only EM or HAD showers are simulated, skip all events that don't fulfill this criterion
@@ -750,13 +757,11 @@ class simulation():
                                     # check if the shower was already simulated (e.g. for a different channel or ray tracing solution)
                                     if self._cfg['signal']['model'] in ["ARZ2019", "ARZ2020"]:
                                         if self._sim_shower.has_parameter(shp.charge_excess_profile_id):
-                                            kwargs = {
-                                                'iN': self._sim_shower.get_parameter(shp.charge_excess_profile_id)}
+                                            kwargs = {'iN': self._sim_shower.get_parameter(shp.charge_excess_profile_id)}
                                     if self._cfg['signal']['model'] == "Alvarez2009":
                                         if self._sim_shower.has_parameter(shp.k_L):
                                             kwargs = {'k_L': self._sim_shower.get_parameter(shp.k_L)}
-                                            logger.debug(
-                                                f"reusing k_L parameter of Alvarez2009 model of k_L = {kwargs['k_L']:.4g}")
+                                            logger.debug(f"reusing k_L parameter of Alvarez2009 model of k_L = {kwargs['k_L']:.4g}")
 
                                 spectrum, additional_output = askaryan.get_frequency_spectrum(
                                     self._fin['shower_energies'][self._shower_index], viewing_angles[iS],
@@ -767,10 +772,8 @@ class simulation():
                                     if 'shower_realization_ARZ' not in self._mout:
                                         self._mout['shower_realization_ARZ'] = np.zeros(self._n_showers)
                                     if not self._sim_shower.has_parameter(shp.charge_excess_profile_id):
-                                        self._sim_shower.set_parameter(shp.charge_excess_profile_id,
-                                                                       additional_output['iN'])
-                                        self._mout['shower_realization_ARZ'][self._shower_index] = additional_output[
-                                            'iN']
+                                        self._sim_shower.set_parameter(shp.charge_excess_profile_id, additional_output['iN'])
+                                        self._mout['shower_realization_ARZ'][self._shower_index] = additional_output['iN']
                                         logger.debug(
                                             f"setting shower profile for ARZ shower library to i = {additional_output['iN']}")
                                 if self._cfg['signal']['model'] == "Alvarez2009":
@@ -778,19 +781,20 @@ class simulation():
                                         self._mout['shower_realization_Alvarez2009'] = np.zeros(self._n_showers)
                                     if not self._sim_shower.has_parameter(shp.k_L):
                                         self._sim_shower.set_parameter(shp.k_L, additional_output['k_L'])
-                                        self._mout['shower_realization_Alvarez2009'][self._shower_index] = \
-                                        additional_output['k_L']
+                                        self._mout['shower_realization_Alvarez2009'][self._shower_index] = additional_output['k_L']
                                         logger.debug(
                                             f"setting k_L parameter of Alvarez2009 model to k_L = {additional_output['k_L']:.4g}")
                                 askaryan_time += (time.time() - t_ask)
 
                                 polarization_direction_onsky = self._calculate_polarization_vector()
                                 cs_at_antenna = cstrans.cstrafo(*hp.cartesian_to_spherical(*receive_vector))
-                                polarization_direction_at_antenna = cs_at_antenna.transform_from_onsky_to_ground(polarization_direction_onsky)
-                                logger.debug('receive zenith {:.0f} azimuth {:.0f} polarization on sky {:.2f} {:.2f} {:.2f}, on ground @ antenna {:.2f} {:.2f} {:.2f}'.format(
-                                                zenith / units.deg, azimuth / units.deg, polarization_direction_onsky[0],
-                                                polarization_direction_onsky[1], polarization_direction_onsky[2],
-                                                *polarization_direction_at_antenna))
+                                polarization_direction_at_antenna = cs_at_antenna.transform_from_onsky_to_ground(
+                                    polarization_direction_onsky)
+                                logger.debug(
+                                    'receive zenith {:.0f} azimuth {:.0f} polarization on sky {:.2f} {:.2f} {:.2f}, on ground @ antenna {:.2f} {:.2f} {:.2f}'.format(
+                                        zenith / units.deg, azimuth / units.deg, polarization_direction_onsky[0],
+                                        polarization_direction_onsky[1], polarization_direction_onsky[2],
+                                        *polarization_direction_at_antenna))
                                 sg['polarization'][iSh, channel_id, iS] = polarization_direction_at_antenna
                                 eR, eTheta, ePhi = np.outer(polarization_direction_onsky, spectrum)
 
@@ -813,8 +817,7 @@ class simulation():
                                 # source voltage given to the emitter
                                 voltage_spectrum_emitter = emitter.get_frequency_spectrum(amplitude, self._n_samples,
                                                                                           self._dt,
-                                                                                          self._fin['emitter_model'][
-                                                                                              self._shower_index],
+                                                                                          self._fin['emitter_model'][self._shower_index],
                                                                                           half_width=half_width,
                                                                                           emitter_frequency=emitter_frequency)
                                 # convolve voltage output with antenna response to obtain emitted electric field
@@ -877,7 +880,7 @@ class simulation():
                             # apply a simple threshold cut to speed up the simulation,
                             # application of antenna response will just decrease the
                             # signal amplitude
-                            if (np.max(np.abs(electric_field.get_trace())) > float(self._cfg['speedup']['min_efield_amplitude']) * self._Vrms_efield_per_channel[self._station_id][channel_id]):
+                            if np.max(np.abs(electric_field.get_trace())) > float(self._cfg['speedup']['min_efield_amplitude']) * self._Vrms_efield_per_channel[self._station_id][channel_id]:
                                 candidate_station = True
                         # end of ray tracing solutions loop
                     t3 = time.time()
@@ -1003,8 +1006,7 @@ class simulation():
                             for channel_id in channel_ids:
                                 norm = self._bandwidth_per_channel[self._station.get_id()][channel_id]
                                 # normalize noise level to the bandwidth its generated for
-                                Vrms[channel_id] = self._Vrms_per_channel[self._station.get_id()][channel_id] / (
-                                        norm / max_freq) ** 0.5
+                                Vrms[channel_id] = self._Vrms_per_channel[self._station.get_id()][channel_id] / (norm / max_freq) ** 0.5
                             channelGenericNoiseAdder.run(self._evt, self._station, self._det, amplitude=Vrms,
                                                          min_freq=0 * units.MHz,
                                                          max_freq=max_freq, type='rayleigh',
@@ -1029,12 +1031,9 @@ class simulation():
 
                     if self._outputfilenameNuRadioReco is not None:
                         # downsample traces to detector sampling rate to save file size
-                        channelResampler.run(self._evt, self._station, self._det,
-                                             sampling_rate=self._sampling_rate_detector)
-                        channelResampler.run(self._evt, self._station.get_sim_station(), self._det,
-                                             sampling_rate=self._sampling_rate_detector)
-                        electricFieldResampler.run(self._evt, self._station.get_sim_station(), self._det,
-                                                   sampling_rate=self._sampling_rate_detector)
+                        channelResampler.run(self._evt, self._station, self._det, sampling_rate=self._sampling_rate_detector)
+                        channelResampler.run(self._evt, self._station.get_sim_station(), self._det, sampling_rate=self._sampling_rate_detector)
+                        electricFieldResampler.run(self._evt, self._station.get_sim_station(), self._det, sampling_rate=self._sampling_rate_detector)
 
                         output_mode = {'Channels': self._cfg['output']['channel_traces'],
                                        'ElectricFields': self._cfg['output']['electric_field_traces'],
@@ -1234,9 +1233,9 @@ class simulation():
         if 'multiple_triggers' not in self._mout:
             self._mout['multiple_triggers'] = np.zeros((self._n_showers, len(self._mout_attrs['trigger_names'])),
                                                        dtype=np.bool)
-        # for station_id in self._station_ids:
-        #     sg = self._mout_groups[station_id]
-        #     sg['multiple_triggers'] = np.zeros((self._n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
+            # for station_id in self._station_ids:
+            #     sg = self._mout_groups[station_id]
+            #     sg['multiple_triggers'] = np.zeros((self._n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
         elif extend_array:
             tmp = np.zeros((self._n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
             nx, ny = self._mout['multiple_triggers'].shape
@@ -1490,8 +1489,10 @@ class simulation():
                 for i_ch, channel_id in enumerate(self._det.get_channel_ids(self._station_id)):
                     positions[i_ch] = self._det.get_relative_position(station_id, channel_id) + self._det.get_absolute_position(station_id)
                 fout["station_{:d}".format(station_id)].attrs['antenna_positions'] = positions
-                fout["station_{:d}".format(station_id)].attrs['Vrms'] = list(self._Vrms_per_channel[station_id].values())
-                fout["station_{:d}".format(station_id)].attrs['bandwidth'] = list(self._bandwidth_per_channel[station_id].values())
+                fout["station_{:d}".format(station_id)].attrs['Vrms'] = list(
+                    self._Vrms_per_channel[station_id].values())
+                fout["station_{:d}".format(station_id)].attrs['bandwidth'] = list(
+                    self._bandwidth_per_channel[station_id].values())
 
             fout.attrs.create("Tnoise", self._noise_temp, dtype=np.float)
             fout.attrs.create("Vrms", self._Vrms, dtype=np.float)
@@ -1522,8 +1523,8 @@ class simulation():
             # only save attributes sets that haven't been recomputed and saved already
             if not key in fout.attrs.keys():
                 # don't write trigger names from input to output file, this will lead to problems with incompatible trigger names when merging output files
-                if (key not in ["trigger_names", "Tnoise", "Vrms", "bandwidth", "n_samples", "dt", "detector",
-                                "config"]):
+                if key not in ["trigger_names", "Tnoise", "Vrms", "bandwidth", "n_samples", "dt", "detector",
+                               "config"]:
                     fout.attrs[key] = self._fin_attrs[key]
         fout.close()
 

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -1497,32 +1497,3 @@ class simulation():
             msg = "{} for config.signal.polarization is not a valid option".format(self._cfg['signal']['polarization'])
             logger.error(msg)
             raise ValueError(msg)
-        
-    def _save_triggers_to_hdf5_LP(self, sg, shower_index_sub_events):
-
-        extend_array = self._create_trigger_structures()
-        # now we also need to create the trigger structure also in the sg (station group) dictionary that contains
-        # the information fo the current station and event group
-        n_showers = sg['launch_vectors'].shape[0]
-        if ('multiple_triggers' not in sg):
-            sg['multiple_triggers'] = np.zeros((n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
-        elif (extend_array):
-            tmp = np.zeros((n_showers, len(self._mout_attrs['trigger_names'])), dtype=np.bool)
-            nx, ny = sg['multiple_triggers'].shape
-            tmp[:, 0:ny] = sg['multiple_triggers']
-            sg['multiple_triggers'] = tmp
-
-        self._output_event_group_ids[self._station_id].append(self._evt.get_run_number())
-        self._output_sub_event_ids[self._station_id].append(self._evt.get_id())
-        multiple_triggers = np.zeros(len(self._mout_attrs['trigger_names']), dtype=np.bool)
-        for iT, trigger_name in enumerate(self._mout_attrs['trigger_names']):
-            if (self._station.has_trigger(trigger_name)):
-                multiple_triggers[iT] = self._station.get_trigger(trigger_name).has_triggered()
-                for iSh in shower_index_sub_events:  # now save trigger information per shower of the current station
-                    sg['multiple_triggers'][iSh][iT] = self._station.get_trigger(trigger_name).has_triggered()
-        for iSh in shower_index_sub_events:  # now save trigger information per shower of the current station
-            sg['triggered'][iSh] = np.any(sg['multiple_triggers'][iSh])
-            self._mout['triggered'][iSh] |= sg['triggered'][iSh]
-            self._mout['multiple_triggers'][iSh] |= sg['multiple_triggers'][iSh]
-        self._output_multiple_triggers_station[self._station_id].append(multiple_triggers)
-        self._output_triggered_station[self._station_id].append(np.any(multiple_triggers))

--- a/NuRadioReco/modules/trigger/envelopeTrigger.py
+++ b/NuRadioReco/modules/trigger/envelopeTrigger.py
@@ -1,12 +1,12 @@
-from NuRadioReco.modules.base.module import register_run
-from NuRadioReco.modules.trigger.highLowThreshold import get_majority_logic
-from NuRadioReco.framework.trigger import EnvelopeTrigger
-import NuRadioReco.utilities.fft
+import logging
+import time
+
 import numpy as np
 import scipy.signal
-import copy
-import time
-import logging
+
+from NuRadioReco.framework.trigger import EnvelopeTrigger
+from NuRadioReco.modules.base.module import register_run
+from NuRadioReco.modules.trigger.highLowThreshold import get_majority_logic
 
 logger = logging.getLogger('envelopeTrigger')
 
@@ -46,7 +46,7 @@ class triggerSimulator:
     @register_run()
     def run(self, evt, station, det, passband, order, threshold, coinc_window, number_coincidences=2, triggered_channels=None, trigger_name='envelope_trigger'):
         """
-        Simulates simple threshold trigger based on an Hilbert-envelope of the trace. Passband of the trigger, coincidence
+        Simulates simple threshold trigger based on a Hilbert-envelope of the trace. Passband of the trigger, coincidence
         window within different channels should have triggered, and the number of channels needed to trigger can be specified.
 
         Parameters
@@ -89,13 +89,12 @@ class triggerSimulator:
             channel_trace_start_time = station.get_channel(triggered_channels[0]).get_trace_start_time()
 
         for channel in station.iter_channels():
-            trace = channel.get_filtered_trace(passband, 'butter', order)
-            
-            # apply envelope trigger to each channel
             channel_id = channel.get_id()
             if triggered_channels is not None and channel_id not in triggered_channels:
                 logger.debug("skipping channel {}".format(channel_id))
                 continue
+            trace = channel.get_filtered_trace(passband, 'butter', order)
+
             if channel.get_trace_start_time() != channel_trace_start_time:
                 logger.warning('Channel has a trace_start_time that differs from '
                                '        the other channels. The trigger simulator may not work properly')

--- a/NuRadioReco/modules/trigger/envelopeTrigger.py
+++ b/NuRadioReco/modules/trigger/envelopeTrigger.py
@@ -1,7 +1,6 @@
 from NuRadioReco.modules.base.module import register_run
 from NuRadioReco.modules.trigger.highLowThreshold import get_majority_logic
 from NuRadioReco.framework.trigger import EnvelopeTrigger
-import NuRadioReco.framework.base_trace as base_trace
 import NuRadioReco.utilities.fft
 import numpy as np
 import scipy.signal
@@ -29,7 +28,6 @@ def get_envelope_triggers(trace, threshold):  # define trigger constraint for ea
     triggered bins: array of bools
         the bins where the trigger condition is satisfied
     """
-
     return np.abs(scipy.signal.hilbert(trace)) > threshold
 
 
@@ -75,7 +73,6 @@ class triggerSimulator:
         trigger_name: string
             a unique name of this particular trigger
         """
-
         t = time.time()  # absolute time of system
 
         sampling_rate = station.get_channel(det.get_channel_ids(station.get_id())[0]).get_sampling_rate()
@@ -92,8 +89,8 @@ class triggerSimulator:
             channel_trace_start_time = station.get_channel(triggered_channels[0]).get_trace_start_time()
 
         for channel in station.iter_channels():
-            trace = channel.base_trace.get_filtered_trace(passband, 'butter', order)
-
+            trace = channel.get_filtered_trace(passband, 'butter', order)
+            
             # apply envelope trigger to each channel
             channel_id = channel.get_id()
             if triggered_channels is not None and channel_id not in triggered_channels:
@@ -112,7 +109,6 @@ class triggerSimulator:
 
             if True in triggered_bins:
                 channels_that_passed_trigger.append(channel.get_id())
-
         # check for coincidences with get_majority_logic(tts, number_of_coincidences=2,
         # time_coincidence=32 * units.ns, dt=1 * units.ns)
         # returns:


### PR DESCRIPTION
This PR adresses issue  #391 Wrong showers written to station_xxx substructure in .hdf5 output.
Reason for this was a wrongly defined function find_indices. This function is now replaced in line 1025.
The variables local_shower_index and global_shower_index are replaced by event_indices_of_triggered_shower_in_eventgroup and shower_indices_of_triggered_showers. They are too long, please make suggestions. 
I also added to entries to each station: 'event_id_per_shower' and 'event_group_id_per_shower' which should make it easier to match information of station level to a single particle event. 

A test to check if launch_vectors are NaN is not implemented yet.