### PR TITLE
Update proposal dependency to 6.1.8 to avoid problems with pypi

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ new features:
 - update ARA detector description and add a file to Print ARA detector json file
 bugfixes:
 - fix bug in NuRadioProposal which pervented muons from tau decays to be propagated
+- update proposal version to 6.1.8 to avoid problems with pypi
 
 
 version 2.1.6

--- a/documentation/source/Introduction/pages/installation.rst
+++ b/documentation/source/Introduction/pages/installation.rst
@@ -189,7 +189,7 @@ These packages are recommended to be able to use all of NuRadioMC/NuRadioReco's 
 
   .. code-block:: bash
 
-    pip install proposal==6.1.6
+    pip install proposal==6.1.8
 
 - To use the channelGalacticNoiseAdder, you need the `PyGDSM <https://github.com/telegraphic/pygdsm>`_ package.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ numba = "*"
 Sphinx = "*"
 sphinx-rtd-theme = "*"
 numpydoc = "1.1.0"
-proposal = "6.1.6"
+proposal = "6.1.8"
 pygdsm = {git = "https://github.com/telegraphic/pygdsm"}
 nifty5 = {git = "https://gitlab.mpcdf.mpg.de/ift/nifty.git", branch="NIFTy_5"}
 pypocketfft = {git = "https://gitlab.mpcdf.mpg.de/mtr/pypocketfft"}


### PR DESCRIPTION
Installing proposal 6.1.6 on ubuntu22 (and other distributions) has been problematic due to a broken submodule. See [this issue](https://github.com/tudo-astroparticlephysics/PROPOSAL/issues/331) for details, including the current workaround.

I've created a "legacy release" 6.1.8, where this issue has been fixed, so a simple `pip install proposal==6.1.8` should be working now.