### PR TITLE
GL3 attenuation for C++ raytracer

### DIFF
--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -132,7 +132,6 @@ class ray_tracing_2D(ray_tracing_base):
         self.__logger.setLevel(log_level)
         self.__n_frequencies_integration = n_frequencies_integration
         self.__use_optimized_start_values = use_optimized_start_values
-        
         self._use_optimized_calculation = self.attenuation_model in speedup_attenuation_models
         if overwrite_speedup is not None:
             self._use_optimized_calculation = overwrite_speedup
@@ -387,7 +386,6 @@ class ray_tracing_2D(ray_tracing_base):
             launch_angle = self.get_launch_angle(x1, C_0)
             beta = self.n(x1[1]) * np.sin(launch_angle)
             alpha = self.medium.n_ice ** 2 - beta ** 2
-    #         print("launchangle {:.1f} beta {:.2g} alpha {:.2g}, n(z1) = {:.2g} n(z2) = {:.2g}".format(launch_angle/units.deg, beta, alpha, self.n(x1[1]), self.n(x2[1])))
 
             def l1(z):
                 gamma = self.n(z) ** 2 - beta ** 2
@@ -403,8 +401,6 @@ class ray_tracing_2D(ray_tracing_base):
                 if(deep):
                     return self.medium.n_ice * z / alpha ** 0.5
                 else:
-                    #                 print(z, self.n(z), beta)
-                    #                 print(alpha**0.5, l1(z), l2(z))
 
                     path_length = self.medium.n_ice / alpha ** 0.5 * (-z + np.log(l1(z)) * self.medium.z_0) + np.log(l2(z)) * self.medium.z_0
                     if (np.abs(path_length) == np.inf or path_length == np.nan):
@@ -418,8 +414,6 @@ class ray_tracing_2D(ray_tracing_base):
                 int2 = get_s(z2, z2 < z_deep)
                 if (int1 == None or int2 == None):
                     return None
-    #             print('analytic {:.4g} ({:.0f} - {:.0f}={:.4g}, {:.4g})'.format(
-    #                 int2 - int1, get_s(x2[1]), x1[1], x2[1], get_s(x1[1])))
                 if (z1 < z_deep) == (z2 < z_deep):
                     # z0 and z1 on same side of z_deep
                     return int2 - int1
@@ -432,7 +426,6 @@ class ray_tracing_2D(ray_tracing_base):
                         # z0 below z_deep, z1 above z_deep
                         return int2 - int1 + int_diff
                     else:
-                        # print("path:", int2 - int1 - int_diff)
                         # z0 above z_deep, z1 below z_deep
                         return int2 - int1 - int_diff
 
@@ -443,7 +436,6 @@ class ray_tracing_2D(ray_tracing_base):
                     z_turn = 0
                 else:
                     gamma_turn, z_turn = self.get_turning_point(self.medium.n_ice ** 2 - C_0 ** -2)
-    #             print('solution type {:d}, zturn = {:.1f}'.format(solution_type, z_turn))
                 try:
                     tmp += get_path_direct(x1[1], z_turn) + get_path_direct(x2[1], z_turn)
                 except:
@@ -506,7 +498,6 @@ class ray_tracing_2D(ray_tracing_base):
             launch_angle = self.get_launch_angle(x1, C_0)
             beta = self.n(x1[1]) * np.sin(launch_angle)
             alpha = self.medium.n_ice ** 2 - beta ** 2
-    #         print("launchangle {:.1f} beta {:.2g} alpha {:.2g}, n(z1) = {:.2g} n(z2) = {:.2g}".format(launch_angle/units.deg, beta, alpha, self.n(x1[1]), self.n(x2[1])))
 
             def l1(z):
                 gamma = self.n(z) ** 2 - beta ** 2
@@ -540,8 +531,6 @@ class ray_tracing_2D(ray_tracing_base):
                 int2 = get_s(z2, z2 < z_deep)
                 if (int1 == None or int2 == None):
                     return None
-    #             print('analytic {:.4g} ({:.0f} - {:.0f}={:.4g}, {:.4g})'.format(
-    #                 int2 - int1, get_s(x2[1]), x1[1], x2[1], get_s(x1[1])))
                 if (z1 < z_deep) == (z2 < z_deep):
                     # z0 and z1 on same side of z_deep
                     return int2 - int1
@@ -567,7 +556,6 @@ class ray_tracing_2D(ray_tracing_base):
                     z_turn = 0
                 else:
                     gamma_turn, z_turn = self.get_turning_point(self.medium.n_ice ** 2 - C_0 ** -2)
-    #             print('solution type {:d}, zturn = {:.1f}'.format(solution_type, z_turn))
                 try:
                     ttmp = get_ToF_direct(x1[1], z_turn) + get_ToF_direct(x2[1], z_turn)
                     tmp += ttmp
@@ -613,7 +601,7 @@ class ray_tracing_2D(ray_tracing_base):
             else:
                 x11, x1, x22, x2, C_0, C_1 = segment
                 
-            if cpp_available:
+            if cpp_available  and self.attenuation_model_int != 5:
                 mask = frequency > 0
                 freqs = self.__get_frequencies_for_attenuation(frequency, max_detector_freq)
                 tmp = np.zeros_like(freqs)
@@ -639,7 +627,6 @@ class ray_tracing_2D(ray_tracing_base):
                 mask = frequency > 0
                 freqs = self.__get_frequencies_for_attenuation(frequency, max_detector_freq)
                 gamma_turn, z_turn = self.get_turning_point(self.medium.n_ice ** 2 - C_0 ** -2)
-                print("_use_optimized_calculation", self._use_optimized_calculation)
 
                 if self._use_optimized_calculation:
                     # The integration of the attenuation factor along the path with scipy.quad is inefficient. The 
@@ -1147,14 +1134,11 @@ class ray_tracing_2D(ray_tracing_base):
             self.__logger.error("a solution for {:d} reflection(s) off the bottom reflective layer is requested, but ice model does not specify a reflective layer".format(reflection))
             raise AttributeError("a solution for {:d} reflection(s) off the bottom reflective layer is requested, but ice model does not specify a reflective layer".format(reflection))
 
-        if(cpp_available):
-            #             t = time.time()
-#             print("find solutions", x1, x2, self.medium.n_ice, self.medium.delta_n, self.medium.z_0, reflection, reflection_case, self.medium.reflection)
+        if cpp_available:
             tmp_reflection = copy.copy(self.medium.reflection)
             if(tmp_reflection is None):
                 tmp_reflection = 100  # this parameter will never be used but is required to be an into to be able to pass it to the C++ module, so set it to a positive number, i.e., a reflective layer above the ice
             solutions = wrapper.find_solutions(x1, x2, self.medium.n_ice, self.medium.delta_n, self.medium.z_0, reflection, reflection_case, tmp_reflection)
-#             print((time.time() -t)*1000.)
             return solutions
         else:
 
@@ -1203,7 +1187,6 @@ class ray_tracing_2D(ray_tracing_base):
             logC0_stop = 100
             delta_start = self.obj_delta_y(logC0_start, x1, x2, reflection, reflection_case)
             delta_stop = self.obj_delta_y(logC0_stop, x1, x2, reflection, reflection_case)
-        #     print(logC0_start, logC0_stop, delta_start, delta_stop, np.sign(delta_start), np.sign(delta_stop))
             if(np.sign(delta_start) != np.sign(delta_stop)):
                 self.__logger.info("solution with logC0 > {:.3f} exists".format(result.x[0]))
                 result2 = optimize.brentq(self.obj_delta_y, logC0_start, logC0_stop, args=(x1, x2, reflection, reflection_case))
@@ -1226,7 +1209,6 @@ class ray_tracing_2D(ray_tracing_base):
             logC0_stop = result.x[0] - 0.0001
             delta_start = self.obj_delta_y(logC0_start, x1, x2, reflection, reflection_case)
             delta_stop = self.obj_delta_y(logC0_stop, x1, x2, reflection, reflection_case)
-        #     print(logC0_start, logC0_stop, delta_start, delta_stop, np.sign(delta_start), np.sign(delta_stop))
             if(np.sign(delta_start) != np.sign(delta_stop)):
                 self.__logger.info("solution with logC0 < {:.3f} exists".format(result.x[0]))
                 result3 = optimize.brentq(self.obj_delta_y, logC0_start, logC0_stop, args=(x1, x2, reflection, reflection_case))
@@ -1300,7 +1282,6 @@ class ray_tracing_2D(ray_tracing_base):
 #        dydz = self.get_dydz_analytic(C_0, z_pos)
         angle = np.arctan(dydz)
 
-        # print(dydz,angoffdydz)
 
         return angle - angoff
 
@@ -1448,9 +1429,7 @@ class ray_tracing_2D(ray_tracing_base):
             C0check = self.get_C_0_from_angle(np.pi / 2., 0)
             C0check = C0check.x[0]
             gcheck = self.get_gamma(x2[1])
-            # print('C0check, gcheck',C0check,gcheck)
             ycheck = -self.get_y(gcheck, C0check, self.get_C_1([ycrit, 0], C0check)) + 2 * ycrit
-            # print('ycheck, x2[1]',ycheck,x2[1])
             if x2[0] < ycheck:
                 refraction = True
             if plot:
@@ -1536,7 +1515,6 @@ class ray_tracing_2D(ray_tracing_base):
         zsurf = 0
         gamma = self.get_gamma(zsurf)
 
-        # print('nxsin = ',nxsin)
         # find emission angle for starting point x1 to hit the surface at the specified angle
 
         # look at time and distance it takes for the signal to travel from the emitter to the surface
@@ -1549,7 +1527,6 @@ class ray_tracing_2D(ray_tracing_base):
             C0result = self.get_C_0_from_angle(th_emit, x[1])
             C0_emit = C0result.x[0]
 
-            # print(C0_emit)
             self.__logger.info(' emission angle for position {},{} is theta_emit= {}'.format(x[0], x[1], th_emit / units.deg))
 
             # x-coordinate where ray reaches surface; is always bigger than the x-position of the emitter

--- a/NuRadioMC/utilities/attenuation.h
+++ b/NuRadioMC/utilities/attenuation.h
@@ -142,7 +142,8 @@ double fit_GL3(double z, double frequency){
     double slope_interpolation = GL3_slopes[i_row] + slope_diff * (-z - i_row * z_step - z_start) / z_step;
     double offset_diff = GL3_offsets[i_row + 1] - GL3_offsets[i_row];
     double offset_interpolation = GL3_offsets[i_row] + offset_diff * (-z - i_row * z_step - z_start) / z_step;
-    return frequency * slope_interpolation + offset_interpolation;
+    // Restrict frequency to prevent negative attenuation lengths
+    return min(frequency, 0.6) * slope_interpolation + offset_interpolation;
 
 
 

--- a/NuRadioMC/utilities/attenuation.py
+++ b/NuRadioMC/utilities/attenuation.py
@@ -150,6 +150,8 @@ def get_attenuation_length(z, frequency, model):
     elif model == 'GL3':
         slopes = gl3_slope_interpolation(-z)
         offsets = gl3_offset_interpolation(-z)
+        if frequency > .6:     # restric frequency to prevent negative attenuation lengths
+            frequency = .6
         att_length_f = slopes * frequency + offsets
 
     elif(model == "MB1"):


### PR DESCRIPTION
This fixes the GL3 attenuation model for the C++ raytracer. Instead of using the GSL integrator (which had problems dealing with the GL3 model), the raytracer uses `get_path` to get points on the ray path, and then uses those to calculate the attenuation factor.
This is not 100% the same, but I tested the difference by generating a transmitter at random depths from 0.5m and 150m, and a transmitter at random depths between 30 and 3000m and distances between 50 and 3000m. This plot shows the difference between the attenuation factor of the C++ and the python raytracer, so the difference is under 1%.
![attenuation_test_random_points](https://user-images.githubusercontent.com/42930879/228969775-3aec02e4-eea7-4677-9744-a0be5f0c40d4.png)
To make it easier to compare, I also added the option to tell the raytracer to use python, even if the C++ implementation is available.

I also noticed another problem with the C++ raytracer: For frequencies above 1.4GHz or so, the interpolation can cause negative attenuation lenghts. Even though this is out of band, it can blow up the signal enough to overcome the filter. So I restricted the interpolation to 600MHz to prevent this.