### PR TITLE
Expand the phased-array noise gen

### DIFF
--- a/NuRadioReco/utilities/noise.py
+++ b/NuRadioReco/utilities/noise.py
@@ -233,7 +233,7 @@ class thermalNoiseGeneratorPhasedArray():
                  Vrms, threshold, ref_index,
                  noise_type="rayleigh", log_level=logging.WARNING,
                  pre_trigger_time=100 * units.ns, trace_length=512 * units.ns, filt=None,
-                 window_length=16 * units.ns, step_size=8 * units.ns,
+                 upsampling=2, window_length=16 * units.ns, step_size=8 * units.ns,
                  main_low_angle=np.deg2rad(-59.54968597864437), 
                  main_high_angle=np.deg2rad(59.54968597864437),
                  n_beams=11, quantize=True):
@@ -283,7 +283,7 @@ class thermalNoiseGeneratorPhasedArray():
         self.debug = False
         self.max_amp = 0
 
-        self.upsampling = 2
+        self.upsampling = upsampling
         self.det = detector.GenericDetector(json_filename=detector_filename)
         self.det.update(datetime.datetime(2018, 10, 1))
         self.n_samples = self.det.get_number_of_samples(station_id, triggered_channels[0])  # assuming same settings for all channels

--- a/NuRadioReco/utilities/noise.py
+++ b/NuRadioReco/utilities/noise.py
@@ -266,6 +266,8 @@ class thermalNoiseGeneratorPhasedArray():
             the total trace length
         filt: array of complex values
             the filter that should be applied after noise generation (needs to match frequency binning in upsampled domain)
+        upsampling: int
+            factor by which the waveforms will be upsampled before calculating time delays and beamforming
         window_length: float
             time interval of the integration window
         step_size: float
@@ -348,7 +350,7 @@ class thermalNoiseGeneratorPhasedArray():
         else:
             if len(filt) != len(self.ff):
                 logger.error(f"Frequency filter supplied has {len(filt)} bins. It should match the upsampled" +
-                             f" frequency binning of {len(ff)} bins from {ff[0] / units.MHz:.0f} to {ff[-1] / units.MHz:.0f} MHz")
+                             f" frequency binning of {len(self.ff)} bins from {self.ff[0] / units.MHz:.0f} to {self.ff[-1] / units.MHz:.0f} MHz")
                 exit()
             self.filt = np.array(filt)
 

--- a/NuRadioReco/utilities/noise.py
+++ b/NuRadioReco/utilities/noise.py
@@ -565,7 +565,7 @@ class thermalNoiseGeneratorPhasedArray():
                 self._traces = scipy.signal.resample(self._traces, np.shape(self._traces)[-1] // self.upsampling, axis=-1)
 
                 if (i_low >= 0) and (i_high < self.n_samples): # If range is directly a subset of the waveform
-                    return self._traces[:, i_low:i_high], self._phased_traces
+                    return self._traces[:, i_low:i_high], self._phased_traces, triggered_beam
 
                 # Otherwise, roll the waveforms. Safe as long as noise is generated in the freq domain
                 self._phased_traces = np.roll(self._phased_traces, -i_low * self.upsampling, axis=-1)


### PR DESCRIPTION
This is expanding the utility of the phased-array noise generation module. It simply allows the user full configuration of all the previously hard-coded values.

It also fixes a "bug" where waveforms weren't used because of where the trigger actually was instead of rolling. So this version is more efficient.