### PR TITLE
return useful debug message if .nur file is empty

### DIFF
--- a/NuRadioReco/modules/io/NuRadioRecoio.py
+++ b/NuRadioReco/modules/io/NuRadioRecoio.py
@@ -105,8 +105,14 @@ class NuRadioRecoio(object):
                 f"but current version is {VERSION}.{VERSION_MINOR}. "
                 f"This might indicate the file is empty. The file size is {os.stat(self._filenames[iF]).st_size} B.")
 
+        elif (self.__file_version > VERSION):
+            self.logger.error(
+                f"File might be corrupt, file has version {self.__file_version}.{self.__file_version} "
+                f"but current version is {VERSION}.{VERSION_MINOR}. "
+                f"This might indicate the file is empty. The file size is {os.stat(self._filenames[iF]).st_size} B.")
 
-        elif(self.__file_version != VERSION):
+
+        elif(self.__file_version == 1):
             self.logger.error(
                 "data file not readable. File has version {}.{} but current version is {}.{}".format(
                     self.__file_version,

--- a/NuRadioReco/modules/io/NuRadioRecoio.py
+++ b/NuRadioReco/modules/io/NuRadioRecoio.py
@@ -6,6 +6,7 @@ import NuRadioReco.modules.io.event_parser_factory
 import numpy as np
 import logging
 import time
+import os
 
 VERSION = 2
 VERSION_MINOR = 2
@@ -97,7 +98,15 @@ class NuRadioRecoio(object):
     def __check_file_version(self, iF):
         self.__file_version = int.from_bytes(self._get_file(iF).read(6), 'little')
         self.__file_version_minor = int.from_bytes(self._get_file(iF).read(6), 'little')
-        if(self.__file_version != VERSION):
+
+        if (self.__file_version == 0):
+            self.logger.error(
+                f"File might be corrupt, file has version {self.__file_version}.{self.__file_version} "
+                f"but current version is {VERSION}.{VERSION_MINOR}. "
+                f"This might indicate the file is empty. The file size is {os.stat(self._filenames[iF]).st_size} B.")
+
+
+        elif(self.__file_version != VERSION):
             self.logger.error(
                 "data file not readable. File has version {}.{} but current version is {}.{}".format(
                     self.__file_version,
@@ -108,9 +117,9 @@ class NuRadioRecoio(object):
             )
             if(self.__fail_on_version_mismatch):
                 raise IOError
-        if(self.__file_version_minor != VERSION_MINOR):
+        elif(self.__file_version_minor != VERSION_MINOR):
             self.logger.error(
-                "data file might not readable. File has version {}.{} but current version is {}.{}".format(
+                "Data file might not readable, File has version {}.{} but current version is {}.{}".format(
                     self.__file_version,
                     self.__file_version_minor,
                     VERSION,

--- a/NuRadioReco/modules/io/event_parser_factory.py
+++ b/NuRadioReco/modules/io/event_parser_factory.py
@@ -126,8 +126,11 @@ def scan_files_function(version_major, version_minor):
             return scan_files_2_0
         else:
             return scan_files_2_2
+    elif version_major == 0:
+        raise ValueError(f'File version is {version_major}.{version_major} which might indicate the file is empty')
     else:
-        raise ValueError('File version {}.{} is not supported. Major version needs to be 2 but is {}'.format(version_major, version_minor, version_major))
+        raise ValueError('File version {}.{} is not supported. Major version needs to be 2 but is {}.'.format(version_major, version_minor, version_major))
+
 
 
 def iter_events_function(version_major, version_minor):
@@ -185,5 +188,7 @@ def iter_events_function(version_major, version_minor):
             return iter_events_2_0
         else:
             return iter_events_2_2
+    elif version_major == 0:
+        raise ValueError(f'File version is {version_major}.{version_major} which might indicate the file is empty')
     else:
         raise ValueError('File version {}.{} is not supported. Major version needs to be 2 but is {}'.format(version_major, version_minor, version_major))


### PR DESCRIPTION
Here is the cleaned up PR (before #476)

I added a file size check in NuRadioReco/modules/io/NuRadioRecoio.py and added an elif for version 0.0 in NuRadioReco/modules/io/event_parser_factory.py. Please contribute if you have more ideas.


@christophwelling wrote:
Could you make this more robust and also check if the file version is a reasonable number?
The reason is that if NuRadioReco tries to read in a corrupted file, it often interprets some random byte as the version, which often results in very weird version numbers.
So could you check if abs(self.__file_version) <= VERSION and give out a warning that the file is probably corrupted otherwise?
