### PR TITLE
Fix propagation of secondary muons from tau decay in NuRadioProposal.py

### DIFF
--- a/NuRadioMC/EvtGen/NuRadioProposal.py
+++ b/NuRadioMC/EvtGen/NuRadioProposal.py
@@ -578,19 +578,13 @@ class ProposalFunctions(object):
 
             # Checking if there is a muon in the products
             if propagate_decay_muons:
-
                 decay_muons_array.append([None, None, None, None])
 
                 for sec in secondaries:
-
-                    if (sec.type not in proposal_interaction_codes) or (sec.type not in particle_names.particle_names):
-                        continue
-
-                    if (sec.particle_def == pp.particle.MuMinusDef()) or (sec.particle_def == pp.particle.MuPlusDef()):
-
-                        if sec.particle_def == pp.particle.MuMinusDef():
+                    if (sec.type == 13) or (sec.type == -13):
+                        if sec.type == 13:
                             mu_code = 13
-                        elif sec.particle_def == pp.particle.MuPlusDef():
+                        elif sec.type == -13:
                             mu_code = -13
 
                         mu_energy = sec.energy

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,7 +11,7 @@ new features:
 - add uniform ice model with 1.78 refractive index
 - update ARA detector description and add a file to Print ARA detector json file
 bugfixes:
-- fix bug in NuRadiProposal which pervented muons from tau decays to be propagated
+- fix bug in NuRadioProposal which pervented muons from tau decays to be propagated
 
 
 version 2.1.6

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ new features:
 - add uniform ice model with 1.78 refractive index
 - update ARA detector description and add a file to Print ARA detector json file
 bugfixes:
+- fix bug in NuRadiProposal which pervented muons from tau decays to be propagated
 
 
 version 2.1.6


### PR DESCRIPTION
When updating the NuRadioMC interface to PROPOSAL 7, we figured out that there was a disagreement in the energy loss spectra of taus.

After some debugging, we found out that the spectra do agree if we disable the propagation of secondary muons in the new interface, and with that, we learned that in the old version of the interface, secondary muons are not propagated at all!

This PR fixes the bug in the interface with proposal 6. The bug will also be fixed in PR #458.

### Validation plots

As a validation, these are the energy losses for the propagation of 1e5 tau leptons with an initial energy of 1e11 MeV, using the greenland configuration file.

**Current development branch:**

![image](https://user-images.githubusercontent.com/15159319/211413815-ec7fd91a-8bff-4131-ba44-993ff0090672.png)

**This PR:**

![image](https://user-images.githubusercontent.com/15159319/211413893-198544f2-27af-445e-841e-512e51d2d2b5.png)

**PR #458 (i.e. PROPOSAL version 7), with secondary muon simulation enabled**:

![image](https://user-images.githubusercontent.com/15159319/211414001-76ffb76e-b1ca-431d-a645-9044dac36c5c.png)

**PR #458 (i.e. PROPOSAL version 7), with secondary muon simulation disabled**:

![image](https://user-images.githubusercontent.com/15159319/211414036-6ec153e9-4a85-4e39-b793-fee696674bda.png)
