### PR TITLE
Getter for the ARZ Model to query shower profiles

### DIFF
--- a/NuRadioMC/SignalGen/ARZ/ARZ.py
+++ b/NuRadioMC/SignalGen/ARZ/ARZ.py
@@ -63,7 +63,7 @@ def get_vector_potential(
     profile_ce: array of floats
         charge-excess values of the charge excess profile
     shower_type: string (default "HAD")
-        type of shower, either "HAD" (hadronic), "EM" (electromagnetic) or "TAU" (tau lepton induced)
+        type of shower, either "HAD" (hadronic) or "EM" (electromagnetic)
     n_index: float (default 1.78)
         index of refraction where the shower development takes place
     distance: float (default 1km)
@@ -477,7 +477,7 @@ class ARZ(object):
         shower_energy: float
             the energy of the shower
         shower_type: string (default "HAD")
-            type of shower, either "HAD" (hadronic), "EM" (electromagnetic) or "TAU" (tau lepton induced)
+            type of shower, either "HAD" (hadronic) or "EM" (electromagnetic)
         iN: int
             specify shower number
 
@@ -515,7 +515,7 @@ class ARZ(object):
         dt: float
             size of one time bin in units of time
         shower_type: string (default "HAD")
-            type of shower, either "HAD" (hadronic), "EM" (electromagnetic) or "TAU" (tau lepton induced)
+            type of shower, either "HAD" (hadronic) or "EM" (electromagnetic)
         n_index: float (default 1.78)
             index of refraction where the shower development takes place
         R: float (default 1km)
@@ -625,7 +625,7 @@ class ARZ(object):
             logger.error("Tau showers are not yet implemented")
             raise NotImplementedError("Tau showers are not yet implemented")
         else:
-            msg = "showers of type {} are not implemented. Use 'HAD', 'EM' or 'TAU'".format(shower_type)
+            msg = "showers of type {} are not implemented. Use 'HAD', 'EM'".format(shower_type)
             logger.error(msg)
             raise NotImplementedError(msg)
         if self._use_numba:
@@ -697,7 +697,7 @@ class ARZ(object):
         profile_ce: array of floats
             charge-excess values of the charge excess profile
         shower_type: string (default "HAD")
-            type of shower, either "HAD" (hadronic), "EM" (electromagnetic) or "TAU" (tau lepton induced)
+            type of shower, either "HAD" (hadronic) or "EM" (electromagnetic)
         n_index: float (default 1.78)
             index of refraction where the shower development takes place
         distance: float (default 1km)
@@ -1164,7 +1164,7 @@ class ARZ_tabulated(object):
         dt: float
             size of one time bin in units of time
         shower_type: string (default "HAD")
-            type of shower, either "HAD" (hadronic), "EM" (electromagnetic) or "TAU" (tau lepton induced)
+            type of shower, either "HAD" (hadronic) or "EM" (electromagnetic)
         n_index: float (default 1.78)
             index of refraction where the shower development takes place
         R: float (default 1km)

--- a/NuRadioMC/SignalGen/ARZ/ARZ.py
+++ b/NuRadioMC/SignalGen/ARZ/ARZ.py
@@ -468,6 +468,38 @@ class ARZ(object):
         """
         self._interp_factor2 = interp_factor
 
+    def get_shower_profile(self, shower_energy, shower_type, iN):
+        """
+        Gets a charge-excess profile
+
+        Parameters
+        ----------
+        shower_energy: float
+            the energy of the shower
+        shower_type: string (default "HAD")
+            type of shower, either "HAD" (hadronic), "EM" (electromagnetic) or "TAU" (tau lepton induced)
+        iN: int
+            specify shower number
+
+        Returns
+        -------
+        efield_trace: two arrays of floats
+            slant depths and charge profile amplitudes
+        """
+
+        energies = np.array([*self._library[shower_type]])
+        iE = np.argmin(np.abs(energies - shower_energy))
+
+        rescaling_factor = shower_energy / energies[iE]
+
+        profiles = self._library[shower_type][energies[iE]]
+        N_profiles = len(profiles['charge_excess'])
+        profile_depth = profiles['depth']
+        profile_ce = profiles['charge_excess'][iN] * rescaling_factor
+
+        return profile_depth, profile_ce
+
+
     def get_time_trace(self, shower_energy, theta, N, dt, shower_type, n_index, R, shift_for_xmax=False,
                        same_shower=False, iN=None, output_mode='trace', maximum_angle=20 * units.deg):
         """
@@ -483,10 +515,6 @@ class ARZ(object):
             number of samples in the time domain
         dt: float
             size of one time bin in units of time
-        profile_depth: array of floats
-            shower depth values of the charge excess profile
-        profile_ce: array of floats
-            charge-excess values of the charge excess profile
         shower_type: string (default "HAD")
             type of shower, either "HAD" (hadronic), "EM" (electromagnetic) or "TAU" (tau lepton induced)
         n_index: float (default 1.78)
@@ -537,6 +565,7 @@ class ARZ(object):
         rescaling_factor = shower_energy / energies[iE]
         logger.info("shower energy of {:.3g}eV requested, closest available energy is {:.3g}eV. The amplitude of the charge-excess profile will be rescaled accordingly by a factor of {:.2f}".format(shower_energy / units.eV, energies[iE] / units.eV, rescaling_factor))
         profiles = self._library[shower_type][energies[iE]]
+
         N_profiles = len(profiles['charge_excess'])
 
         if(iN is None or np.isnan(iN)):

--- a/NuRadioMC/SignalGen/ARZ/ARZ.py
+++ b/NuRadioMC/SignalGen/ARZ/ARZ.py
@@ -483,7 +483,7 @@ class ARZ(object):
 
         Returns
         -------
-        efield_trace: two arrays of floats
+        depth, excess: two arrays of floats
             slant depths and charge profile amplitudes
         """
 
@@ -493,7 +493,6 @@ class ARZ(object):
         rescaling_factor = shower_energy / energies[iE]
 
         profiles = self._library[shower_type][energies[iE]]
-        N_profiles = len(profiles['charge_excess'])
         profile_depth = profiles['depth']
         profile_ce = profiles['charge_excess'][iN] * rescaling_factor
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ please update the categories "new features" and "bugfixes" before a pull request
 
 version 2.2.0-dev
 new features:
+- added getting to query ARZ charge-excess profiles
 - upgrade to proposal v 7.5.0 with new NuRadioProposal interface and improved LPM treatment
 - add script to generate / download pre-calculated proposal tables for known detector configurations
 - adding default RadioPropa ice model object to medium with the feature to set a personlised object as alternative


### PR DESCRIPTION
Issue being addressed:

There isn't a way to directly extract the charge-excess profile distributions in the ARZ model. This PR simply adds a getter to query them directly from the ARZ class
