### PR TITLE
upgrade proposal to version 7.6.2

### DIFF
--- a/documentation/source/Introduction/pages/installation.rst
+++ b/documentation/source/Introduction/pages/installation.rst
@@ -189,7 +189,7 @@ These packages are recommended to be able to use all of NuRadioMC/NuRadioReco's 
 
   .. code-block:: bash
 
-    pip install proposal==7.5.1
+    pip install proposal==7.6.2
 
   Note that the pip installation for this version of proposal may not work on all systems, in particular:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ numba = "*"
 Sphinx = "*"
 sphinx-rtd-theme = "*"
 numpydoc = "*"
-proposal = "7.5.1"
+proposal = "7.6.2"
 pygdsm = {git = "https://github.com/telegraphic/pygdsm"}
 nifty5 = {git = "https://gitlab.mpcdf.mpg.de/ift/nifty.git", branch="NIFTy_5"}
 pypocketfft = {git = "https://gitlab.mpcdf.mpg.de/mtr/pypocketfft"}


### PR DESCRIPTION
Upgrade PROPOSAL to version 7.6.2

Notably, this upgrades the package manager `conan` (which is used to install proposal dependencies) from version 1 to version 2. This should increase stability, and hopefully fix #569 

Full release notes of PROPOSAL can be found [here](https://github.com/tudo-astroparticlephysics/PROPOSAL/releases), although none of the other changes should affect NuRadioMC.