### PR TITLE
This allows to specify root files to be read with the mattak reader i…

### DIFF
--- a/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
+++ b/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
@@ -18,9 +18,26 @@ import mattak.Dataset
 import string
 import random
 
+
 def create_random_directory_path(prefix="/tmp/", n=7):
+    """
+    Produces a path for a temporary directory with a n letter random suffix
     
-    # using random.choices()
+    Parameters
+    ----------
+    
+    prefix: str
+        Path prefix, i.e., root directory. (Defaut: /tmp/)
+        
+    n: int
+        Number of letters for the random suffix. (Default: 7)
+        
+    Returns
+    -------
+    
+    path: str
+        Return path (e.g, /tmp/readRNOGData_XXXXXXX)
+    """
     # generating random strings
     res = ''.join(random.choices(string.ascii_lowercase + string.digits, k=n))
     path = os.path.join(prefix, "readRNOGData_" + res)
@@ -325,6 +342,10 @@ class readRNOGData:
                     self.logger.error(f"Incomplete directory: {dir_file}. Skip ...")
                     continue
             else:
+                # Providing direct paths to a Mattak combined.root file is not supported by the mattak library yet. 
+                # It only accepts directry paths in which it will look for a file called `combined.root` (or waveforms.root if 
+                # it is not a combined file). To work around this: Create a tmp directory under `/tmp/`, link the file you want to
+                # read into this directory with the the name `combined.root`, use this path to read the run.
                 
                 path = create_random_directory_path()
                 self.logger.debug(f"Create temporary directory: {path}")
@@ -332,21 +353,19 @@ class readRNOGData:
                     raise ValueError(f"Temporary directory {path} already exists.")
                 
                 os.mkdir(path)
-                self.__temporary_dirs.append(path)
+                self.__temporary_dirs.append(path)  # for housekeeping
                 
                 self.logger.debug(f"Create symlink for {dir_file}")
                 os.symlink(dir_file, os.path.join(path, "combined.root"))
                 
-                dir_file = path
+                dir_file = path  # set path to e.g. /tmp/NuRadioReco_XXXXXXX/combined.root
                 
-                # raise NotImplementedError("The option to read in files is not implemented yet")
 
             try:
                 dataset = mattak.Dataset.Dataset(station=0, run=0, data_dir=dir_file, verbose=verbose, **mattak_kwargs)
             except (ReferenceError, KeyError) as e:
                 self.logger.error(f"The following exeption was raised reading in the run: {dir_file}. Skip that run ...:\n", exc_info=e)
                 continue
-
 
             # filter runs/datasets based on 
             if select_runs and self.__run_table is not None and not self.__select_run(dataset):
@@ -816,8 +835,9 @@ class readRNOGData:
                 f"\n\tRead {self.__n_runs} runs, skipped {self.__skipped_runs} runs.")
         else:
             self.logger.info(
-                f"\n\tRead {self.__counter} events (skipped {self.__skipped} events, {self.__invalid} invalid events)")
-            
+                f"\n\tRead {self.__counter} events   (skipped {self.__skipped} events, {self.__invalid} invalid events)")
+        
+        # Clean up links and temporary directories.
         for d in self.__temporary_dirs:
             self.logger.debug(f"Remove temporary folder: {d}")
             os.unlink(os.path.join(d, "combined.root"))


### PR DESCRIPTION
…nstead of directories. Because the mattak library can not handle this so far we have to employ some diry hack. Create a temp directory and link the file in question to a the file combined.root within the directory. Simple and naive housekeeing included

This is not suppose to be a long term solution. But I feel that this feature is needed! 