### PR TITLE
Bug fix for antennapattern.py

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,37 +2,22 @@ Changelog - to keep track of all relevant changes
 
 please update the categories "new features" and "bugfixes" before a pull request merge!
 
-version 2.2.0-dev
-new features:
-- added getting to query ARZ charge-excess profiles
-- upgrade to proposal v 7.5.0 with new NuRadioProposal interface and improved LPM treatment
-- add script to generate / download pre-calculated proposal tables for known detector configurations
-- adding default RadioPropa ice model object to medium with the feature to set a personlised object as alternative
-- add positions array functionality to simple ice model in average and gradient functions
-- analytic ray tracing solutions are now sorted consistently from lowest to highest ray
-- added ability to generate high-low-triggered noise on a narrow band but return full-band waveforms
-- phased array noise generation utility class: calculate trigger time and cut trace accordingly
-- use Philox noise generator in noise adder module (this changes the default random sequence)
-
+version 2.1.8:
 bugfixes:
-- fixed/improved C++ raytracer not finding solutions for some near-horizontal or near-shadowzone vertices
-- fixed wrong number in Feldman-Cousins upper limit
-
-version 2.1.8
-bugfixes:
-- replace deprecated np.float with float
+- fixed bug in antennapattern where frequencies for the analytic_LPDA model were allowed to = 0 instead of the correct > 0 
 
 version 2.1.7
 new features:
 - add attenuation model from the 2021 measurements taken at Summit Station
-- print warning for positive z in attenuation, and set attenuation length to +inf for positive z
+- print warning for positive z in attenuation, and set attenuation length to
++inf for positive z
 - adding minimize mode to the radiopropa propagation module & more configurable settings in config file
 - add uniform ice model with 1.78 refractive index
 - update ARA detector description and add a file to Print ARA detector json file
-- pass evt_time to sim station
 bugfixes:
 - fix bug in NuRadioProposal which pervented muons from tau decays to be propagated
 - update proposal version to 6.1.8 to avoid problems with pypi
+
 
 version 2.1.6
 bugfixes:
@@ -45,10 +30,11 @@ secondary interactions. With this bug, the initial interaction needs to be idenf
 This bug does not effect any effective volume calculation. 
 
 new features:
-- add hvsp1, update idl1 model for emitter simulation (from KU lab measurements) and remove hvsp2(no longer in use for experiment)
+- add hvsp1, update idl1 model for emitter simulation (from KU lab measurements) and remove
+hvsp2(no longer in use for experiment)
 - add CalPulser data for emitter simulation
-
 version 2.1.5
+new features:
 
 bugfixes:
 - the phased array trigger module did not calculate the trigger time.


### PR DESCRIPTION
Extremely minor bugfix. In antennapattern.py, class AntennaPatternAnalytic._get_antenna_response_vectorized_raw, line 1410, frequencies are constrained by the following mask for the "analytic_LPDA" antenna model:

`fmask = freq >= 0`

However, this allows for frequencies that are equal to 0, which causes issues later on, as other parameters are divided by the frequency. If freq = 0, of course, this returns NaN values for those parameters.

My fix is simply:
`fmask = freq > 0`
so that NaNs can not be produced if one uses this antenna model.

