### PR TITLE
Optimise calculation of attenuation factor with GL3 model

### DIFF
--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -632,6 +632,7 @@ class ray_tracing_2D(ray_tracing_base):
                     # of integrating over dt (the exponent of the attenuation factor), we integrate only over ds (the path length)
                     # and evaluate the attenuation (as function of depth and frequency) for the central depth of this segment 
                     # (because this is what takes time)
+                    # For more details and comparisons see PR #507 : https://github.com/nu-radio/NuRadioMC/pull/507
 
                     # define the width of the vertical (!) segments over which we sum. 
                     # Since we use linspace the actual width will differ slightly

--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -15,7 +15,6 @@ from NuRadioMC.utilities import attenuation as attenuation_util
 from NuRadioReco.framework.parameters import electricFieldParameters as efp
 from NuRadioMC.SignalProp.propagation_base_class import ray_tracing_base
 from NuRadioMC.SignalProp.propagation import solution_types, solution_types_revert
-
 import logging
 logging.basicConfig()
 
@@ -45,6 +44,20 @@ except:
 analytic ray tracing solution
 """
 speed_of_light = scipy.constants.c * units.m / units.s
+
+
+def get_n_steps(x1, x2, dx):
+    """ Returns number of segments necessary for width to be approx dx """
+    return max(int(abs(x1 - x2) // dx), 3)
+
+
+def get_segments(x1, x2, dx):
+    """ Returns equi.dist. segments (np.linspace). Choose number of segments such that
+        width of segments is approx. dx
+    """
+    if x1 == x2:
+        return [x1]
+    return np.linspace(x1, x2, get_n_steps(x1, x2, dx))
 
 
 @lru_cache(maxsize=32)
@@ -104,6 +117,7 @@ class ray_tracing_2D(ray_tracing_base):
         self.__logger.setLevel(log_level)
         self.__n_frequencies_integration = n_frequencies_integration
         self.__use_optimized_start_values = use_optimized_start_values
+        
 
     def n(self, z):
         """
@@ -214,6 +228,7 @@ class ray_tracing_2D(ray_tracing_base):
         """
         derivative dy(z)/dz
         """
+
         z = self.get_z_unmirrored(z_raw, C_0)
         c = self.medium.n_ice ** 2 - C_0 ** -2
         B = (0.2e1 * np.sqrt(c) * np.sqrt(-self.__b * self.medium.delta_n * np.exp(z / self.medium.z_0) + self.medium.delta_n **
@@ -605,14 +620,81 @@ class ray_tracing_2D(ray_tracing_base):
                 mask = frequency > 0
                 freqs = self.__get_frequencies_for_attenuation(frequency, max_detector_freq)
                 gamma_turn, z_turn = self.get_turning_point(self.medium.n_ice ** 2 - C_0 ** -2)
-                points = None
-                if x1[1] < z_turn and z_turn < x2_mirrored[1]:
-                    points = [z_turn]
-                
-                attenuation_exp = np.array([integrate.quad(dt, x1[1], x2_mirrored[1], args=(
-                    C_0, f), epsrel=1e-2, points=points)[0] for f in freqs])
+
+                if self.attenuation_model == "GL3":
+                    # The integration of the attenuation factor along the path with scipy.quad is inefficient. The 
+                    # reason for this is that attenuation profile is varying a lot with depth. Hence, to improve
+                    # performance we sum over discrete segments with loss of some accuracy. 
+                    # However, when a path becomes to horizontal (i.e., at the turning point of an refracted ray)
+                    # the calculation via a discrete sum becomes to inaccurate. This is because we describe the
+                    # path as a function of dz (vertical distance) and have the sum over discrete bins in dz. To avoid that
+                    # we fall back to a numerical integration with scipy.quad only around the turning point. However, instead 
+                    # of integrating over dt (the exponent of the attenuation factor), we integrate only over ds (the path length)
+                    # and evaluate the attenuation (as function of depth and frequency) for the central depth of this segment 
+                    # (because this is what takes time)
+
+                    # define the width of the vertical (!) segments over which we sum. 
+                    # Since we use linspace the actual width will differ slightly
+                    dx = 10
+                    # define the vertical window around a turning point within we will fall back to a numerical integration
+                    int_window_size = 20
+                    
+                    # Check if a turning point "z_turn" is within our ray path or close to it (i.e., right behind the antenna)
+                    # if so we need to fallback to numerical integration
+                    fallback = False
+                    if x1[1] - int_window_size / 2 < z_turn and z_turn < x2_mirrored[1] + int_window_size / 2:
+                        fallback = True
+                        
+                    if fallback:
+                        # If we need the fallback, make sure that the turning point is in the middle of a segment (unless it is at
+                        # the edge of a path). Otherwise the segment next to the turning point will be inaccurate
+                        int_window = [max(x1[1], z_turn - int_window_size / 2), 
+                                      min(z_turn + int_window_size / 2, x2_mirrored[1])]
+
+                        # Merge two arrays which start and stop at int_window (and thus include it). The width might be slightly different
+                        segments = np.append(get_segments(x1[1], int_window[0], dx), get_segments(int_window[1], x2_mirrored[1], dx))
+                    else:
+                        segments = get_segments(x1[1], x2_mirrored[1], dx)
+                    
+                    # get the actual width of each segment and their center
+                    dx_actuals = np.diff(segments)
+                    mid_points = segments[:-1] + dx_actuals / 2
+
+                    # calculate attenuation for the different segments using the middle depth of the segment
+                    attenuation_exp_tmp = np.array(
+                        [[dt(x, C_0, f) * dx_actual for x, dx_actual in zip(mid_points, dx_actuals)]
+                        for f in freqs])
+
+                    if fallback:
+                        # for the segment around z_turn fall back to integration. We only integrate ds (and not dt) for performance reasons
+
+                        # find segment which contains z_turn
+                        idx = np.digitize(z_turn, segments) - 1
+                        
+                        # if z_turn is outside of segments
+                        if idx == len(segments) - 1:
+                            idx -= 1
+                        elif idx == -1:
+                            idx = 0
+                        
+                        att_int = np.array(
+                            [integrate.quad(self.ds, segments[idx], segments[idx + 1], args=(C_0), epsrel=1e-2, points=[z_turn])[0] /
+                            attenuation_util.get_attenuation_length(z_turn, f, self.attenuation_model) for f in freqs])
+                            
+                        attenuation_exp_tmp[:, idx] = att_int
+                    
+                    # sum over all segments
+                    attenuation_exp = np.sum(attenuation_exp_tmp, axis=1)
+
+                else:
+                    points = None
+                    if x1[1] < z_turn and z_turn < x2_mirrored[1]:
+                        points = [z_turn]
+                    
+                    attenuation_exp = np.array([integrate.quad(dt, x1[1], x2_mirrored[1], args=(
+                        C_0, f), epsrel=1e-2, points=points)[0] for f in freqs])
+
                 tmp = np.exp(-1 * attenuation_exp)
-                # tmp = np.array([integrate.quad(dt, x1[1], x2_mirrored[1], args=(C_0, f), epsrel=0.05)[0] for f in frequency[mask]])
                 
                 tmp_attenuation = np.ones_like(frequency)
                 tmp_attenuation[mask] = np.interp(frequency[mask], freqs, tmp)

--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -110,7 +110,13 @@ class ray_tracing_2D(ray_tracing_base):
             if True, the initial C_0 paramter (launch angle) is set to the ray that skims the surface
             (default: False)
         overwrite_speedup: bool
-            If not None, use value to overwrite _use_optimized_calculation. (Default: None)
+            The signal attenuation is calculated using a numerical integration
+            along the ray path. This calculation can be computational inefficient depending on the details of 
+            the ice model. An optimization is implemented approximating the integral with a discrete sum with the loss
+            of some accuracy, See PR #507. This optimization is used for all ice models listed in 
+            speedup_attenuation_models (i.e., "GL3"). With this argument you can explicitly activate or deactivate
+            (True or False) if you want to use the optimization. (Default: None, i.e., use optimization if ice model is
+            listed in speedup_attenuation_models)
             
         """
         self.medium = medium

--- a/NuRadioMC/SignalProp/propagation_base_class.py
+++ b/NuRadioMC/SignalProp/propagation_base_class.py
@@ -17,7 +17,7 @@ class ray_tracing_base:
 
     def __init__(self, medium, attenuation_model=None, log_level=logging.WARNING, 
                  n_frequencies_integration=None, n_reflections=None, config=None, 
-                 detector = None):
+                 detector=None, ray_tracing_2D_kwards={}):
         """
         class initilization
 
@@ -45,6 +45,8 @@ class ray_tracing_base:
         config: nested dictionary
             loaded yaml config file
         detector: detector object
+        ray_tracing_2D_kwards: dict
+            Additional arguments which are passed to ray_tracing_2D
         """
         self.__logger = logging.getLogger('ray_tracing_base')
         self.__logger.setLevel(log_level)


### PR DESCRIPTION
This PR tries to implement an optimization for `get_attenuation_along_path` when the `GL3` attenuation model is used. With this model the integration of `ds(z) / L(z, f)` (Eq. 14 in [paper](https://link.springer.com/article/10.1140/epjc/s10052-020-7612-8)) with `scipy.integration.quad` is very time consuming (due to details of a(z, f), @christophwelling can give more details). 

The idea is, instead of the numerical integration:
```
 attenuation_exp = np.array([integrate.quad(dt, x1[1], x2_mirrored[1], args=(
        C_0, f), epsrel=1e-2, points=points)[0] for f in freqs])
```
 to calculate the attenuation for discrete segments of `ds` and sum them up:  
```
attenuation_exp = np.array(
    [np.sum([dt(x, C_0, f) * dx_actual for x, dx_actual in zip(mid_points, dx_actuals)]) for f in freqs])
```
Tuning the (vertical) width of the segments (i.e., `dx_actual `) this gives decent accuracy with a great improvement in time (~ x10) for many geometries. However, in cases where the ray travels on horizontal trajectories this method becomes inaccurate (because we bin the path in segments of vertical distance). Hence, in those cases we fall back to a numerical integration (for this part of the ray path). And instead of integrating  `ds(z) / L(z, f)`, we only integrate `ds(z)` and divide by `L(<z>, f)` for performance reasons.


I also tested the new algorithm for the attenuation model `GL1`. However, for this model the new algorithm is not faster and can even be more slowly. Hence, it is only used for `GL3`

PS: This PR is based on PR #506. Once merged the cosmetic changes also included here should vanish from the diff.

In the following I enclose figures which show the accuracy between the original calculation and the new one for several different geometries with an antenna at an depth of -100m. Also the acceleration factor is shown. 

Emission at x=-100, varying depth:
![attenuation_opt_dev_x-100 0m_dx10m_GL3_int20](https://user-images.githubusercontent.com/30903175/223434981-957e59e4-2e59-445f-a630-95955d756c55.png)
![attenuation_opt_hists_x-100 0m_dx10m_GL3_int20](https://user-images.githubusercontent.com/30903175/223434987-253adf93-80c3-4e2b-8c17-4ca522f86c9a.png)


Emission at x=-300, varying depth:
![attenuation_opt_dev_x-300 0m_dx10m_GL3_int20](https://user-images.githubusercontent.com/30903175/223433761-a45fac90-a9bc-4caa-85ab-0f9395696457.png)
![attenuation_opt_hists_x-300 0m_dx10m_GL3_int20](https://user-images.githubusercontent.com/30903175/223433773-48552b1c-1ec6-4e5a-8ada-60319d39a0a9.png)

Emission at x=-500, varying depth:
![attenuation_opt_dev_x-500 0m_dx10m_GL3_int20](https://user-images.githubusercontent.com/30903175/223434074-5827c1de-398c-4be2-9eed-457d9aa5eb81.png)
![attenuation_opt_hists_x-500 0m_dx10m_GL3_int20](https://user-images.githubusercontent.com/30903175/223434085-1bc59355-e17f-48f4-ab52-8f8e48ab057a.png)

Emission at x=-800, varying depth:
![attenuation_opt_dev_x-800 0m_dx10m_GL3_int20](https://user-images.githubusercontent.com/30903175/223434160-ab4d4599-659e-4739-9bb7-b8ba8de556d8.png)
![attenuation_opt_hists_x-800 0m_dx10m_GL3_int20](https://user-images.githubusercontent.com/30903175/223434161-23b4a3b0-c974-44e5-afc1-ceede0dd4487.png)

Emission at x=-1000, varying depth:
![attenuation_opt_dev_x-1000 0m_dx10m_GL3_int20](https://user-images.githubusercontent.com/30903175/223434215-48752293-5d55-4a91-b9ef-e098dab5cfbf.png)
![attenuation_opt_hists_x-1000 0m_dx10m_GL3_int20](https://user-images.githubusercontent.com/30903175/223434218-990914cb-5833-4965-a092-8b7e541d9338.png)

Emission at z=-300, varying horizontal distance 
![attenuation_opt_dev_z-300 0m_dx10m_GL3_int20](https://user-images.githubusercontent.com/30903175/223434320-535a63eb-33c7-455c-a54d-9b2c62e0c047.png)
![attenuation_opt_hists_z-300 0m_dx10m_GL3_int20](https://user-images.githubusercontent.com/30903175/223434322-439c9301-027d-4d8c-8f91-40f45f267282.png)

Emission at z=-500, varying horizontal distance 
![attenuation_opt_dev_z-500 0m_dx10m_GL3_int20](https://user-images.githubusercontent.com/30903175/223434685-c747c39c-4471-4b0b-9b44-b3f5f139157b.png)
![attenuation_opt_hists_z-500 0m_dx10m_GL3_int20](https://user-images.githubusercontent.com/30903175/223434699-a14804c7-234a-4aee-866e-f87676e5c89c.png)

Emission at z=-800, varying horizontal distance 
![attenuation_opt_dev_z-800 0m_dx10m_GL3_int20](https://user-images.githubusercontent.com/30903175/223434781-22278a78-0407-4a22-a613-9aa31b1eaf7a.png)
![attenuation_opt_hists_z-800 0m_dx10m_GL3_int20](https://user-images.githubusercontent.com/30903175/223434785-8a6b73fd-f1a2-4f28-8a04-a74cd532bba9.png)

Emission at z=-1000, varying horizontal distance 
![attenuation_opt_dev_z-1000 0m_dx10m_GL3_int20](https://user-images.githubusercontent.com/30903175/223434855-ea7bd68a-9154-4e15-814d-45694909c130.png)
![attenuation_opt_hists_z-1000 0m_dx10m_GL3_int20](https://user-images.githubusercontent.com/30903175/223434860-c2d49c41-fc39-4412-897e-bb395a758630.png)

