### PR TITLE
Fix bug which caused that the first interaction of a triggered event …

### DIFF
--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -1370,7 +1370,7 @@ class simulation:
             # a reference! saved indicates the interactions to be saved, while
             # triggered should indicate if an interaction has produced a trigger
             saved = np.copy(self._mout['triggered'])
-            if 'n_interactions' in self._fin:  # if n_interactions is not specified, there are not parents
+            if 'n_interaction' in self._fin:  # if n_interactions is not specified, there are not parents
                 parent_mask = self._fin['n_interaction'] == 1
                 for event_id in np.unique(self._fin['event_group_ids']):
                     event_mask = self._fin['event_group_ids'] == event_id


### PR DESCRIPTION
…was not stored when the interaction ifself did not trigger

This little typo caused the issue that the first interaction was not stored even if the event triggered. 

I think such code a 'la `if "key" in f:` is dangerous and we should avoid it. Can we add this to the validation (i.e., do we validate a simulation with propagated leptons?)