### PR TITLE
 pass event time to the sim station to simulate time dependent detect…

### DIFF
--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -850,7 +850,8 @@ class simulation:
                 t1 = time.time()
                 self._station = NuRadioReco.framework.station.Station(self._station_id)
                 self._station.set_sim_station(self._sim_station)
-
+                self._station.get_sim_station().set_station_time(self._evt_time)
+                
                 # convert efields to voltages at digitizer
                 if hasattr(self, '_detector_simulation_part1'):
                     # we give the user the opportunity to define a custom detector simulation

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,10 +21,10 @@ new features:
 - adding minimize mode to the radiopropa propagation module & more configurable settings in config file
 - add uniform ice model with 1.78 refractive index
 - update ARA detector description and add a file to Print ARA detector json file
+- pass evt_time to sim station
 bugfixes:
 - fix bug in NuRadioProposal which pervented muons from tau decays to be propagated
 - update proposal version to 6.1.8 to avoid problems with pypi
-
 
 version 2.1.6
 bugfixes:


### PR DESCRIPTION
We have created a private package for the ARA detector that can be used in conjunction with NuRadioMC. This pull request adds a simple line to the simulation.py file, which passes event time information to the sim station, making the ARA package compatible with NuRadioMC.

changelog.txt has been updated