### PR TITLE
modify event.get_station() to return the first and only station of no…

### DIFF
--- a/NuRadioReco/framework/event.py
+++ b/NuRadioReco/framework/event.py
@@ -132,15 +132,15 @@ class Event:
         """
         Returns the station for a given station id.
 
-        Paramters
-        ---------
+        Parameters
+        ----------
 
         station_id: int
             Id of the station you want to get. If None and event has only one station
             return it, otherwise raise error. (Default: None)
 
-        Return
-        ------
+        Returns
+        -------
 
         station: NuRadioReco.framework.station
         """

--- a/NuRadioReco/framework/event.py
+++ b/NuRadioReco/framework/event.py
@@ -128,7 +128,30 @@ class Event:
     def get_run_number(self):
         return self.__run_number
 
-    def get_station(self, station_id):
+    def get_station(self, station_id=None):
+        """
+        Returns the station for a given station id.
+
+        Paramters
+        ---------
+
+        station_id: int
+            Id of the station you want to get. If None and event has only one station
+            return it, otherwise raise error. (Default: None)
+
+        Return
+        ------
+
+        station: NuRadioReco.framework.station
+        """
+        if station_id is None:
+            if len(self.get_station_ids()) == 1:
+                return self.__stations[self.get_station_ids()[0]]
+            else:
+                err = "Event has more than one station, you have to specify \"station_id\""
+                logger.error(err)
+                raise ValueError(err)
+
         return self.__stations[station_id]
 
     def get_stations(self):


### PR DESCRIPTION
… station id is given

The idea is to avoid code like:

```
for station in evt.get_stations():
   ....
```
or worse 
```
station = evt.get_station(evt.get_station_ids()[0])
```
if it is clear that the event has only one station (which is typically the case ?!)

What do you think about that? Unnecessary? 


