### PR TITLE
Fixing the mattak RNO-G reader.

### DIFF
--- a/NuRadioReco/examples/RNO_data/read_data_example/read_rnog.py
+++ b/NuRadioReco/examples/RNO_data/read_data_example/read_rnog.py
@@ -9,7 +9,7 @@ import logging
 list_of_root_files = sys.argv[1:-1]
 output_filename = sys.argv[-1]
 
-rnog_reader = readRNOGDataMattak.readRNOGData()
+rnog_reader = readRNOGDataMattak.readRNOGData(log_level=logging.DEBUG)
 writer = eventWriter.eventWriter()
 
 """
@@ -53,11 +53,9 @@ rnog_reader.begin(
 
 writer.begin(filename=output_filename)
 
-for i_event, event in enumerate(rnog_reader.run()):
-    
+for i_event, event in enumerate(rnog_reader.run()):   
     writer.run(event)
 
-print(i_event)
 rnog_reader.end()
 writer.end()
 

--- a/NuRadioReco/examples/RNO_data/read_data_example/read_rnog.py
+++ b/NuRadioReco/examples/RNO_data/read_data_example/read_rnog.py
@@ -36,7 +36,6 @@ selectors = [lambda einfo: einfo.triggerType == "FORCE"]
 rnog_reader.begin(
     list_of_root_files, 
     selectors=selectors, 
-    log_level=logging.INFO, 
     # Currently false because Mattak does not contain calibrated data yet
 	read_calibrated_data=False,
  	# Only used when read_calibrated_data==False, performs a simple baseline subtraction each 128 bins

--- a/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
+++ b/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
@@ -295,7 +295,7 @@ class readRNOGData:
         if "verbose" in mattak_kwargs:
             verbose = mattak_kwargs.pop("verbose")
         else:
-            verbose =  self.logger.level == logging.DEBUG
+            verbose = self.logger.level >= logging.DEBUG
 
         for dir_file in dirs_files:
 

--- a/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
+++ b/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
@@ -155,7 +155,7 @@ class readRNOGData:
                                       "Runs can not be filtered.")
             except ImportError:
                 self.logger.warn("Import of run table failed. Runs can not be filtered.! \n" 
-                        "You can get the interface from GitHub: git@github.com:RNO-G/rnog-data-analysis-and-issues.git")
+                        "You can get the interface from GitHub: git@github.com:RNO-G/rnog-runtable.git")
         else:
             import pandas
             self.__run_table = pandas.read_csv(run_table_path)

--- a/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
+++ b/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
@@ -306,9 +306,13 @@ class readRNOGData:
             
                 if not all_files_in_directory(dir_file):
                     self.logger.error(f"Incomplete directory: {dir_file}. Skip ...")
-                    continue      
-            
-                dataset = mattak.Dataset.Dataset(station=0, run=0, data_dir=dir_file, verbose=verbose, **mattak_kwargs)
+                    continue
+                
+                try:
+                    dataset = mattak.Dataset.Dataset(station=0, run=0, data_dir=dir_file, verbose=verbose, **mattak_kwargs)
+                except Exception as e:
+                    self.logger.error(f"The following Exeption was raised reading in the run: f{dir_file}. Skip that run ...: {e}")
+                    continue
             else:
                 raise NotImplementedError("The option to read in files is not implemented yet")
 
@@ -474,7 +478,7 @@ class readRNOGData:
             for selector in self._selectors:
                 if not selector(evtinfo):
                     self.logger.debug(f"Event {event_idx} (station {evtinfo.station}, run {evtinfo.run}, "
-                                            f"event number {evtinfo.eventNumber}) is skipped.")
+                                      f"event number {evtinfo.eventNumber}) is skipped.")
                     self.__skipped += 1
                     return True
         
@@ -772,9 +776,13 @@ class readRNOGData:
 
 
     def end(self):
-        self.logger.info(
-            f"\n\tRead {self.__counter} events (skipped {self.__skipped} events, {self.__invalid} invalid events)"
-            f"\n\tTime to initialize data sets  : {self._time_begin:.2f}s"
-            f"\n\tTime to read all events       : {self._time_run:.2f}s"
-            f"\n\tTime to per event             : {self._time_run / self.__counter:.2f}s"
-            f"\n\tRead {self.__n_runs} runs, skipped {self.__skipped_runs} runs.")
+        if self.__counter:
+            self.logger.info(
+                f"\n\tRead {self.__counter} events (skipped {self.__skipped} events, {self.__invalid} invalid events)"
+                f"\n\tTime to initialize data sets  : {self._time_begin:.2f}s"
+                f"\n\tTime to read all events       : {self._time_run:.2f}s"
+                f"\n\tTime to per event             : {self._time_run / self.__counter:.2f}s"
+                f"\n\tRead {self.__n_runs} runs, skipped {self.__skipped_runs} runs.")
+        else:
+            self.logger.info(
+                f"\n\tRead {self.__counter} events (skipped {self.__skipped} events, {self.__invalid} invalid events)")

--- a/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
+++ b/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
@@ -132,14 +132,20 @@ def all_files_in_directory(mattak_dir):
 
 class readRNOGData:
     
-    def __init__(self, run_table_path=None):
+    def __init__(self, run_table_path=None, log_level=logging.INFO):
         """
         Parameters
         ----------
         
         run_table_path: str
             Path to a run_table.cvs file. If None, the run table is queried from the DB. (Default: None)
+            
+        log_level: enum
+            Set verbosity level of logger. If logging.DEBUG, set mattak to verbose (unless specified in mattak_kwargs).
+            (Default: logging.INFO) 
         """
+        self.logger = logging.getLogger('NuRadioReco.readRNOGData')
+        self.logger.setLevel(log_level)
      
         # Initialize run table for run selection
         self.__run_table = None
@@ -173,8 +179,7 @@ class readRNOGData:
             run_time_range=None,
             max_trigger_rate=0 * units.Hz,
             mattak_kwargs={},
-            overwrite_sampling_rate=None,
-            log_level=logging.INFO):
+            overwrite_sampling_rate=None):
         """
         Parameters
         ----------
@@ -232,16 +237,9 @@ class readRNOGData:
             Set sampling rate of the imported waveforms. This overwrites what is read out from runinfo (i.e., stored in the mattak files).
             If None, nothing is overwritten and the sampling rate from the mattak file is used. (Default: None)
             NOTE: This option might be necessary when old mattak files are read which have this not set. 
-
-        log_level: enum
-            Set verbosity level of logger. If logging.DEBUG, set mattak to verbose (unless specified in mattak_kwargs).
-            (Default: logging.INFO) 
         """
         
         t0 = time.time()
-        
-        self.logger = logging.getLogger('NuRadioReco.readRNOGData')
-        self.logger.setLevel(log_level)
         
         self._read_calibrated_data = read_calibrated_data
         self._apply_baseline_correction = apply_baseline_correction

--- a/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
+++ b/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
@@ -294,7 +294,7 @@ class readRNOGData:
         if "verbose" in mattak_kwargs:
             verbose = mattak_kwargs.pop("verbose")
         else:
-            verbose = log_level == logging.DEBUG
+            verbose =  self.logger.level == logging.DEBUG
 
         for dir_file in dirs_files:
             

--- a/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
+++ b/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
@@ -14,6 +14,7 @@ import NuRadioReco.framework.trigger
 
 from NuRadioReco.utilities import units
 import mattak.Dataset
+import uproot  # only needed to catch an exception
 
 
 def baseline_correction(wfs, n_bins=128, func=np.median):
@@ -297,7 +298,7 @@ class readRNOGData:
             verbose =  self.logger.level == logging.DEBUG
 
         for dir_file in dirs_files:
-            
+
             if not os.path.exists(dir_file):
                 self.logger.error(f"The directory/file {dir_file} does not exist")
                 continue
@@ -310,8 +311,11 @@ class readRNOGData:
                 
                 try:
                     dataset = mattak.Dataset.Dataset(station=0, run=0, data_dir=dir_file, verbose=verbose, **mattak_kwargs)
-                except Exception as e:
-                    self.logger.error(f"The following Exeption was raised reading in the run: f{dir_file}. Skip that run ...: {e}")
+                except (ReferenceError, uproot.exceptions.KeyInFileError) as e:
+                    self.logger.error(f"The following exeption was raised reading in the run: {dir_file}. Skip that run ...:\n")
+                    import traceback
+                    traceback.print_exc()
+                    print("")
                     continue
             else:
                 raise NotImplementedError("The option to read in files is not implemented yet")

--- a/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
+++ b/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
@@ -14,7 +14,6 @@ import NuRadioReco.framework.trigger
 
 from NuRadioReco.utilities import units
 import mattak.Dataset
-import uproot  # only needed to catch an exception
 
 
 def baseline_correction(wfs, n_bins=128, func=np.median):
@@ -311,7 +310,7 @@ class readRNOGData:
                 
                 try:
                     dataset = mattak.Dataset.Dataset(station=0, run=0, data_dir=dir_file, verbose=verbose, **mattak_kwargs)
-                except (ReferenceError, uproot.exceptions.KeyInFileError) as e:
+                except (ReferenceError, KeyError) as e:
                     self.logger.error(f"The following exeption was raised reading in the run: {dir_file}. Skip that run ...:\n")
                     import traceback
                     traceback.print_exc()

--- a/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
+++ b/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
@@ -311,10 +311,7 @@ class readRNOGData:
                 try:
                     dataset = mattak.Dataset.Dataset(station=0, run=0, data_dir=dir_file, verbose=verbose, **mattak_kwargs)
                 except (ReferenceError, KeyError) as e:
-                    self.logger.error(f"The following exeption was raised reading in the run: {dir_file}. Skip that run ...:\n")
-                    import traceback
-                    traceback.print_exc()
-                    print("")
+                    self.logger.error(f"The following exeption was raised reading in the run: {dir_file}. Skip that run ...:\n", exc_info=e)
                     continue
             else:
                 raise NotImplementedError("The option to read in files is not implemented yet")


### PR DESCRIPTION
This PR implements fixes for bugs found by @thoglu.

First it fixes a simple bug in the `__init__` which was introduce by me with the last PR. A few other minor fixes and corrections to the corresponding example script.

Than it wraps an `try` and `except` block around the `mattak.dataset.Dataset` to catch faulty files. In principle we could also try to check wether files are okay in a function like `all_files_in_directory` but I am not sure how robust that is. Checking the file size is somewhat primitive. Any comments @shallmann @sjoerd-bouma 

