### PR TITLE
Modify hdf5 simulations files. 

### DIFF
--- a/NuRadioMC/EvtGen/generator.py
+++ b/NuRadioMC/EvtGen/generator.py
@@ -1370,8 +1370,8 @@ def generate_eventlist_cylinder(filename, n_events, Emin, Emax,
                                 n_interaction += 1
                                 data_sets_fiducial['shower_energies'][-1] = product.energy
                                 data_sets_fiducial['inelasticity'][-1] = np.nan
-                                # interaction_type is either 'had' or 'em' for proposal products
-                                data_sets_fiducial['interaction_type'][-1] = product.shower_type
+                                # interaction_type is particle codes taken from NuRadioProposal.py
+                                data_sets_fiducial['interaction_type'][-1] = product.code
                                 data_sets_fiducial['shower_type'][-1] = product.shower_type
 
                                 data_sets_fiducial['xx'][-1] = x
@@ -1381,8 +1381,8 @@ def generate_eventlist_cylinder(filename, n_events, Emin, Emax,
                                 # Calculating vertex interaction time with respect to the primary neutrino
                                 data_sets_fiducial['vertex_times'][-1] = vertex_time
 
-                                # Flavors are particle codes taken from NuRadioProposal.py
-                                data_sets_fiducial['flavors'][-1] = product.code
+                                # Flavors from parent lepton
+                                data_sets_fiducial['flavors'][-1] = lepton_codes[iE]
             time_proposal = time.time() - init_time
         else:
             if(n_batches == 1):

--- a/NuRadioMC/EvtGen/generator.py
+++ b/NuRadioMC/EvtGen/generator.py
@@ -1340,33 +1340,13 @@ def generate_eventlist_cylinder(filename, n_events, Emin, Emax,
                                                           [data_sets['xx'][iE], data_sets['yy'][iE], data_sets['zz'][iE]],
                                                           lepton_directions[iE])
                     if geometry_selection:
-                        products_array, leptons_energies = proposal_functions.get_secondaries_array(
+                        products_array = proposal_functions.get_secondaries_array(
                             np.array([E_all_leptons[iE]]), np.array([lepton_codes[iE]]),
                             np.array([lepton_positions[iE]]), np.array([lepton_directions[iE]]),
-                            return_lepton_energy=True,
                             propagate_decay_muons=False,
                             **proposal_kwargs)
-                        
+
                         products = products_array[0]
-                        print(len(products), len(leptons_energies))
-                        
-                        if 0:
-                            from matplotlib import pyplot as plt
-                            fig, ax = plt.subplots()
-                            
-                            energy_proxy = E_all_leptons[iE] - np.cumsum([p.energy for p in products])
-                            ax.plot(np.array(leptons_energies) * 1e6, label="parent energy")
-                            ax.plot(energy_proxy, label="primary - cum(showers)")
-    
-                            energy_proxy = np.append(E_all_leptons[iE], energy_proxy)
-                            ax.plot(energy_proxy, color="C1", ls="--", label="shifted by 1 bin")
-    
-                            ax.set_yscale("log")
-                            ax.set_xlabel("number showers")
-                            ax.set_ylabel("energy")
-                            ax.legend()
-                            fig.tight_layout()
-                            fig.savefig("lepton_energy_%d.png" % iE)
     
                         n_interaction = 2
                         for product in products:
@@ -1395,7 +1375,10 @@ def generate_eventlist_cylinder(filename, n_events, Emin, Emax,
                                 # interaction_type is particle codes taken from NuRadioProposal.py
                                 data_sets_fiducial['interaction_type'][-1] = product.code
                                 data_sets_fiducial['shower_type'][-1] = product.shower_type
-
+                                
+                                # energy of the parent lepton
+                                data_sets_fiducial['energies'][-1] = product.parent_energy
+                                
                                 data_sets_fiducial['xx'][-1] = x
                                 data_sets_fiducial['yy'][-1] = y
                                 data_sets_fiducial['zz'][-1] = z
@@ -1405,6 +1388,7 @@ def generate_eventlist_cylinder(filename, n_events, Emin, Emax,
 
                                 # Flavors from parent lepton
                                 data_sets_fiducial['flavors'][-1] = lepton_codes[iE]
+            
             time_proposal = time.time() - init_time
         else:
             if(n_batches == 1):

--- a/NuRadioMC/EvtGen/generator.py
+++ b/NuRadioMC/EvtGen/generator.py
@@ -1340,12 +1340,34 @@ def generate_eventlist_cylinder(filename, n_events, Emin, Emax,
                                                           [data_sets['xx'][iE], data_sets['yy'][iE], data_sets['zz'][iE]],
                                                           lepton_directions[iE])
                     if geometry_selection:
-                        products_array = proposal_functions.get_secondaries_array(np.array([E_all_leptons[iE]]),
-                                                                                   np.array([lepton_codes[iE]]),
-                                                                                   np.array([lepton_positions[iE]]),
-                                                                                   np.array([lepton_directions[iE]]),
-                                                                                   **proposal_kwargs)
+                        products_array, leptons_energies = proposal_functions.get_secondaries_array(
+                            np.array([E_all_leptons[iE]]), np.array([lepton_codes[iE]]),
+                            np.array([lepton_positions[iE]]), np.array([lepton_directions[iE]]),
+                            return_lepton_energy=True,
+                            propagate_decay_muons=False,
+                            **proposal_kwargs)
+                        
                         products = products_array[0]
+                        print(len(products), len(leptons_energies))
+                        
+                        if 0:
+                            from matplotlib import pyplot as plt
+                            fig, ax = plt.subplots()
+                            
+                            energy_proxy = E_all_leptons[iE] - np.cumsum([p.energy for p in products])
+                            ax.plot(np.array(leptons_energies) * 1e6, label="parent energy")
+                            ax.plot(energy_proxy, label="primary - cum(showers)")
+    
+                            energy_proxy = np.append(E_all_leptons[iE], energy_proxy)
+                            ax.plot(energy_proxy, color="C1", ls="--", label="shifted by 1 bin")
+    
+                            ax.set_yscale("log")
+                            ax.set_xlabel("number showers")
+                            ax.set_ylabel("energy")
+                            ax.legend()
+                            fig.tight_layout()
+                            fig.savefig("lepton_energy_%d.png" % iE)
+    
                         n_interaction = 2
                         for product in products:
 


### PR DESCRIPTION
The flavor contains now the type of th…e parent particle. The interaction type contains now, in case of a charge lepton, the type of energy loss.

Implement the recently contained changes to the hdf5 files: 

- [x] `flavors` contains now the PDG particle code of the parent (neutrinos or muon, tau leptons)
- [x] `interaction_type` not anymore contains the neutrino interaction type ("cc" or "nc") but can also contain the PDG code for the shower creating secondary (when a charge lepton produces a shower)
- [x] Store the parent energy (directly before energy loss) in `energies`

A few thoughts:
 - Do we want/need to bump the version number 
 - Is it a problem to store strings and int both in `interaction_type` 