### PR TITLE
run actions on pull requests also + move tests to ubuntu 20.04

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -8,18 +8,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@v3
     - name: Get the master branch (for checks)
-      uses: actions/checkout@v2.4.0
+      uses: actions/checkout@v3
       with:
         ref: 'refs/heads/master'
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -1,6 +1,6 @@
 name: Build and publish
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -28,11 +28,11 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
           ${{ runner.os }}-
-    
+
     - name: Install poetry
       run: |
         python -m pip install --upgrade pip
-        pip install poetry 
+        pip install poetry
       # poetry recommends using curl to install - probably doesn't make a difference though?
     - name: Check if version is updated
       run: |
@@ -47,14 +47,14 @@ jobs:
 
     - name: Build NuRadioMC # let's always build - maybe this will occasionally catch errors
       run: poetry build
-    
+
     - name: Publish distribution 📦 to Test PyPI
       if: ${{ github.ref == 'refs/heads/master'}} # only runs if the push is to master
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
-    
+
     - name: Publish distribution 📦 to PyPI
       if: ${{ github.ref == 'refs/heads/master'}} # only runs if the push is to master
       uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -1,6 +1,6 @@
 name: Build and publish
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/deploy_documentation.yaml
+++ b/.github/workflows/deploy_documentation.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - id: check
       run: |
-        output = 'false'
+        output='false'
         if [[ "${{ github.event_name }}" != pull_request]]
         then
           runtests='true'

--- a/.github/workflows/deploy_documentation.yaml
+++ b/.github/workflows/deploy_documentation.yaml
@@ -3,6 +3,7 @@ name: Deploy Documentation
 on: [push, pull_request]
 jobs:
   build:
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy_documentation.yaml
+++ b/.github/workflows/deploy_documentation.yaml
@@ -2,22 +2,40 @@ name: Deploy Documentation
 
 on: [push, pull_request]
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      runtests: ${{ steps.check.outputs.runtests }}
+    steps:
+    - id: check
+      run: |
+        output = 'false'
+        if [[ "${{ github.event_name }}" != pull_request]]
+        then
+          runtests='true'
+        elif [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]]
+        then
+          runtests='true'
+        fi
+        echo "runtests=${runtests}" >> $GITHUB_OUTPUT
+
   build:
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    needs: [prepare]
+    if: ${{ needs.prepare.outputs.runtests }}
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.4.0 # get the develop branch
+      - uses: actions/checkout@v3 # get the develop branch
         with:
           ref: 'refs/heads/develop'
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
@@ -67,7 +85,7 @@ jobs:
 
       - name: Deploy 🚀
         if: ${{ github.ref == 'refs/heads/develop'}} # only runs if the push is to develop
-        uses: JamesIves/github-pages-deploy-action@4.1.6
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: documentation/build/html # The folder the action should deploy.

--- a/.github/workflows/deploy_documentation.yaml
+++ b/.github/workflows/deploy_documentation.yaml
@@ -1,6 +1,6 @@
 name: Deploy Documentation
 
-on: push
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2.4.0 # get the develop branch
         with:
           ref: 'refs/heads/develop'
-      - uses: actions/checkout@v2.4.0        
+      - uses: actions/checkout@v2.4.0
       - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/deploy_documentation.yaml
+++ b/.github/workflows/deploy_documentation.yaml
@@ -9,19 +9,19 @@ jobs:
     steps:
     - id: check
       run: |
-        export runtests=false
-        if [[ "${{ github.event_name }}" != pull_request]]
+        output='false'
+        if [[ "${{ github.event_name }}" != pull_request ]]
         then
-          export runtests=true
+          runtests='true'
         elif [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]]
         then
-          export runtests=true
+          runtests='true'
         fi
         echo "runtests=${runtests}" >> $GITHUB_OUTPUT
 
   build:
     needs: [prepare]
-    if: ${{ needs.prepare.outputs.runtests }}
+    if: needs.prepare.outputs.runtests
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy_documentation.yaml
+++ b/.github/workflows/deploy_documentation.yaml
@@ -9,13 +9,13 @@ jobs:
     steps:
     - id: check
       run: |
-        output='false'
+        export runtests=false
         if [[ "${{ github.event_name }}" != pull_request]]
         then
-          runtests='true'
+          export runtests=true
         elif [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]]
         then
-          runtests='true'
+          export runtests=true
         fi
         echo "runtests=${runtests}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -1,11 +1,11 @@
 name: Unit tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
         python install_dev.py --install --no-interactive
         pip uninstall numba -y # easiest way to test ARZ without numba
         export PYTHONPATH=$(pwd):$PYTHONPATH
-        
+
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"
     - name: Lint with flake8 (important)
@@ -108,7 +108,7 @@ jobs:
     - name: "Test webinar examples"
       if: always()
       run: |
-        export GSLDIR=$(gsl-config --prefix) 
+        export GSLDIR=$(gsl-config --prefix)
         export PYTHONPATH=$(pwd):$PYTHONPATH
         NuRadioMC/test/examples/test_webinar.sh
     - name: "Veff test"
@@ -124,7 +124,7 @@ jobs:
         export PYTHONPATH=$(pwd):$PYTHONPATH
         NuRadioMC/test/Veff/1e18eV/test_build_noise.sh
     - name: "Atmospheric Aeff test"
-      if: always() 
+      if: always()
       run: |
         export GSLDIR=$(gsl-config --prefix)
         export PYTHONPATH=$(pwd):$PYTHONPATH

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -10,13 +10,13 @@ jobs:
     steps:
     - id: check
       run: |
-        output='false'
+        export runtests=false
         if [[ "${{ github.event_name }}" != pull_request]]
         then
-          runtests='true'
+          export runtests=true
         elif [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]]
         then
-          runtests='true'
+          export runtests=true
         fi
         echo "runtests=${runtests}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - id: check
       run: |
-        output = 'false'
+        output='false'
         if [[ "${{ github.event_name }}" != pull_request]]
         then
           runtests='true'

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -10,19 +10,19 @@ jobs:
     steps:
     - id: check
       run: |
-        export runtests=false
+        output='false'
         if [[ "${{ github.event_name }}" != pull_request ]]
         then
-          export runtests=true
+          runtests='true'
         elif [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]]
         then
-          export runtests=true
+          runtests='true'
         fi
         echo "runtests=${runtests}" >> $GITHUB_OUTPUT
 
   build:
     needs: [prepare]
-    if: ${{ needs.prepare.outputs.runtests }}
+    if: needs.prepare.outputs.runtests
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -3,18 +3,36 @@ name: Unit tests
 on: [push, pull_request]
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      runtests: ${{ steps.check.outputs.runtests }}
+    steps:
+    - id: check
+      run: |
+        output = 'false'
+        if [[ "${{ github.event_name }}" != pull_request]]
+        then
+          runtests='true'
+        elif [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]]
+        then
+          runtests='true'
+        fi
+        echo "runtests=${runtests}" >> $GITHUB_OUTPUT
+
   build:
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    needs: [prepare]
+    if: ${{ needs.prepare.outputs.runtests }}
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -11,7 +11,7 @@ jobs:
     - id: check
       run: |
         export runtests=false
-        if [[ "${{ github.event_name }}" != pull_request]]
+        if [[ "${{ github.event_name }}" != pull_request ]]
         then
           export runtests=true
         elif [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]]


### PR DESCRIPTION
see title

`ubuntu-latest` has been updated to 22.04, meaning our unit tests fail until #458 has been merged. This PR reverts the unit tests to 20.04 until that happens. We should remember to go back to `ubuntu-latest` once this is the case.

The second issue I also noticed based on #458  - our actions only run on our own branches. It's _probably_ useful to run them on PRs from forks, too? (Note that, as far as I understand, actions still will not run *by default* on PRs from forks due to the potential security risk, but anyone with write permission should be able to click a button to allow them to run in that case now).
