### PR TITLE
Update PROPOSAL to version 7.5.1

### DIFF
--- a/documentation/source/Introduction/pages/installation.rst
+++ b/documentation/source/Introduction/pages/installation.rst
@@ -189,7 +189,7 @@ These packages are recommended to be able to use all of NuRadioMC/NuRadioReco's 
 
   .. code-block:: bash
 
-    pip install proposal==7.5.0
+    pip install proposal==7.5.1
 
   Note that the pip installation for this version of proposal may not work on all systems, in particular:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ numba = "*"
 Sphinx = "*"
 sphinx-rtd-theme = "*"
 numpydoc = "1.1.0"
-proposal = {git = "https://github.com/tudo-astroparticlephysics/PROPOSAL.git", rev="b95628a"}
+proposal = "7.5.1"
 pygdsm = {git = "https://github.com/telegraphic/pygdsm"}
 nifty5 = {git = "https://gitlab.mpcdf.mpg.de/ift/nifty.git", branch="NIFTy_5"}
 pypocketfft = {git = "https://gitlab.mpcdf.mpg.de/mtr/pypocketfft"}


### PR DESCRIPTION
This updates PROPOSAL to version 7.5.1.
This fixes #494, so we don't have to checkout a specific commit anymore.

All other bugfixes included in this patch release of PROPOSAL don't include any changes that are relevant for NuRadioMC (see [here](https://github.com/tudo-astroparticlephysics/PROPOSAL/releases/tag/7.5.1) for the complete Changelog).

Should I also update the `changelog.txt` for this?