### PR TITLE
Fix git rev or tag specification in dependencies

### DIFF
--- a/install_dev.py
+++ b/install_dev.py
@@ -83,6 +83,10 @@ def convert_poetry_to_pip(reqs):
                 req = 'git+{}'.format(version['git'])
                 if 'branch' in version:
                     req+='@{}'.format(version['branch'])
+                elif 'rev' in version:
+                    req+='@{}'.format(version['rev'])
+                elif 'tag' in version:
+                    req+='@{}'.format(version['tag'])
             if 'version' in version:
                 version = version['version']
             else:


### PR DESCRIPTION
Whoever wrote the `install_dev` script didn't account for `rev` or `tag` specifications in the pyproject.toml dependency specifications. This means that the proposal version (since #502) wasn't pinned until now.

Long term, there probably is a better way to install dependencies from `pyproject.toml` without requiring a poetry installation than the current implementation, but I'm not sure if/when I'll have time to look into that.