### PR TITLE
Remove non built-in objects for the __modules_event list which gets s…

### DIFF
--- a/NuRadioReco/framework/event.py
+++ b/NuRadioReco/framework/event.py
@@ -8,13 +8,8 @@ import NuRadioReco.framework.parameters as parameters
 import NuRadioReco.utilities.version
 from six import itervalues
 import collections
-import copy
 import logging
 logger = logging.getLogger('Event')
-
-
-def is_serializable(obj):
-    return obj.__class__.__module__ == 'builtins' or obj.__class__.__module__ == "numpy"
 
 
 class Event:
@@ -46,15 +41,6 @@ class Event:
         kwargs:
             the key word arguments of the run method
         """
-        kwargs = copy.deepcopy(kwargs)
-        # Not every kwargs argument passed to a run(..) method is serializable. Example is a detector object. 
-        # Drop all arguments for which this is the case
-        keys_to_be_dropped = [key for key in kwargs 
-                             if not is_serializable(kwargs[key])]
-        
-        for key in keys_to_be_dropped:
-            logger.warn(f"Dropping \"{key}\" of type {type(kwargs[key])} from kwargs of __modules_event")
-            kwargs.pop(key)
                 
         self.__modules_event.append([name, instance, kwargs])
 
@@ -73,20 +59,9 @@ class Event:
         kwargs:
             the key word arguments of the run method
         """
-        kwargs = copy.deepcopy(kwargs)
-
         if station_id not in self.__modules_station:
             self.__modules_station[station_id] = []
             
-        # Not every kwargs argument passed to a run(..) method is serializable. Example is a detector object. 
-        # Drop all arguments for which this is the case
-        keys_to_be_dropped = [key for key in kwargs 
-                             if not is_serializable(kwargs[key])]
-        
-        for key in keys_to_be_dropped:
-            logger.warn(f"Dropping \"{key}\" of type {type(kwargs[key])} from kwargs of __modules_station")
-            kwargs.pop(key)
-        
         iE = len(self.__modules_event)
         self.__modules_station[station_id].append([iE, name, instance, kwargs])
 

--- a/NuRadioReco/framework/event.py
+++ b/NuRadioReco/framework/event.py
@@ -12,8 +12,8 @@ import logging
 logger = logging.getLogger('Event')
 
 
-def is_builtin_class_instance(obj):
-    return obj.__class__.__module__ == '__builtin__'
+def is_serializable(obj):
+    return obj.__class__.__module__ == 'builtins' or obj.__class__.__module__ == "numpy"
 
 
 class Event:
@@ -46,9 +46,10 @@ class Event:
             the key word arguments of the run method
         """
         key_to_be_dropped = [key for key in kwargs 
-                             if not is_builtin_class_instance(kwargs[key])]
+                             if not is_serializable(kwargs[key])]
         
         for key in key_to_be_dropped:
+            logger.warn(f"Dropping \"{key}\" of type {type(kwargs[key])} from kwargs of __modules_event")
             kwargs.pop(key)
                 
         self.__modules_event.append([name, instance, kwargs])
@@ -72,9 +73,10 @@ class Event:
             self.__modules_station[station_id] = []
             
         key_to_be_dropped = [key for key in kwargs 
-                             if not is_builtin_class_instance(kwargs[key])]
+                             if not is_serializable(kwargs[key])]
         
         for key in key_to_be_dropped:
+            logger.warn(f"Dropping \"{key}\" of type {type(kwargs[key])} from kwargs of __modules_station")
             kwargs.pop(key)
         
         iE = len(self.__modules_event)

--- a/NuRadioReco/framework/event.py
+++ b/NuRadioReco/framework/event.py
@@ -8,6 +8,7 @@ import NuRadioReco.framework.parameters as parameters
 import NuRadioReco.utilities.version
 from six import itervalues
 import collections
+import copy
 import logging
 logger = logging.getLogger('Event')
 
@@ -45,7 +46,7 @@ class Event:
         kwargs:
             the key word arguments of the run method
         """
-        
+        kwargs = copy.deepcopy(kwargs)
         # Not every kwargs argument passed to a run(..) method is serializable. Example is a detector object. 
         # Drop all arguments for which this is the case
         keys_to_be_dropped = [key for key in kwargs 
@@ -72,6 +73,8 @@ class Event:
         kwargs:
             the key word arguments of the run method
         """
+        kwargs = copy.deepcopy(kwargs)
+
         if station_id not in self.__modules_station:
             self.__modules_station[station_id] = []
             

--- a/NuRadioReco/framework/event.py
+++ b/NuRadioReco/framework/event.py
@@ -45,10 +45,13 @@ class Event:
         kwargs:
             the key word arguments of the run method
         """
-        key_to_be_dropped = [key for key in kwargs 
+        
+        # Not every kwargs argument passed to a run(..) method is serializable. Example is a detector object. 
+        # Drop all arguments for which this is the case
+        keys_to_be_dropped = [key for key in kwargs 
                              if not is_serializable(kwargs[key])]
         
-        for key in key_to_be_dropped:
+        for key in keys_to_be_dropped:
             logger.warn(f"Dropping \"{key}\" of type {type(kwargs[key])} from kwargs of __modules_event")
             kwargs.pop(key)
                 
@@ -72,10 +75,12 @@ class Event:
         if station_id not in self.__modules_station:
             self.__modules_station[station_id] = []
             
-        key_to_be_dropped = [key for key in kwargs 
+        # Not every kwargs argument passed to a run(..) method is serializable. Example is a detector object. 
+        # Drop all arguments for which this is the case
+        keys_to_be_dropped = [key for key in kwargs 
                              if not is_serializable(kwargs[key])]
         
-        for key in key_to_be_dropped:
+        for key in keys_to_be_dropped:
             logger.warn(f"Dropping \"{key}\" of type {type(kwargs[key])} from kwargs of __modules_station")
             kwargs.pop(key)
         

--- a/NuRadioReco/framework/event.py
+++ b/NuRadioReco/framework/event.py
@@ -443,12 +443,18 @@ class Event:
         modules_out_event = []
         for value in self.__modules_event:  # remove module instances (this will just blow up the file size)
             modules_out_event.append([value[0], None, value[2]])
+            invalid_keys = [key for key,val in value[2].items() if isinstance(val, TypeError)]
+            if len(invalid_keys):
+                logger.warning(f"The following arguments to module {value[0]} could not be serialized and will not be stored: {invalid_keys}")
 
         modules_out_station = {}
         for key in self.__modules_station:  # remove module instances (this will just blow up the file size)
             modules_out_station[key] = []
             for value in self.__modules_station[key]:
                 modules_out_station[key].append([value[0], value[1], None, value[3]])
+                invalid_keys = [key for key,val in value[3].items() if isinstance(val, TypeError)]
+                if len(invalid_keys):
+                    logger.warning(f"The following arguments to module {value[0]} could not be serialized and will not be stored: {invalid_keys}")
 
         data = {'_parameters': self._parameters,
                 '__run_number': self.__run_number,

--- a/NuRadioReco/framework/event.py
+++ b/NuRadioReco/framework/event.py
@@ -443,7 +443,7 @@ class Event:
         modules_out_event = []
         for value in self.__modules_event:  # remove module instances (this will just blow up the file size)
             modules_out_event.append([value[0], None, value[2]])
-            invalid_keys = [key for key,val in value[2].items() if isinstance(val, TypeError)]
+            invalid_keys = [key for key,val in value[2].items() if isinstance(val, BaseException)]
             if len(invalid_keys):
                 logger.warning(f"The following arguments to module {value[0]} could not be serialized and will not be stored: {invalid_keys}")
 
@@ -452,7 +452,7 @@ class Event:
             modules_out_station[key] = []
             for value in self.__modules_station[key]:
                 modules_out_station[key].append([value[0], value[1], None, value[3]])
-                invalid_keys = [key for key,val in value[3].items() if isinstance(val, TypeError)]
+                invalid_keys = [key for key,val in value[3].items() if isinstance(val, BaseException)]
                 if len(invalid_keys):
                     logger.warning(f"The following arguments to module {value[0]} could not be serialized and will not be stored: {invalid_keys}")
 

--- a/NuRadioReco/modules/base/module.py
+++ b/NuRadioReco/modules/base/module.py
@@ -64,7 +64,7 @@ def register_run(level=None):
             for key,value in parameters.items():
                 if key not in all_kwargs.keys():
                     if value.default is not inspect.Parameter.empty:
-                        all_kwargs[key] = value
+                        all_kwargs[key] = value.default
 
             for key,value in all_kwargs.items():
                 if isinstance(value, NuRadioReco.framework.event.Event):

--- a/NuRadioReco/modules/base/module.py
+++ b/NuRadioReco/modules/base/module.py
@@ -39,20 +39,21 @@ def register_run(level=None):
             # generator, so not sure how to access the event.
             evt = None
             station = None
+            
             # find out type of module automatically
-            if(len(args) == 1):
-                if(isinstance(args[0], NuRadioReco.framework.event.Event)):
+            if len(args) == 1:
+                if isinstance(args[0], NuRadioReco.framework.event.Event):
                     module_level = "event"
                     evt = args[0]
                 else:
                     # this is a module that creats events
                     module_level = "reader"
-            elif(len(args) >= 2):
-                if(isinstance(args[0], NuRadioReco.framework.event.Event) and isinstance(args[1], NuRadioReco.framework.base_station.BaseStation)):
+            elif len(args) >= 2:
+                if isinstance(args[0], NuRadioReco.framework.event.Event) and isinstance(args[1], NuRadioReco.framework.base_station.BaseStation):
                     module_level = "station"
                     evt = args[0]
                     station = args[1]
-                elif(isinstance(args[0], NuRadioReco.framework.event.Event)):
+                elif isinstance(args[0], NuRadioReco.framework.event.Event):
                     module_level = "event"
                     evt = args[0]
                 else:
@@ -64,18 +65,27 @@ def register_run(level=None):
                 module_level = "reader"
 
             start = timer()
-            res = run(self, *args, **kwargs)
-            if(module_level == "event"):
+
+            # Currently we are not storing the args with which the module is called. Typically those are the event and/or station
+            # on which the module is run which should not be stored here. The danger is if other data is passed as args
+            # kwargs["args"] = args  # otherwise we do not store the args 
+            
+            if module_level == "event":
                 evt.register_module_event(self, self.__class__.__name__, kwargs)
-            elif(module_level == "station"):
+            elif module_level == "station":
                 evt.register_module_station(station.get_id(), self, self.__class__.__name__, kwargs)
-            elif(module_level == "reader"):
+            elif module_level == "reader":
                 # not sure what to do... function returns generator, not sure how to access the event...
                 pass
+            
+            res = run(self, *args, **kwargs)
+            
             end = timer()
+            
             if self not in register_run_method.time:  # keep track of timing of modules. We use the module instance as key to time different module instances separately.
                 register_run_method.time[self] = 0
             register_run_method.time[self] += (end - start)
+            
             return res
 
         register_run_method.time = {}

--- a/NuRadioReco/modules/base/module.py
+++ b/NuRadioReco/modules/base/module.py
@@ -44,7 +44,7 @@ def register_run(level=None):
             signature = inspect.signature(run)
             parameters = signature.parameters
             # convert args to kwargs to facilitate easier bookkeeping
-            all_kwargs = {key:value for key,value in zip(parameters.keys(), args)}
+            all_kwargs = {key:value for key,value in zip(parameters.keys(), args) if key is not 'self'}
             all_kwargs.update(kwargs) # this silently overwrites positional args with kwargs, but this is probably okay as we still raise an error later
 
             # include parameters with default values
@@ -63,9 +63,8 @@ def register_run(level=None):
                     try:
                         pickle.dumps(value, protocol=4)
                         store_kwargs[key] = value
-                    except TypeError as e: # object couldn't be pickled - we store the error instead
+                    except (TypeError, AttributeError) as e: # object couldn't be pickled - we store the error instead
                         store_kwargs[key] = e
-                        
             if station is not None:
                 module_level = "station"
             elif evt is not None:


### PR DESCRIPTION
…erialised together with the event. In this case the optional detector argument of the eventWriter caused the issue. Also adding entries to __modules_event before acutally running the module. In this case the eventWriter will already appear in that list the first time it is called.

This PR should fix #568. However, a few thoughts: 

- Currently there is no warning when an argument is dropped because it is not a built-in type. This might cause lost of needed information. On the other hand we might have frequently arguments which we want to drop. Do we need a white list for types to release a warning (or not to release a warning)
- As far as I understand we only store arguments passed to the function with a keyword. Hence we are ignoring any positional argument and any argument using its default value (the latter is problematic if defaults change). I think we should fix that, any opinions on that?
