### PR TITLE
Update tests and install_dev script

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -1,6 +1,6 @@
 name: Build and publish
 
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/deploy_documentation.yaml
+++ b/.github/workflows/deploy_documentation.yaml
@@ -1,6 +1,6 @@
 name: Deploy Documentation
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -1,6 +1,6 @@
 name: Unit tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   prepare:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -23,7 +23,7 @@ jobs:
   build:
     needs: [prepare]
     if: needs.prepare.outputs.runtests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/install_dev.py
+++ b/install_dev.py
@@ -139,6 +139,7 @@ if __name__ == "__main__":
 
     top_dir = os.path.dirname(os.path.realpath(__file__))
     os.chdir(top_dir) # change CWD to repository root
+    retcode = 0
 
     if '.git' in os.listdir(top_dir): # check that we are in a git repository
         ### Install dependencies
@@ -151,7 +152,7 @@ if __name__ == "__main__":
             # print("Installing poetry...")
             # subprocess.call([sys.executable, "-m", "pip", "install", "poetry"])
             # subprocess.call(["poetry", "install", "--no-root"])
-            subprocess.call([sys.executable, '-m', 'pip', 'install', 'toml']+ pip_install_as_user) # we need toml to read pyproject.toml
+            retcode |= subprocess.call([sys.executable, '-m', 'pip', 'install', 'toml']+ pip_install_as_user) # we need toml to read pyproject.toml
             import toml
             toml_dict = toml.load(os.path.join(top_dir, 'pyproject.toml'))
             reqs = toml_dict['tool']['poetry']['dependencies']
@@ -161,7 +162,7 @@ if __name__ == "__main__":
             with tempfile.NamedTemporaryFile(mode='w+t') as req_txt: # make a temporary requirements.txt
                 req_txt.writelines('\n'.join(reqs_pip))
                 req_txt.seek(0)
-                subprocess.call([sys.executable, '-m', 'pip', 'install', '-r', req_txt.name] + pip_install_as_user)
+                retcode |= subprocess.call([sys.executable, '-m', 'pip', 'install', '-r', req_txt.name] + pip_install_as_user)
         
         ### Install optional / dev dependencies
         install_dev_dependencies = yesno_input(
@@ -171,7 +172,7 @@ if __name__ == "__main__":
             try:
                 import toml
             except ImportError:
-                subprocess.call([sys.executable, '-m', 'pip', 'install', 'toml'] + pip_install_as_user) # we need toml to read pyproject.toml
+                retcode |= subprocess.call([sys.executable, '-m', 'pip', 'install', 'toml'] + pip_install_as_user) # we need toml to read pyproject.toml
                 import toml
             toml_dict = toml.load(os.path.join(top_dir, 'pyproject.toml'))
             reqs = toml_dict['tool']['poetry']['dev-dependencies']
@@ -230,7 +231,7 @@ if __name__ == "__main__":
             with tempfile.NamedTemporaryFile(mode='w+t') as req_txt: # make a temporary requirements.txt
                 req_txt.writelines('\n'.join(reqs_pip))
                 req_txt.seek(0)
-                subprocess.call([sys.executable, '-m', 'pip', 'install', '-r', req_txt.name] + pip_install_as_user)
+                retcode |= subprocess.call([sys.executable, '-m', 'pip', 'install', '-r', req_txt.name] + pip_install_as_user)
 
         ### Add NuRadioMC to PYTHONPATH in .bashrc, if not already available
         try:
@@ -270,7 +271,7 @@ if __name__ == "__main__":
                 write_pre_commit_hook = yesno_input("Custom pre-commit file already present at {}. Overwrite?".format(new_file), skip=args['git_hook'])
         if write_pre_commit_hook:
             shutil.copy(old_file, new_file)
-            subprocess.call(['chmod', '+x', new_file])
+            retcode |= subprocess.call(['chmod', '+x', new_file])
             print('Successfully installed pre-commit hook at {}'.format(new_file))
     else:
         msg = (
@@ -279,3 +280,5 @@ if __name__ == "__main__":
             'instructions at https://nu-radio.github.io/NuRadioMC/Introduction/pages/installation.html#manual-installation'
         )
         print(msg)
+
+    sys.exit(retcode)


### PR DESCRIPTION
Minor changes to the tests:
- Update to latest Ubuntu again, now that proposal can be pip installed on it... (although we seem to have a new issue now), closes #471 
- Include `workflow_dispatch` hook in tests, so they can all be manually launched from the Actions tab
- Update `install_dev.py` such that it raises an error if an error occurs during dependency installation. Previously, these errors would be ignored, making troubleshooting the tests harder. (Sorry @fschlueter - I didn't see you had also fixed this, feel free to change to your implementation if you prefer).
