### PR TITLE
Minor updates to documentation

### DIFF
--- a/NuRadioReco/framework/parameters.py
+++ b/NuRadioReco/framework/parameters.py
@@ -1,164 +1,170 @@
+"""
+Provides an interface to store simulated and reconstructed quantities
+
+The parameters module provides access to store and read simulated or 
+reconstructed quantities in the different custom classes used in NuRadioMC.
+
+"""
+
 from aenum import Enum
 
 
 class stationParameters(Enum):
-    nu_zenith = 1  # the zenith angle of the incoming neutrino direction
-    nu_azimuth = 2  # the azimuth angle of the incoming neutrino direction
-    nu_energy = 3  # the energy of the neutrino
-    nu_flavor = 4  # the flavor of the neutrino
-    ccnc = 5  # neutral current of charged current interaction
-    nu_vertex = 6  # the neutrino vertex position
-    inelasticity = 7  # inelasticity ot neutrino interaction
-    triggered = 8  # flag if station was triggered or not
-    cr_energy = 9  # the cosmic-ray energy
-    cr_zenith = 10  # zenith angle of the cosmic-ray incoming direction
-    cr_azimuth = 11  # azimuth angle of the cosmic-ray incoming direction
-    channels_max_amplitude = 12  # the maximum amplitude of all channels (considered in the trigger module)
-    zenith = 13  # the zenith angle of the incoming signal direction (WARNING: this parameter is not well defined as the incoming signal direction might be different for different channels)
-    azimuth = 14  # the azimuth angle of the incoming signal direction (WARNING: this parameter is not well defined as the incoming signal direction might be different for different channels)
+    nu_zenith = 1  #: the zenith angle of the incoming neutrino direction
+    nu_azimuth = 2  #: the azimuth angle of the incoming neutrino direction
+    nu_energy = 3  #: the energy of the neutrino
+    nu_flavor = 4  #: the flavor of the neutrino
+    ccnc = 5  #: neutral current of charged current interaction
+    nu_vertex = 6  #: the neutrino vertex position
+    inelasticity = 7  #: inelasticity ot neutrino interaction
+    triggered = 8  #: flag if station was triggered or not
+    cr_energy = 9  #: the cosmic-ray energy
+    cr_zenith = 10  #: zenith angle of the cosmic-ray incoming direction
+    cr_azimuth = 11  #: azimuth angle of the cosmic-ray incoming direction
+    channels_max_amplitude = 12  #: the maximum amplitude of all channels (considered in the trigger module)
+    zenith = 13  #: the zenith angle of the incoming signal direction (WARNING: this parameter is not well defined as the incoming signal direction might be different for different channels)
+    azimuth = 14  #: the azimuth angle of the incoming signal direction (WARNING: this parameter is not well defined as the incoming signal direction might be different for different channels)
     zenith_cr_templatefit = 15
     zenith_nu_templatefit = 16
-    cr_xcorrelations = 19  # dict of result of crosscorrelations with cr templates
-    nu_xcorrelations = 20  # dict of result of crosscorrelations with nu templates
+    cr_xcorrelations = 19  #: dict of result of crosscorrelations with cr templates
+    nu_xcorrelations = 20  #: dict of result of crosscorrelations with nu templates
     station_time = 21
-    cr_energy_em = 24  # the electromagnetic shower energy (the cosmic ray energy that ends up in electrons, positrons and gammas)
-    nu_inttype = 25  # interaction type, e.g., cc, nc, tau_em, tau_had
-    chi2_efield_time_direction_fit = 26  # the chi2 of the direction fitter that used the maximum pulse times of the efields
-    ndf_efield_time_direction_fit = 27  # the number of degrees of freedom of the direction fitter that used the maximum pulse times of the efields
-    cr_xmax = 28  # Depth of shower maximum of the air shower
-    vertex_2D_fit = 29  # horizontal distance and z coordinate of the reconstructed vertex of the neutrino
+    cr_energy_em = 24  #: the electromagnetic shower energy (the cosmic ray energy that ends up in electrons, positrons and gammas)
+    nu_inttype = 25  #: interaction type, e.g., cc, nc, tau_em, tau_had
+    chi2_efield_time_direction_fit = 26  #: the chi2 of the direction fitter that used the maximum pulse times of the efields
+    ndf_efield_time_direction_fit = 27  #: the number of degrees of freedom of the direction fitter that used the maximum pulse times of the efields
+    cr_xmax = 28  #: Depth of shower maximum of the air shower
+    vertex_2D_fit = 29  #: horizontal distance and z coordinate of the reconstructed vertex of the neutrino
     distance_correlations = 30
-    shower_energy = 31 # the energy of the shower 
-    viewing_angles = 32 # reconstructed viewing angles. A nested map structure. First key is channel id, second key is ray tracing solution id. Value is a float
+    shower_energy = 31 #: the energy of the shower 
+    viewing_angles = 32 #: reconstructed viewing angles. A nested map structure. First key is channel id, second key is ray tracing solution id. Value is a float
 
 
 class channelParameters(Enum):
-    zenith = 1  # zenith angle of the incoming signal direction
-    azimuth = 2  # azimuth angle of the incoming signal direction
-    maximum_amplitude = 4  # the maximum ampliude of the magnitude of the trace
-    SNR = 5  # an dictionary of various signal-to-noise ratio definitions
-    maximum_amplitude_envelope = 6  # the maximum ampliude of the hilbert envelope of the trace
-    P2P_amplitude = 7  # the peak to peak amplitude
-    cr_xcorrelations = 8  # dict of result of crosscorrelations with cr templates
-    nu_xcorrelations = 9  # dict of result of crosscorrelations with nu templates
-    signal_time = 10  # the time of the maximum amplitude of the envelope
-    noise_rms = 11  # the root mean square of the noise
-    signal_regions = 12     # list of start and end times of regions that likely contain a signal
-    noise_regions = 13      # list of start and end times of regions that likel do not contain any signals
-    signal_time_offset = 14     # the relative timing differences of the signal arrival times between channels
-    signal_receiving_zenith = 15    # the zenith angle of direction at which the radio signal arrived at the antenna
-    signal_ray_type = 16        # type of the ray propagation path of the signal received by this channel. Options are direct, reflected and refracted
-    signal_receiving_azimuth = 17   # the azimuth angle of direction at which the radio signal arrived at the antenna
+    zenith = 1  #: zenith angle of the incoming signal direction
+    azimuth = 2  #: azimuth angle of the incoming signal direction
+    maximum_amplitude = 4  #: the maximum ampliude of the magnitude of the trace
+    SNR = 5  #: an dictionary of various signal-to-noise ratio definitions
+    maximum_amplitude_envelope = 6  #: the maximum ampliude of the hilbert envelope of the trace
+    P2P_amplitude = 7  #: the peak to peak amplitude
+    cr_xcorrelations = 8  #: dict of result of crosscorrelations with cr templates
+    nu_xcorrelations = 9  #: dict of result of crosscorrelations with nu templates
+    signal_time = 10  #: the time of the maximum amplitude of the envelope
+    noise_rms = 11  #: the root mean square of the noise
+    signal_regions = 12     #: list of start and end times of regions that likely contain a signal
+    noise_regions = 13      #: list of start and end times of regions that likel do not contain any signals
+    signal_time_offset = 14     #: the relative timing differences of the signal arrival times between channels
+    signal_receiving_zenith = 15    #: the zenith angle of direction at which the radio signal arrived at the antenna
+    signal_ray_type = 16        #: type of the ray propagation path of the signal received by this channel. Options are direct, reflected and refracted
+    signal_receiving_azimuth = 17   #: the azimuth angle of direction at which the radio signal arrived at the antenna
 
 
 class electricFieldParameters(Enum):
-    ray_path_type = 1  # the type of the ray tracing solution ('direct', 'refracted' or 'reflected')
-    polarization_angle = 2  # electric field polarization in onsky-coordinates. 0 corresponds to polarization in e_theta, 90deg is polarization in e_phi
-    polarization_angle_expectation = 3  # expected polarization based on shower geometry. Defined analogous to polarization_angle
-    signal_energy_fluence = 4  # Energy/area in the radio signal
-    cr_spectrum_slope = 5  # Slope of the radio signal's spectrum as reconstructed by the voltageToAnalyticEfieldConverter
-    zenith = 7  # zenith angle of the signal. Note that refraction at the air/ice boundary is not taken into account
-    azimuth = 8  # azimuth angle of the signal. Note that refraction at the air/ice boundary is not taken into account
+    ray_path_type = 1  #: the type of the ray tracing solution ('direct', 'refracted' or 'reflected')
+    polarization_angle = 2  #: electric field polarization in onsky-coordinates. 0 corresponds to polarization in e_theta, 90deg is polarization in e_phi
+    polarization_angle_expectation = 3  #: expected polarization based on shower geometry. Defined analogous to polarization_angle
+    signal_energy_fluence = 4  #: Energy/area in the radio signal
+    cr_spectrum_slope = 5  #: Slope of the radio signal's spectrum as reconstructed by the voltageToAnalyticEfieldConverter
+    zenith = 7  #: zenith angle of the signal. Note that refraction at the air/ice boundary is not taken into account
+    azimuth = 8  #: azimuth angle of the signal. Note that refraction at the air/ice boundary is not taken into account
     signal_time = 9
-    nu_vertex_distance = 10  # the distance along the ray path from the vertex to the channel
-    nu_viewing_angle = 11  # the angle between shower axis and launch vector
-    max_amp_antenna = 12  # the maximum amplitude of the signal after convolution with the antenna response pattern, dict with channelid as key
-    max_amp_antenna_envelope = 13  # the maximum amplitude of the signal envelope after convolution with the antenna response pattern, dict with channelid as key
-    reflection_coefficient_theta = 14  # for reflected rays: the complex Fresnel reflection coefficient of the eTheta component
-    reflection_coefficient_phi = 15  # for reflected rays: the complex Fresnel reflection coefficient of the ePhi component
-    cr_spectrum_quadratic_term = 16  # result of the second order correction to the spectrum fitted by the voltageToAnalyticEfieldConverter
-    energy_fluence_ratios = 17   # Ratios of the energy fluences in different passbands
+    nu_vertex_distance = 10  #: the distance along the ray path from the vertex to the channel
+    nu_viewing_angle = 11  #: the angle between shower axis and launch vector
+    max_amp_antenna = 12  #: the maximum amplitude of the signal after convolution with the antenna response pattern, dict with channelid as key
+    max_amp_antenna_envelope = 13  #: the maximum amplitude of the signal envelope after convolution with the antenna response pattern, dict with channelid as key
+    reflection_coefficient_theta = 14  #: for reflected rays: the complex Fresnel reflection coefficient of the eTheta component
+    reflection_coefficient_phi = 15  #: for reflected rays: the complex Fresnel reflection coefficient of the ePhi component
+    cr_spectrum_quadratic_term = 16  #: result of the second order correction to the spectrum fitted by the voltageToAnalyticEfieldConverter
+    energy_fluence_ratios = 17   #: Ratios of the energy fluences in different passbands
 
 
-class ARIANNAParameters(Enum):  # this class stores parameters specific to the ARIANNA data taking
-    seq_start_time = 1  # the start time of a sequence
-    seq_stop_time = 2  # the stop time of a sequence
-    seq_num = 3  # the sequence number of the current event
-    comm_period = 4  # length of data taking window
-    comm_duration = 5  # maximum diration of communication window
-    trigger_thresholds = 6  # trigger thresholds converted to voltage
-    l1_supression_value = 7  # This provieds the L1 supression value for given event
-    internal_clock_time = 8  # time since last trigger with ms precision
+class ARIANNAParameters(Enum):  #: this class stores parameters specific to the ARIANNA data taking
+    seq_start_time = 1  #: the start time of a sequence
+    seq_stop_time = 2  #: the stop time of a sequence
+    seq_num = 3  #: the sequence number of the current event
+    comm_period = 4  #: length of data taking window
+    comm_duration = 5  #: maximum diration of communication window
+    trigger_thresholds = 6  #: trigger thresholds converted to voltage
+    l1_supression_value = 7  #: This provieds the L1 supression value for given event
+    internal_clock_time = 8  #: time since last trigger with ms precision
 
 
 class showerParameters(Enum):
-    zenith = 1  # zenith angle of the shower axis pointing towards xmax
-    azimuth = 2  # azimuth angle of the shower axis pointing towards xmax
-    core = 3  # position of the intersection between shower axis and an observer plane
-    energy = 4  # total energy of the primary particle, or shower energy for in-ice particle showers
-    electromagnetic_energy = 5  # energy of the electromagnetic shower component
-    radiation_energy = 6  # totally emitted radiation energy
-    electromagnetic_radiation_energy = 7  # radiation energy originated from the electromagnetic emission
-    primary_particle = 8  # particle id of the primary particle
-    shower_maximum = 9  # position of shower maximum in slant depth, e.g., Xmax
-    distance_shower_maximum_geometric = 10  # distance to xmax in meter
-    distance_shower_maximum_grammage = 11  # distance to xmax in g / cm^2
-    parent_id = 12 # id of parent in sim particles
+    zenith = 1  #: zenith angle of the shower axis pointing towards xmax
+    azimuth = 2  #: azimuth angle of the shower axis pointing towards xmax
+    core = 3  #: position of the intersection between shower axis and an observer plane
+    energy = 4  #: total energy of the primary particle, or shower energy for in-ice particle showers
+    electromagnetic_energy = 5  #: energy of the electromagnetic shower component
+    radiation_energy = 6  #: totally emitted radiation energy
+    electromagnetic_radiation_energy = 7  #: radiation energy originated from the electromagnetic emission
+    primary_particle = 8  #: particle id of the primary particle
+    shower_maximum = 9  #: position of shower maximum in slant depth, e.g., Xmax
+    distance_shower_maximum_geometric = 10  #: distance to xmax in meter
+    distance_shower_maximum_grammage = 11  #: distance to xmax in g / cm^2
+    parent_id = 12 #: id of parent in sim particles
 
-    # dedicated parameter for sim showers
-    refractive_index_at_ground = 100  # refractivity at sea level
-    atmospheric_model = 101  # atmospheric model used in simulation
-    # offset between magnetic field and north in reconstruction corrdinatesystem
+    #: dedicated parameter for sim showers
+    refractive_index_at_ground = 100  #: refractivity at sea level
+    atmospheric_model = 101  #: atmospheric model used in simulation
+    #: offset between magnetic field and north in reconstruction corrdinatesystem
     magnetic_field_rotation = 102
-    magnetic_field_vector = 103  # magnetic field used in simulation in local coordinate system
-    observation_level = 104  # altitude a.s.l where the particles are stored
+    magnetic_field_vector = 103  #: magnetic field used in simulation in local coordinate system
+    observation_level = 104  #: altitude a.s.l where the particles are stored
 
-    charge_excess_profile_id = 105  # the id of the charge-excess profile used in the ARZ Askaryan calculation
-    type = 106  # for neutrino induces showers in ice: can be "HAD" or "EM"
-    vertex = 107  # the interaction vertex (for air showers this corresponds to the point of X0)
-    vertex_time = 108  # the propagation time relative to the first interactions
-    interaction_type = 109  # the interaction type, e.g. cc or nc
-    k_L = 110  # the k_L parameter of the Alvarez2009 parameter that controls the longitudional width of the charge excess profile
-    flavor = 111  # the flavor of the particle initiating the shower
+    charge_excess_profile_id = 105  #: the id of the charge-excess profile used in the ARZ Askaryan calculation
+    type = 106  #: for neutrino induces showers in ice: can be "HAD" or "EM"
+    vertex = 107  #: the interaction vertex (for air showers this corresponds to the point of X0)
+    vertex_time = 108  #: the propagation time relative to the first interactions
+    interaction_type = 109  #: the interaction type, e.g. cc or nc
+    k_L = 110  #: the k_L parameter of the Alvarez2009 parameter that controls the longitudional width of the charge excess profile
+    flavor = 111  #: the flavor of the particle initiating the shower
 
-    interferometric_shower_maximum = 120  # depth of the maximum of the longitudinal profile of the beam-formed signal
-    interferometric_shower_axis = 121  # shower axis (direction) derived from beam-formed signal
-    interferometric_core = 122  # core (intersection of shower axis with obs plane) derived from beam-formed signal
+    interferometric_shower_maximum = 120  #: depth of the maximum of the longitudinal profile of the beam-formed signal
+    interferometric_shower_axis = 121  #: shower axis (direction) derived from beam-formed signal
+    interferometric_core = 122  #: core (intersection of shower axis with obs plane) derived from beam-formed signal
 
 class particleParameters(Enum):
-    parent_id = 1 # the entry number of the parent particle, None if primary.
-    zenith = 2  # the zenith angle of the incoming neutrino direction
-    azimuth = 3  # the azimuth angle of the incoming neutrino direction
-    energy = 4  # the energy of the neutrino
-    flavor = 5  # the flavor of the neutrino, more generally the PDG code
-    vertex = 6  # the neutrino vertex position (x,y,z)
+    parent_id = 1 #: the entry number of the parent particle, None if primary.
+    zenith = 2  #: the zenith angle of the incoming neutrino direction
+    azimuth = 3  #: the azimuth angle of the incoming neutrino direction
+    energy = 4  #: the energy of the neutrino
+    flavor = 5  #: the flavor of the neutrino, more generally the PDG code
+    vertex = 6  #: the neutrino vertex position (x,y,z)
     vertex_time = 9
     weight = 10
-    inelasticity = 11  # inelasticity ot neutrino interaction
-    interaction_type = 12  # interaction type, e.g., cc, nc
-    n_interaction = 13 # number of interaction
+    inelasticity = 11  #: inelasticity ot neutrino interaction
+    interaction_type = 12  #: interaction type, e.g., cc, nc
+    n_interaction = 13 #: number of interaction
 
-    cr_energy = 101  # the cosmic-ray energy
-    cr_zenith = 102  # zenith angle of the cosmic-ray incoming direction
-    cr_azimuth = 103  # azimuth angle of the cosmic-ray incoming direction
-    cr_energy_em = 104  # the electromagnetic shower energy (the cosmic ray energy that ends up in electrons, positrons and gammas)
+    cr_energy = 101  #: the cosmic-ray energy
+    cr_zenith = 102  #: zenith angle of the cosmic-ray incoming direction
+    cr_azimuth = 103  #: azimuth angle of the cosmic-ray incoming direction
+    cr_energy_em = 104  #: the electromagnetic shower energy (the cosmic ray energy that ends up in electrons, positrons and gammas)
 
 class generatorAttributes(Enum):
-    Emax = 1 # maximum simulated energy
-    Emin = 2 # minimum simulated energy
+    Emax = 1 #: maximum simulated energy
+    Emin = 2 #: minimum simulated energy
 
-    deposited = 3 # deposited energies or neutrino energies?
+    deposited = 3 #: deposited energies or neutrino energies?
 
-    # fiducial volume parameters, rmin/max for circular footprint
-    fiducial_rmin = 4
-    fiducial_rmax = 5
-    #  alternatively xy min/max for rectangular footprint will be set
-    fiducial_xmin = 6
-    fiducial_xmax = 7
-    fiducial_ymin = 8
-    fiducial_ymax = 9
+    fiducial_rmin = 4 #: fiducial volume parameter (if cylindrical footprint used)
+    fiducial_rmax = 5 #: fiducial volume parameter (if cylindrical footprint used)
+
+    fiducial_xmin = 6 #: fiducial volume parameter (if rectangular footprint used)
+    fiducial_xmax = 7 #: fiducial volume parameter (if rectangular footprint used)
+    fiducial_ymin = 8 #: fiducial volume parameter (if rectangular footprint used)
+    fiducial_ymax = 9 #: fiducial volume parameter (if rectangular footprint used)
 
     fiducial_zmin = 10
     fiducial_zmax = 11
 
-    # volume parameters, rmin/max for circular footprint
-    rmin = 12
-    rmax = 13
-    # alternatively xy min/max for rectangular footprint will be set
-    xmin = 14
-    xmax = 15
-    ymin = 16
-    ymax = 17
+    rmin = 12 #: volume parameter (if cylindrical)
+    rmax = 13 #: volume parameter (if cylindrical)
+
+    xmin = 14 #: volume parameter (if rectangular)
+    xmax = 15 #: volume parameter (if rectangular)
+    ymin = 16 #: volume parameter (if rectangular)
+    ymax = 17 #: volume parameter (if rectangular)
 
     zmin = 18
     zmax = 19
@@ -167,14 +173,13 @@ class generatorAttributes(Enum):
     volume = 20
     area = 21
 
-    # simulated space angle range
-    phimax = 22
-    phimin = 23
-    thetamax = 24
-    thetamin = 25
+    phimax = 22 #: simulated space angle range
+    phimin = 23 #: simulated space angle range
+    thetamax = 24 #: simulated space angle range
+    thetamin = 25 #: simulated space angle range
 
-    flavors = 26 # list of simulated event flavours
-    dt = 27 # not sure the dt (time since primary vertex from proposal) is needed here.
+    flavors = 26 #: list of simulated event flavours
+    dt = 27 #: inverse of sampling rate used in the simulation
 
     # simulated statistics
     n_events = 100
@@ -189,6 +194,6 @@ class generatorAttributes(Enum):
     NuRadioMC_version_hash = 203
 
 class eventParameters(Enum):
-    sim_config = 1  # contents of the config file that the NuRadioMC simulation was run with
-    hash_NuRadioReco = 2    # deprecated, since NuRadioReco is no longer its own repository
-    hash_NuRadioMC = 3  # git hash of the NuRadioMC commit that the file was created with
+    sim_config = 1 #: contents of the config file that the NuRadioMC simulation was run with
+    hash_NuRadioReco = 2 #: deprecated, since NuRadioReco is no longer its own repository
+    hash_NuRadioMC = 3 #: git hash of the NuRadioMC commit that the file was created with

--- a/documentation/make_docs.py
+++ b/documentation/make_docs.py
@@ -3,62 +3,42 @@ import os
 import sys
 import argparse
 import logging
+import re
 
 logging.basicConfig()
 logger = logging.getLogger(name="Make_docs")
 logger.setLevel(logging.INFO)
 
-def filter_errs(errs, filter_string, multi_line=[], exclude=None, include_line_numbers=False):
-    """Selects only lines that contain filter_string
-    
-    Optionally can include multiple lines around each match,
-    and exclude matches containing 'exclude'
-    """
-    line_numbers = []
-    for filter_substr in filter_string.split('|'):
-        line_numbers += [
-            i for i,err in enumerate(errs)
-            if filter_substr in err
-        ]
-    line_numbers = sorted(list(set(line_numbers))) # remove duplicates
-    matches = [(j, errs[j]) for j in line_numbers]
-    
-    if exclude != None:
-        matches = [k for k in matches if (not exclude in k[1])]
-
-    if len(multi_line) == 2:
-        matches = [
-            (k[0], errs[k[0]-multi_line[0]:k[0]+multi_line[1]])
-            for k in matches
-        ]
-    
-    if not include_line_numbers:
-        return [k[1] for k in matches]
-    else:
-        return matches
-
-err_sections = [
-    '[reference target not found]',
-    '[title underline too short]',
-    '[stub file not found]',
-    '[unexpected section title]',
-    '[numpydoc]',
-    '[indentation]',
-    '[toctree]',
-    '[other]'
-]
-
-# we try to classify some of the errors to be helpful
-# these are tuples (name, string_to_match)
-error_classes = [
-    ('reference target not found', 'reference target not found|undefined label'),
-    ('title underline too short', 'Title underline too short'),
-    ('stub file not found', 'stub file not found'),
-    ('unexpected section title', 'Unexpected section title'),
-    ('numpydoc', 'numpydoc'),
-    ('indentation', 'expected indent|expected unindent'),
-    ('toctree', 'toctree')
-]
+# we do some error classification, because we don't want to fail on all errors
+# This is done with simple string matching using re.search
+# The classification is exclusive, i.e. once a match has been found the error 
+# won't be included in a category lower down this list 
+error_dict = {
+        'reference target not found': dict(
+            pattern='reference target not found|undefined label|unknown document', matches=[]
+        ),
+        'title underline too short': dict(
+            pattern='Title underline too short', matches=[]
+        ),
+        'Unexpected section title': dict(
+            pattern='Unexpected section title', matches=[]
+        ),
+        'numpydoc': dict(
+            pattern='numpydoc', matches=[]
+        ),
+        'stub file not found': dict(
+            pattern='stub file not found', matches=[]
+        ),
+        'indentation': dict(
+            pattern='expected indent|expected unindent', matches=[]
+        ),
+        'toctree': dict(
+            pattern='toctree', matches=[]
+        ),
+        'other': dict(
+            pattern='', matches = []
+        )
+    }
 
 if __name__ == "__main__":
     argparser = argparse.ArgumentParser(
@@ -86,6 +66,9 @@ if __name__ == "__main__":
         file_logger = logging.FileHandler(logfile)
         file_logger.setLevel(logger.getEffectiveLevel())
         logger.addHandler(file_logger)
+        pipe_stdout = None
+    else:
+        pipe_stdout = subprocess.PIPE # hide the stdout
 
     doc_path = os.path.dirname(os.path.realpath(__file__))
     os.chdir(doc_path)
@@ -113,12 +96,12 @@ if __name__ == "__main__":
 
         logger.info("Creating automatic documentation files with apidoc:")
         logger.info("excluding modules: {}".format(exclude_modules))
-        subprocess.call(
+        subprocess.run(
             [
                 'sphinx-apidoc', '-efMT', '--ext-autodoc', '--ext-intersphinx',
                 '--ext-coverage', '--ext-githubpages', '-o', output_folder,
                 module_path, *exclude_modules
-            ]
+            ], stdout=pipe_stdout
         )
         # We don't use the top level NuRadioReco.rst / NuRadioMC.rst toctrees,
         # so we remove them to eliminate a sphinx warning
@@ -128,96 +111,54 @@ if __name__ == "__main__":
     if not parsed_args.no_clean:
         logger.info('Removing old \'build\' directory...')
         subprocess.check_output(['make', 'clean'])
-    sphinx_log = subprocess.run(['make', 'html'], stderr=subprocess.PIPE) # stdout=subprocess.PIPE,
+    sphinx_log = subprocess.run(['make', 'html'], stderr=subprocess.PIPE, stdout=pipe_stdout)
 
-    errs = sphinx_log.stderr.decode().split('\n')
+    # errs = sphinx_log.stderr.decode().split('\n')
+    errs = re.split('\\x1b\[[0-9;]+m', sphinx_log.stderr.decode()) # split the errors
     # output = sphinx_log.stdout.decode().split('\n')
 
-    # broken cross-references. We ignore warnings originating from docstrings
-    match_str = 'reference target not found|undefined label|unknown document'
-    xref_errs = filter_errs(errs, match_str)
-    xref_errs_in_docstrings = filter_errs(xref_errs, 'docstring')
-    xref_tofix = filter_errs(errs, match_str, exclude='docstring')
-    logger.info('{} broken xrefs, of which {} outside docstrings'.format(len(xref_errs), len(xref_tofix)))
+    for err in errs:
+        if not err.split(): # whitespace only
+            continue
+        for key in error_dict.keys():
+            if re.search(error_dict[key]['pattern'], err):
+                error_dict[key]['matches'].append(err)
+                break # we don't match errors to multiple categories
 
-    # broken sections
-    match_str = 'Title underline too short'
-    section_errs = filter_errs(errs, match_str, multi_line=(0,4))
-    section_errs_tofix = filter_errs(errs, match_str, multi_line=(0,4), exclude='docstring')
-    logger.info('{} bad section titles, of which {} outside docstrings'.format(
-        len(section_errs), len(section_errs_tofix)))
-
-    # bad docstrings
-    match_str = 'Unexpected section title'
-    unexpected_title_errs = filter_errs(errs, match_str, multi_line=(1,4))
-    logger.info('{} bad docstring sections'.format(len(unexpected_title_errs)))
-
-    match_str = 'numpydoc'
-    numpydoc_errs = filter_errs(errs, match_str, multi_line=(0,3))
-    logger.info('{} numpydoc errors'.format(len(numpydoc_errs)))
-
-    # missing stubs in .rst files - if these happen, may have to rerun apidoc!
-    match_str = 'stub file not found'
-    stub_errs = filter_errs(errs, match_str)
-    logger.info('{} stub errs'.format(len(stub_errs)))
-
-    match_str = 'expected indent|expected unindent'
-    indentation_errs = filter_errs(errs, match_str)
-    indentation_errs_outside_docstrings = filter_errs(errs, match_str, exclude='docstring')
-    logger.info(
-        '{} indentation errors, of which {} outside docstrings'.format(
-        len(indentation_errs), len(indentation_errs_outside_docstrings))
-    )
-
-    match_str = 'toctree'
-    toctree_errs = filter_errs(errs, match_str)
-    logger.info(
-        '{} toctree errors (missing document or missing entry)'.format(len(toctree_errs))
-    )
+    fixable_errors = 0
+    for key in error_dict.keys():
+        if key == 'other': # we don't fail on these errors
+            continue
+        fixable_errors += len(error_dict[key]['matches'])
     
-    all_errs = (
-        ['[reference target not found]'] + xref_tofix # we exclude broken xrefs in docstrings
-        + ['[title underline too short]'] + [k for j in section_errs for k in j]
-        + ['[stub file not found]'] + stub_errs 
-        + ['[unexpected section title]'] + [k for j in unexpected_title_errs for k in j]
-        + ['[numpydoc]'] + [k for j in numpydoc_errs for k in j]
-        + ['[indentation]'] + indentation_errs
-        + [err_sections[6]] + toctree_errs
-    )
-
-    other_errs = [
-        err for err in errs 
-        if (err not in all_errs) & (err not in xref_errs)
-    ]
-
-    fixable_errors = (len(all_errs) > len(err_sections) - 1)
-    
+    print(2*'\n'+78*'-')
     if fixable_errors:
         logger.warning("The documentation was not built without errors. Please fix the following errors!")
-        print('\n'.join(all_errs))
-    elif len(other_errs):
+        for key, item in error_dict.items():
+            if len(item['matches']):
+                print(f'[{key}]')
+                print('\n'.join(item['matches']))
+    elif len(error_dict['other']['matches']):
         logger.warning((
             "make_docs found some errors but doesn't know what to do with them.\n"
             "The documentation may not be rejected, but consider fixing the following anyway:"
             ))
-        print('\n'.join(other_errs))
+        print('\n'.join(error_dict['other']['matches']))
+    print(78*'-'+2*'\n')
 
     if sphinx_log.returncode:
         logger.error("The documentation failed to build, make_docs will raise an error.")
-
+    # print(error_dict)
     if parsed_args.debug:
         logger.info('Logging output under {}'.format(logfile))
         with open(logfile, 'w') as file:
             # file.write('[stdout]\n')
             # file.write('\n'.join(output))
             # file.write('\n')
-            file.write('[broken references in docstrings] # these can be ignored\n')
-            file.write('\n'.join(xref_errs_in_docstrings))
-            file.write('\n')
-            file.write('\n'.join(all_errs))
-            file.write('\n')
-            file.write('[other]\n')
-            file.write('\n'.join(other_errs))
-    
+            for key, item in error_dict.items():
+                if len(item['matches']):
+                    file.write(f'\n[{key}]\n')
+                    file.write('\n'.join(item['matches']))
+
     if fixable_errors or sphinx_log.returncode:
         sys.exit(1)

--- a/documentation/source/Introduction/pages/contributing.rst
+++ b/documentation/source/Introduction/pages/contributing.rst
@@ -214,8 +214,8 @@ Compiling the documentation is then done by running
 
   python documentation/make_docs.py
 
-This will build the documentation at `documentation/build/html`
-(open `main.html` to view it in your browser).
+This will build the documentation at ``documentation/build/html``
+(open ``main.html`` to view it in your browser).
 
 Headings and text
 ^^^^^^^^^^^^^^^^^

--- a/documentation/source/Introduction/pages/installation.rst
+++ b/documentation/source/Introduction/pages/installation.rst
@@ -193,7 +193,7 @@ These packages are recommended to be able to use all of NuRadioMC/NuRadioReco's 
 
   Note that the pip installation for this version of proposal may not work on all systems, in particular:
 
-  - conda cannot be used on all systems (eg. on Mac), in that case use a python venv, see details `here <https://github.com/tudo-astroparticlephysics/PROPOSAL/issues/209>`_
+  - conda cannot be used on all systems (eg. on Mac), in that case use a python venv, see details `here <https://github.com/tudo-astroparticlephysics/PROPOSAL/issues/209>`__
 
   - if the linux kernel is too old (eg. on some computing clusters), refer to `this step-by-step guide <https://github.com/tudo-astroparticlephysics/PROPOSAL/wiki/Installing-PROPOSAL-on-a-Linux-kernel---4.11>`_
   
@@ -218,6 +218,6 @@ ____________________________
   With GSL installed, compile the CPP ray tracer by navigating to ``NuRadioMC/NuRadioMC/SignalProp``
   and running the included ``install.sh`` script.
 - To use the :mod:`RadioPropa numerical ray tracing <NuRadioMC.SignalProp.radioproparaytracing>` module, ``radiopropa`` needs to be installed.
-  The radiopropa github, with installation instructions, can be found `here <https://github.com/nu-radio/RadioPropa>`_.
+  The radiopropa github, with installation instructions, can be found `here <https://github.com/nu-radio/RadioPropa>`__.
 - To read ARIANNA files, `Snowshovel <https://arianna.ps.uci.edu/mediawiki/index.php/Local_DAQ_Instructions>`_ needs to be installed.
 - To read ARA files, `ARA ROOT <http://www.hep.ucl.ac.uk/uhen/ara/araroot/branches/3.13/index.shtml>`_ needs to be installed.

--- a/documentation/source/NuRadioMC/pages/HDF5_structure.rst
+++ b/documentation/source/NuRadioMC/pages/HDF5_structure.rst
@@ -103,6 +103,7 @@ is the number of showers (which may be larger than the number of events), and ``
             ``interaction_type`` | (``n_showers``) | Interaction type producing the shower (for the first interaction that can be "nc" or "cc")
             ``multiple_triggers`` | (``n_showers``, ``n_triggers``) | Information which exact trigger fired each shower. The different triggers are specified in the attributes (``f.attrs["triggers"]``). The order of ``f.attrs["triggers"]`` matches that in ``multiple_triggers``
             ``triggered`` | (``n_showers``) | A boolean; ``True`` if any trigger fired for this shower, ``False`` otherwise
+            ``trigger_times`` | (``n_showers``, ``n_triggers``) | The trigger times (relative to the first interaction) at which each shower triggered. If there are multiple stations, this will be the earliest trigger time.
             ``n_interaction`` | (``n_showers``) | Hierarchical counter for the number of showers per event (also accounts for showers which did not trigger and might not be saved)
             ``shower_ids`` | (``n_showers``) | Hierarchical counter for the number of triggered showers
             ``shower_realization_ARZ`` | (``n_showers``) | Which realization from the ARZ shower library was used for each shower (only if ARZ was used for signal generation).
@@ -150,3 +151,4 @@ station triggered, with which amplitude, etc. The same approach works for ``show
             ``travel_times`` | (``m_showers``, ``n_channels``, ``n_ray_tracing_solutions``) | The time travelled by each ray tracing solution to a specific channel
             ``triggered`` | (``m_showers``) | Whether each shower contributed to an event that satisfied any trigger condition
             ``triggered_per_event`` | (``m_events``) | Whether each event fulfilled any trigger condition.
+            ``trigger_times`` | (``m_showers``, ``n_triggers``) | The trigger times for each shower and trigger.

--- a/documentation/source/NuRadioReco/pages/event_structure.rst
+++ b/documentation/source/NuRadioReco/pages/event_structure.rst
@@ -122,6 +122,7 @@ it just needs to be added to the
 .. admonition:: For Developers
 
   New parameters should always be added to the bottom of the list. Do not re-use old Enums!
+  A description should be added to each new parameter with a comment docstring starting with ``#:``.
 
 Additionally, parameters can be written and accessed via indexing, like one
 would do to a dictionary:

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -213,7 +213,12 @@ epub_exclude_files = ['search.html']
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy', None),
+    'numpy': ("https://numpy.org/doc/stable", None)
+}
+default_role = 'autolink' #TODO: probably switch to py:obj?
 
 # Make sure the target is unique
 autosectionlabel_prefix_document = True
@@ -222,6 +227,11 @@ autosectionlabel_prefix_document = True
 numpydoc_class_members_toctree = False
 
 autoclass_content = 'both' # include __init__ docstrings in class description
+autodoc_default_options = {
+    'show-inheritance': True, # show 'Bases: Parent' for classes that inherit from parent classes
+    'inherited-members': True, # also document inherited methods; mostly done to avoid missing cross-references
+}
+autodoc_member_order = 'bysource' # list methods/variables etc. by the order they are defined, rather than alphabetically
 # 
 # coverage_ignore_modules
 
@@ -237,14 +247,11 @@ nitpicky = True
 # this ignores some cross-reference errors inside docstrings
 # that we don't care about
 nitpick_ignore_regex = [
-    ("py:class", "NuRadioReco.*"),
-    ("py:class", "NuRadioMC.*"),
     ("py:class", "aenum.Enum"),
     ("py:class", "tinydb_serialization.Serializer"),
     ("py:class", "radiopropa.ScalarField"),
-    ("py:obj", "NuRadioReco.*"),
-    ("py:obj", "NuRadioMC.*"),
-    ("py:class", "nifty5.*")
+    ("py:class", "nifty5.*"),
+    ("py:obj",".*__call__") # not sure why this method is listed sometimes - it shouldn't be?
 ]
 
 # def skip_modules(app, what, name, obj, skip, options):

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -109,7 +109,8 @@ html_theme_options = {
     'sticky_navigation': True,
     'navigation_depth': 5
 }
-html_css_files = [os.path.abspath('custom_scripts/styling.css')]
+html_static_path = ['custom_scripts']
+html_css_files = ['styling.css']
 
 html_logo = 'logo_small.png'
 


### PR DESCRIPTION
Some small improvements to the documentation:
- Simplified/improved the error classification and error output of the `make_docs` script by switching to `re` string matching.
- Fixed a bug that meant custom css was only used locally, but not on the deployed documentation
- Changed the documentation for `parameters.py` from `#` (comments only visible in source code) to `#:`, which means their descriptions are now also visible in the deployed documentation.