### PR TITLE
Fix set_trigger_time

### DIFF
--- a/NuRadioReco/framework/trigger.py
+++ b/NuRadioReco/framework/trigger.py
@@ -81,7 +81,7 @@ class Trigger:
 
     def get_trigger_time(self):
         """
-        get the trigger time (time with respect to beginning of trace)
+        get the trigger time (time with respect to the beginning of the event, e.g. the first neutrino interaction)
         """
         return self._trigger_time
 
@@ -97,7 +97,7 @@ class Trigger:
 
     def get_trigger_times(self):
         """
-        get the trigger times (time with respect to beginning of trace)
+        get the trigger times (time with respect to beginning of trace?)
         """
         return self._trigger_times
 

--- a/NuRadioReco/framework/trigger.py
+++ b/NuRadioReco/framework/trigger.py
@@ -4,6 +4,7 @@ try:
     import cPickle as pickle
 except ImportError:
     import pickle
+import numpy as np
 
 
 def deserialize(triggers_pkl):
@@ -81,7 +82,7 @@ class Trigger:
 
     def get_trigger_time(self):
         """
-        get the trigger time (time with respect to the beginning of the event, e.g. the first neutrino interaction)
+        get the trigger time (absolute time with respect to the beginning of the event)
         """
         return self._trigger_time
 

--- a/NuRadioReco/framework/trigger.py
+++ b/NuRadioReco/framework/trigger.py
@@ -99,6 +99,8 @@ class Trigger:
         """
         get the trigger times (time with respect to beginning of trace?)
         """
+        if self._trigger_times is None and not np.isnan(self._trigger_time):
+            return np.array(self._trigger_time)
         return self._trigger_times
 
     def get_name(self):

--- a/NuRadioReco/framework/trigger.py
+++ b/NuRadioReco/framework/trigger.py
@@ -97,7 +97,7 @@ class Trigger:
 
     def get_trigger_times(self):
         """
-        get the trigger times (time with respect to beginning of trace?)
+        get the trigger times (time with respect to beginning of trace)
         """
         if self._trigger_times is None and not np.isnan(self._trigger_time):
             return np.array(self._trigger_time)

--- a/NuRadioReco/modules/phasedarray/triggerSimulator.py
+++ b/NuRadioReco/modules/phasedarray/triggerSimulator.py
@@ -569,7 +569,7 @@ class triggerSimulator:
             #trigger_time(s)= time(s) from start of trace + start time of trace with respect to moment of first interaction = trigger time from moment of first interaction; time offset to interaction time (channel_trace_start_time) already recognized in self.phased_trigger
             trigger.set_trigger_time(trigger_time)# 
             trigger.set_trigger_times(trigger_times)
-	else:
+        else:
             trigger.set_trigger_time(None)
 
         station.set_trigger(trigger)

--- a/NuRadioReco/modules/phasedarray/triggerSimulator.py
+++ b/NuRadioReco/modules/phasedarray/triggerSimulator.py
@@ -333,9 +333,9 @@ class triggerSimulator:
             the delays for the primary channels that have caused a trigger.
             If there is no trigger, it's an empty dictionary
         trigger_time: float
-            the earliest trigger time with respect to interaction time.
+            the earliest trigger time with respect to first interaction time.
         trigger_times: dictionary
-            all time bins that fulfil the trigger condition per beam. The key is the beam number. Time with respect to interaction time.
+            all time bins that fulfil the trigger condition per beam. The key is the beam number. Time with respect to first interaction time.
         """
 
         if(triggered_channels is None):
@@ -566,7 +566,7 @@ class triggerSimulator:
         trigger.set_triggered(is_triggered)
         
         if is_triggered:
-            #trigger_time(s)= time(s) from start of trace + start time of trace with respect to moment of interaction = trigger time from moment of interaction; time offset to interaction time (channel_trace_start_time) already recognized in self.phased_trigger
+            #trigger_time(s)= time(s) from start of trace + start time of trace with respect to moment of first interaction = trigger time from moment of first interaction; time offset to interaction time (channel_trace_start_time) already recognized in self.phased_trigger
             trigger.set_trigger_time(trigger_time)# 
             trigger.set_trigger_times(trigger_times)
             trigger.set_trigger_time(None)

--- a/NuRadioReco/modules/phasedarray/triggerSimulator.py
+++ b/NuRadioReco/modules/phasedarray/triggerSimulator.py
@@ -569,6 +569,7 @@ class triggerSimulator:
             #trigger_time(s)= time(s) from start of trace + start time of trace with respect to moment of first interaction = trigger time from moment of first interaction; time offset to interaction time (channel_trace_start_time) already recognized in self.phased_trigger
             trigger.set_trigger_time(trigger_time)# 
             trigger.set_trigger_times(trigger_times)
+	else:
             trigger.set_trigger_time(None)
 
         station.set_trigger(trigger)

--- a/NuRadioReco/modules/phasedarray/triggerSimulator.py
+++ b/NuRadioReco/modules/phasedarray/triggerSimulator.py
@@ -333,9 +333,9 @@ class triggerSimulator:
             the delays for the primary channels that have caused a trigger.
             If there is no trigger, it's an empty dictionary
         trigger_time: float
-            the earliest trigger time
+            the earliest trigger time with respect to interaction time.
         trigger_times: dictionary
-            all time bins that fulfil the trigger condition per beam. The key is the beam number.
+            all time bins that fulfil the trigger condition per beam. The key is the beam number. Time with respect to interaction time.
         """
 
         if(triggered_channels is None):
@@ -444,7 +444,7 @@ class triggerSimulator:
                 # logger.debug(f"trigger times  = {trigger_times[iTrace]}")
         if is_triggered:
             # logger.debug(trigger_times)
-            trigger_time = min([x.min() for x in trigger_times.values()])
+            trigger_time = min([x.min() for x in trigger_times.values()])+ channel_trace_start_time
             # logger.debug(f"minimum trigger time is {trigger_time:.0f}ns")
 
         return is_triggered, trigger_delays, trigger_time, trigger_times
@@ -564,10 +564,10 @@ class triggerSimulator:
                                       primary_angles=phasing_angles, trigger_delays=trigger_delays)
 
         trigger.set_triggered(is_triggered)
-
+        
         if is_triggered:
-            trigger.set_trigger_time(trigger_time)
-            trigger.set_trigger_times(trigger_times)
+            trigger.set_trigger_time(trigger_time)# #trigger_time= time from start of trace + start time of trace with respect to moment of interaction = trigger time from moment of interaction; time offset to interaction time (channel_trace_start_time) already recognized in self.phased_trigger
+            trigger.set_trigger_times(trigger_times) ##trigger_time= time from start of trace + start time of trace with respect to moment of interaction = trigger time from moment of interaction; time offset to interaction time (channel_trace_start_time) already recognized in self.phased_trigger
         else:
             trigger.set_trigger_time(None)
 

--- a/NuRadioReco/modules/phasedarray/triggerSimulator.py
+++ b/NuRadioReco/modules/phasedarray/triggerSimulator.py
@@ -444,7 +444,7 @@ class triggerSimulator:
                 # logger.debug(f"trigger times  = {trigger_times[iTrace]}")
         if is_triggered:
             # logger.debug(trigger_times)
-            trigger_time = min([x.min() for x in trigger_times.values()])+ channel_trace_start_time
+            trigger_time = min([x.min() for x in trigger_times.values()])
             # logger.debug(f"minimum trigger time is {trigger_time:.0f}ns")
 
         return is_triggered, trigger_delays, trigger_time, trigger_times
@@ -566,9 +566,9 @@ class triggerSimulator:
         trigger.set_triggered(is_triggered)
         
         if is_triggered:
-            trigger.set_trigger_time(trigger_time)# #trigger_time= time from start of trace + start time of trace with respect to moment of interaction = trigger time from moment of interaction; time offset to interaction time (channel_trace_start_time) already recognized in self.phased_trigger
-            trigger.set_trigger_times(trigger_times) ##trigger_time= time from start of trace + start time of trace with respect to moment of interaction = trigger time from moment of interaction; time offset to interaction time (channel_trace_start_time) already recognized in self.phased_trigger
-        else:
+            #trigger_time(s)= time(s) from start of trace + start time of trace with respect to moment of interaction = trigger time from moment of interaction; time offset to interaction time (channel_trace_start_time) already recognized in self.phased_trigger
+            trigger.set_trigger_time(trigger_time)# 
+            trigger.set_trigger_times(trigger_times)
             trigger.set_trigger_time(None)
 
         station.set_trigger(trigger)

--- a/NuRadioReco/modules/trigger/highLowThreshold.py
+++ b/NuRadioReco/modules/trigger/highLowThreshold.py
@@ -192,8 +192,8 @@ class triggerSimulator:
             logger.info("Station has NOT passed trigger")
         else:
             trigger.set_triggered(True)
-            trigger.set_trigger_time(triggered_times.min() + channel_trace_start_time)
-            trigger.set_trigger_times(triggered_times + channel_trace_start_time)
+            trigger.set_trigger_time(triggered_times.min()+channel_trace_start_time) #trigger_time= time from start of trace + start time of trace with respect to moment of interaction = trigger time from moment of interaction
+            trigger.set_trigger_times(triggered_times+channel_trace_start_time) #trigger_times= times from start of trace + start time of trace with respect to moment of interaction = trigger times from moment of interaction
             logger.info("Station has passed trigger, trigger time is {:.1f} ns".format(
                 trigger.get_trigger_time() / units.ns))
 

--- a/NuRadioReco/modules/trigger/highLowThreshold.py
+++ b/NuRadioReco/modules/trigger/highLowThreshold.py
@@ -192,8 +192,8 @@ class triggerSimulator:
             logger.info("Station has NOT passed trigger")
         else:
             trigger.set_triggered(True)
-            trigger.set_trigger_time(triggered_times.min()+channel_trace_start_time) #trigger_time= time from start of trace + start time of trace with respect to moment of interaction = trigger time from moment of interaction
-            trigger.set_trigger_times(triggered_times+channel_trace_start_time) #trigger_times= times from start of trace + start time of trace with respect to moment of interaction = trigger times from moment of interaction
+            trigger.set_trigger_time(triggered_times.min()+channel_trace_start_time) #trigger_time= time from start of trace + start time of trace with respect to moment of first interaction = trigger time from moment of first interaction
+            trigger.set_trigger_times(triggered_times+channel_trace_start_time)
             logger.info("Station has passed trigger, trigger time is {:.1f} ns".format(
                 trigger.get_trigger_time() / units.ns))
 

--- a/NuRadioReco/modules/trigger/multiHighLowThreshold.py
+++ b/NuRadioReco/modules/trigger/multiHighLowThreshold.py
@@ -173,9 +173,11 @@ class triggerSimulator:
         if not has_triggered:
             trigger.set_triggered(False)
             logger.info("Station has NOT passed trigger")
+            trigger.set_trigger_time(None)
         else:
             trigger.set_triggered(True)
             trigger.set_trigger_time(triggered_times.min() + channel_trace_start_time)
+            #trigger_time= earliest trigger_time from start of trace + start time of trace with respect to moment of interaction = trigger time from moment of interaction
             logger.info("Station has passed trigger, trigger time is {:.1f} ns".format(
                 trigger.get_trigger_time() / units.ns))
 

--- a/NuRadioReco/modules/trigger/multiHighLowThreshold.py
+++ b/NuRadioReco/modules/trigger/multiHighLowThreshold.py
@@ -176,7 +176,7 @@ class triggerSimulator:
         else:
             trigger.set_triggered(True)
             trigger.set_trigger_time(triggered_times.min() + channel_trace_start_time)
-            #trigger_time= earliest trigger_time from start of trace + start time of trace with respect to moment of interaction = trigger time from moment of interaction
+            #trigger_time= earliest trigger_time from start of trace + start time of trace with respect to moment of fist interaction = trigger time from moment of first interaction
             logger.info("Station has passed trigger, trigger time is {:.1f} ns".format(
                 trigger.get_trigger_time() / units.ns))
 

--- a/NuRadioReco/modules/trigger/multiHighLowThreshold.py
+++ b/NuRadioReco/modules/trigger/multiHighLowThreshold.py
@@ -173,7 +173,6 @@ class triggerSimulator:
         if not has_triggered:
             trigger.set_triggered(False)
             logger.info("Station has NOT passed trigger")
-            trigger.set_trigger_time(None)
         else:
             trigger.set_triggered(True)
             trigger.set_trigger_time(triggered_times.min() + channel_trace_start_time)

--- a/NuRadioReco/modules/trigger/powerIntegration.py
+++ b/NuRadioReco/modules/trigger/powerIntegration.py
@@ -131,7 +131,6 @@ class triggerSimulator:
             logger.debug("station has triggered")
         else:
             trigger.set_triggered(False)
-            trigger.set_trigger_time(None)
             logger.debug("station has NOT triggered")
         station.set_trigger(trigger)
 

--- a/NuRadioReco/modules/trigger/powerIntegration.py
+++ b/NuRadioReco/modules/trigger/powerIntegration.py
@@ -131,6 +131,7 @@ class triggerSimulator:
             logger.debug("station has triggered")
         else:
             trigger.set_triggered(False)
+            trigger.set_trigger_time(None)
             logger.debug("station has NOT triggered")
         station.set_trigger(trigger)
 

--- a/NuRadioReco/modules/trigger/rnog_surface_trigger.py
+++ b/NuRadioReco/modules/trigger/rnog_surface_trigger.py
@@ -183,7 +183,7 @@ class triggerSimulator:
 
         if has_triggered:
             trigger.set_triggered(True)
-            trigger.set_trigger_time(triggered_times.min()+channel_trace_start_time)  # trigger_time = time from moment of interaction
+            trigger.set_trigger_time(triggered_times.min()+channel_trace_start_time)  # trigger_time = time from moment of first interaction
             logger.debug("station has triggered")
 
         else:

--- a/NuRadioReco/modules/trigger/rnog_surface_trigger.py
+++ b/NuRadioReco/modules/trigger/rnog_surface_trigger.py
@@ -183,7 +183,7 @@ class triggerSimulator:
 
         if has_triggered:
             trigger.set_triggered(True)
-            trigger.set_trigger_time(triggered_times.min() + channel_trace_start_time)  # trigger_time = time from the beginning of the trace
+            trigger.set_trigger_time(triggered_times.min()+channel_trace_start_time)  # trigger_time = time from moment of interaction
             logger.debug("station has triggered")
 
         else:

--- a/NuRadioReco/modules/trigger/simpleThreshold.py
+++ b/NuRadioReco/modules/trigger/simpleThreshold.py
@@ -116,7 +116,7 @@ class triggerSimulator:
             trigger.set_trigger_time(triggered_times.min() + channel_trace_start_time) #trigger_time= earliest trigger_time from start of trace + start time of trace with respect to moment of interaction = trigger time from moment of interaction
             self.logger.debug("station has triggered")
         else:
-            trigger.set_triggered(False)s
+            trigger.set_triggered(False)
             self.logger.debug("station has NOT triggered")
         station.set_trigger(trigger)
 

--- a/NuRadioReco/modules/trigger/simpleThreshold.py
+++ b/NuRadioReco/modules/trigger/simpleThreshold.py
@@ -116,8 +116,7 @@ class triggerSimulator:
             trigger.set_trigger_time(triggered_times.min() + channel_trace_start_time) #trigger_time= earliest trigger_time from start of trace + start time of trace with respect to moment of interaction = trigger time from moment of interaction
             self.logger.debug("station has triggered")
         else:
-            trigger.set_triggered(False)
-            trigger.set_trigger_time(None)
+            trigger.set_triggered(False)s
             self.logger.debug("station has NOT triggered")
         station.set_trigger(trigger)
 

--- a/NuRadioReco/modules/trigger/simpleThreshold.py
+++ b/NuRadioReco/modules/trigger/simpleThreshold.py
@@ -113,10 +113,11 @@ class triggerSimulator:
         trigger.set_triggered_channels(channels_that_passed_trigger)
         if has_triggered:
             trigger.set_triggered(True)
-            trigger.set_trigger_time(triggered_times.min() + channel_trace_start_time)
+            trigger.set_trigger_time(triggered_times.min() + channel_trace_start_time) #trigger_time= earliest trigger_time from start of trace + start time of trace with respect to moment of interaction = trigger time from moment of interaction
             self.logger.debug("station has triggered")
         else:
             trigger.set_triggered(False)
+            trigger.set_trigger_time(None)
             self.logger.debug("station has NOT triggered")
         station.set_trigger(trigger)
 

--- a/NuRadioReco/modules/trigger/simpleThreshold.py
+++ b/NuRadioReco/modules/trigger/simpleThreshold.py
@@ -113,7 +113,7 @@ class triggerSimulator:
         trigger.set_triggered_channels(channels_that_passed_trigger)
         if has_triggered:
             trigger.set_triggered(True)
-            trigger.set_trigger_time(triggered_times.min() + channel_trace_start_time) #trigger_time= earliest trigger_time from start of trace + start time of trace with respect to moment of interaction = trigger time from moment of interaction
+            trigger.set_trigger_time(triggered_times.min() + channel_trace_start_time) #trigger_time= earliest trigger_time from start of trace + start time of trace with respect to moment of first interaction = trigger time from moment of first interaction
             self.logger.debug("station has triggered")
         else:
             trigger.set_triggered(False)

--- a/documentation/source/NuRadioMC/pages/Manuals/event_generation.rst
+++ b/documentation/source/NuRadioMC/pages/Manuals/event_generation.rst
@@ -379,8 +379,7 @@ The module ``NuRadioProposal.py`` in EvtGen can also be used standalone to study
         tau_codes = [15] * N_taus
 
         secondaries_array = proposal_functions.get_secondaries_array(energy_leptons,
-                                                 lepton_codes,
-                                                 config_file='InfIce',
+                                                 tau_codes,
                                                  low_nu=0.1*units.PeV,
                                                  propagate_decay_muons=True)
 


### PR DESCRIPTION
Change of `set_trigger_time` such that it is always in relation to the time of interaction and not (as previously in some cases and in the documentation) with respect to the beginning of the trace.

Additionally I fixed two typos in the **NuRadioProposal as a standalone module** example, I came across.