### PR TITLE
Fix Actions / temporarily switch to git version of proposal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ numba = "*"
 Sphinx = "*"
 sphinx-rtd-theme = "*"
 numpydoc = "1.1.0"
-proposal = "7.5.0"
+proposal = {git = "https://github.com/tudo-astroparticlephysics/PROPOSAL.git", rev="b95628a"}
 pygdsm = {git = "https://github.com/telegraphic/pygdsm"}
 nifty5 = {git = "https://gitlab.mpcdf.mpg.de/ift/nifty.git", branch="NIFTy_5"}
 pypocketfft = {git = "https://gitlab.mpcdf.mpg.de/mtr/pypocketfft"}


### PR DESCRIPTION
See #494
 
Seeing as so many people are actively working on stuff, this was a simple one-line change, and I don't want to end up having to fix a load of docstrings next week - this PR changes the proposal version to the [current version of the master branch](https://github.com/tudo-astroparticlephysics/PROPOSAL/commit/b95628a57befe9650ab6bb3c8ce21442880ea382) which enables it to be pip installed again, such that the tests can run again.

Once the proposal pypi release has been updated, we can switch back to that. 