### PR TITLE
improve documentation script error parsing

### DIFF
--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -w sphinx-debug.log
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = NuRadio
 SOURCEDIR     = source

--- a/documentation/make_docs.py
+++ b/documentation/make_docs.py
@@ -114,7 +114,7 @@ if __name__ == "__main__":
     sphinx_log = subprocess.run(['make', 'html'], stderr=subprocess.PIPE, stdout=pipe_stdout)
 
     # we write out all the sphinx errors to sphinx-debug.log, and parse these
-    with open('sphix-debug.log') as f:
+    with open('sphinx-debug.log') as f:
         errs_raw = f.read()
     errs_sphinx = re.split('\\x1b\[[0-9;]+m', errs_raw) # split the errors
      


### PR DESCRIPTION
The documentation test currently fails because the `make_docs.py` still parses errors by string recognition, which is tricky for multi-line errors. This PR should split up the errors into errors emitted by sphinx-build (which are easier to separate and parse) and other errors during the build process, which the documentation script should now no longer fail on.