### PR TITLE
Fix indices in simulation.py

### DIFF
--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -974,36 +974,9 @@ class simulation():
                     triggered_showers[self._station_id].extend(self._get_shower_index(self._shower_ids_of_sub_event))
                     self._calculate_signal_properties()
 
-                    def find_indices(x, y):
-                        """
-                        finds the indices for the values `x` in array `y`
-
-                        modified from https://stackoverflow.com/questions/8251541/numpy-for-every-element-in-one-array-find-the-index-in-another-array
-                        the original solution returned a masked array which also indicated the elements in y that were
-                        not available in x. We don't need that. x will be always a subset of y, and we want only the
-                        indices in y for the subset x.
-
-                        Parameters
-                        ----------
-                        x: array
-                            the values for which the indices should be found
-                        y: array
-                            the larger array with many values
-
-                        Returns: array of integers
-                        """
-
-                        index = np.argsort(x)
-                        sorted_x = x[index]
-                        sorted_index = np.searchsorted(sorted_x, y)
-
-                        yindex = np.take(index, sorted_index, mode="clip")
-                        mask = x[yindex] != y
-                        result2 = yindex[~mask]
-                        return result2
-
                     global_shower_indices = self._get_shower_index(self._shower_ids_of_sub_event)
-                    local_shower_index = find_indices(global_shower_indices, event_indices)
+                    local_shower_index = np.atleast_1d(np.squeeze(
+                        [np.argwhere(event_indices == gix) for gix in global_shower_indices]))
                     self._save_triggers_to_hdf5(sg, local_shower_index, global_shower_indices)
                     if(self._outputfilenameNuRadioReco is not None):
                         # downsample traces to detector sampling rate to save file size

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -975,8 +975,7 @@ class simulation():
                     self._calculate_signal_properties()
 
                     global_shower_indices = self._get_shower_index(self._shower_ids_of_sub_event)
-                    local_shower_index = np.atleast_1d(np.squeeze(
-                        [np.argwhere(event_indices == gix) for gix in global_shower_indices]))
+                    local_shower_index = np.atleast_1d(np.squeeze(np.argwhere(np.isin(event_indices, global_shower_indices, assume_unique=True))))
                     self._save_triggers_to_hdf5(sg, local_shower_index, global_shower_indices)
                     if(self._outputfilenameNuRadioReco is not None):
                         # downsample traces to detector sampling rate to save file size

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -1219,6 +1219,8 @@ class simulation():
             sg['triggered'][iSh] = np.any(sg['multiple_triggers'][iSh])
             self._mout['triggered'][iSh2] |= sg['triggered'][iSh]
             self._mout['multiple_triggers'][iSh2] |= sg['multiple_triggers'][iSh]
+        sg['event_id_per_shower'][local_shower_index] = self._evt.get_id()
+        sg['event_group_id_per_shower'][local_shower_index] = self._evt.get_run_number()
         self._output_multiple_triggers_station[self._station_id].append(multiple_triggers)
         self._output_triggered_station[self._station_id].append(np.any(multiple_triggers))
 
@@ -1276,7 +1278,10 @@ class simulation():
         nS = self._raytracer.get_number_of_raytracing_solutions()  # number of possible ray-tracing solutions
         sg = {}
         sg['triggered'] = np.zeros(n_showers, dtype=np.bool)
-        sg['shower_id'] = np.zeros(n_showers, dtype=int) * -1  # we need the reference to the shower id to be able to find the correct shower in the upper level hdf5 file
+        # we need the reference to the shower id to be able to find the correct shower in the upper level hdf5 file
+        sg['shower_id'] = np.zeros(n_showers, dtype=int) * -1
+        sg['event_id_per_shower'] = np.zeros(n_showers, dtype=int) * -1
+        sg['event_group_id_per_shower'] = np.zeros(n_showers, dtype=int) * -1
         sg['launch_vectors'] = np.zeros((n_showers, n_antennas, nS, 3)) * np.nan
         sg['receive_vectors'] = np.zeros((n_showers, n_antennas, nS, 3)) * np.nan
         sg['polarization'] = np.zeros((n_showers, n_antennas, nS, 3)) * np.nan


### PR DESCRIPTION
This PR addresses issue https://github.com/nu-radio/NuRadioMC/issues/391 Wrong showers written to station_xxx substructure in .hdf5 output.
Reason for this was a wrongly defined function find_indices. This function is now replaced in line 1025.
I suggest replacing the variables local_shower_index and global_shower_index are replaced by event_indices_of_triggered_shower_in_eventgroup and shower_indices_of_triggered_showers. They are too long, please make suggestions.
I also added to entries to each station: 'event_id_per_shower' and 'event_group_id_per_shower' which should make it easier to match information of station level to a single particle event.

A test to check if launch_vectors are NaN is not implemented yet.