### PR TITLE
Files without a detector would cause failures in combination with the event browser 

### DIFF
--- a/NuRadioMC/test/examples/test_radio_emitting_pulser_example.sh
+++ b/NuRadioMC/test/examples/test_radio_emitting_pulser_example.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 set -e
 python NuRadioMC/examples/05_pulser_calibration_measurement/radioEmitting_pulser_calibration/A01generate_pulser_events.py
-python NuRadioMC/examples/05_pulser_calibration_measurement/radioEmitting_pulser_calibration/runARA02.py emitter_event_list.hdf5 NuRadioMC/examples/05_pulser_calibration_measurement/radioEmitting_pulser_calibration/ARA02Alt.json NuRadioMC/examples/05_pulser_calibration_measurement/radioEmitting_pulser_calibration/config.yaml output.hdf5 output.nur
-python NuRadioMC/test/examples/validate_radio_emitter_allmost_equal.py  output.hdf5 NuRadioMC/test/examples/radio_emitter_output_reference.hdf5
+
+python NuRadioMC/examples/05_pulser_calibration_measurement/radioEmitting_pulser_calibration/runARA02.py \
+    emitter_event_list.hdf5 \
+    NuRadioMC/examples/05_pulser_calibration_measurement/radioEmitting_pulser_calibration/ARA02Alt.json \
+    NuRadioMC/examples/05_pulser_calibration_measurement/radioEmitting_pulser_calibration/config.yaml \
+    output.hdf5 output.nur
+
+python NuRadioMC/test/examples/validate_radio_emitter_allmost_equal.py  output.hdf5 \
+    NuRadioMC/test/examples/radio_emitter_output_reference.hdf5
+
 rm emitter_event_list.hdf5
 # rm output.hdf5
 rm output.nur

--- a/NuRadioReco/modules/io/NuRadioRecoio.py
+++ b/NuRadioReco/modules/io/NuRadioRecoio.py
@@ -3,8 +3,12 @@ import NuRadioReco.framework.event
 import NuRadioReco.detector.detector
 import NuRadioReco.detector.generic_detector
 import NuRadioReco.modules.io.event_parser_factory
+
 import numpy as np
+import astropy.time
+
 import logging
+
 import time
 import os
 
@@ -41,14 +45,16 @@ class NuRadioRecoio(object):
         buffer_size: int
             the size of the read buffer in bytes (default 100MB)
         """
-        if(not isinstance(filenames, list)):
+        if not isinstance(filenames, list):
             filenames = [filenames]
+        
         self.__file_scanned = False
         self.logger = logging.getLogger('NuRadioReco.NuRadioRecoio')
         self.logger.info("initializing NuRadioRecoio with file {}".format(filenames))
         t = time.time()
         if log_level is not None:
             self.logger.setLevel(log_level)
+        
         # Initialize attributes
         self._filenames = None
         self.__n_events = None
@@ -76,43 +82,45 @@ class NuRadioRecoio(object):
         self.logger.info("... finished in {:.0f} seconds".format(time.time() - t))
 
     def _get_file(self, iF):
-        if(iF not in self.__open_files):
+        if iF not in self.__open_files:
             self.logger.debug("file {} is not yet open, opening file".format(iF))
             self.__open_files[iF] = {}
             self.__open_files[iF]['file'] = open(self._filenames[iF], 'rb', buffering=self.__buffer_size)  # 100 MB buffering
             self.__open_files[iF]['time'] = time.time()
             self.__check_file_version(iF)
-            if(len(self.__open_files) > self.__max_open_files):
+            
+            if len(self.__open_files) > self.__max_open_files:
                 self.logger.debug("more than {} file are open, closing oldest file".format(self.__max_open_files))
                 tnow = time.time()
                 iF_close = 0
                 for key, value in self.__open_files.items():
-                    if(value['time'] < tnow):
+                    if value['time'] < tnow:
                         tnow = value['time']
                         iF_close = key
                 self.logger.debug("closing file {} that was opened at {}".format(iF_close, tnow))
                 self.__open_files[iF_close]['file'].close()
                 del self.__open_files[iF_close]
+        
         return self.__open_files[iF]['file']
 
     def __check_file_version(self, iF):
         self.__file_version = int.from_bytes(self._get_file(iF).read(6), 'little')
         self.__file_version_minor = int.from_bytes(self._get_file(iF).read(6), 'little')
 
-        if (self.__file_version == 0):
+        if self.__file_version == 0:
             self.logger.error(
                 f"File might be corrupt, file has version {self.__file_version}.{self.__file_version} "
                 f"but current version is {VERSION}.{VERSION_MINOR}. "
                 f"This might indicate the file is empty. The file size is {os.stat(self._filenames[iF]).st_size} B.")
 
-        elif (self.__file_version > VERSION):
+        elif self.__file_version > VERSION:
             self.logger.error(
                 f"File might be corrupt, file has version {self.__file_version}.{self.__file_version} "
                 f"but current version is {VERSION}.{VERSION_MINOR}. "
                 f"This might indicate the file is empty. The file size is {os.stat(self._filenames[iF]).st_size} B.")
 
 
-        elif(self.__file_version == 1):
+        elif self.__file_version == 1:
             self.logger.error(
                 "data file not readable. File has version {}.{} but current version is {}.{}".format(
                     self.__file_version,
@@ -121,9 +129,10 @@ class NuRadioRecoio(object):
                     VERSION_MINOR
                 )
             )
-            if(self.__fail_on_version_mismatch):
+            if self.__fail_on_version_mismatch:
                 raise IOError
-        elif(self.__file_version_minor != VERSION_MINOR):
+        
+        elif self.__file_version_minor != VERSION_MINOR:
             self.logger.error(
                 "Data file might not readable, File has version {}.{} but current version is {}.{}".format(
                     self.__file_version,
@@ -132,10 +141,13 @@ class NuRadioRecoio(object):
                     VERSION_MINOR
                 )
             )
-            if(self.__fail_on_minor_version_mismatch):
+            if self.__fail_on_minor_version_mismatch:
                 raise IOError
-        self.__scan_files = NuRadioReco.modules.io.event_parser_factory.scan_files_function(self.__file_version, self.__file_version_minor)
-        self.__iter_events = NuRadioReco.modules.io.event_parser_factory.iter_events_function(self.__file_version, self.__file_version_minor)
+            
+        self.__scan_files_versioned = NuRadioReco.modules.io.event_parser_factory.scan_files_function(
+            self.__file_version, self.__file_version_minor)
+        self.__iter_events = NuRadioReco.modules.io.event_parser_factory.iter_events_function(
+            self.__file_version, self.__file_version_minor)
 
     def openFile(self, filenames):
         self._filenames = filenames
@@ -151,7 +163,7 @@ class NuRadioRecoio(object):
         self._event_specific_detector_changes = {}
 
         self.__event_headers = {}
-        if(self.__parse_header):
+        if self.__parse_header:
             self.__scan_files()
 
     def close_files(self):
@@ -178,7 +190,6 @@ class NuRadioRecoio(object):
                         self.__event_headers[station_id][key] = []
 
                     if key == stnp.station_time:
-                        import astropy.time
                         station_time = None
                         if value is not None:
                             if isinstance(value, dict):
@@ -200,11 +211,21 @@ class NuRadioRecoio(object):
     def __scan_files(self):
         current_byte = 12  # skip datafile header
         iF = 0
+        iF_prev = None
         while True:
+            if iF_prev != iF:
+                self.logger.info(f"Start scanning file {iF} ...")
+                iF_prev = iF
+            
             self._get_file(iF).seek(current_byte)
-            continue_loop, iF, current_byte = self.__scan_files(self, iF, current_byte)
+            continue_loop, iF, current_byte = self.__scan_files_versioned(self, iF, current_byte)
+            
+            if iF_prev != iF:
+                self.logger.info(f"Finished scanning file {iF_prev}.")
+
             if not continue_loop:
                 break
+        self.logger.info(f"Finished scanning file {iF}. Finished all")
 
         self.__event_ids = np.array(self.__event_ids)
         self.__file_scanned = True
@@ -221,16 +242,18 @@ class NuRadioRecoio(object):
                 self.__event_headers[station_id][key] = np.array(value)
 
     def get_header(self):
-        if(not self.__file_scanned):
+        if not self.__file_scanned:
             self.__scan_files()
+        
         return self.__event_headers
 
     def get_event_ids(self):
         """
         returns a list of (run, eventid) tuples of all events contained in the data file
         """
-        if(not self.__file_scanned):
+        if not self.__file_scanned:
             self.__scan_files()
+        
         return self.__event_ids
 
     def get_event_i(self, event_number):
@@ -239,18 +262,20 @@ class NuRadioRecoio(object):
             self.logger.debug("read lock waiting 1ms")
         self.__read_lock = True
 
-        if(not self.__file_scanned):
+        if not self.__file_scanned:
             self.__scan_files()
-        if(event_number < 0 or event_number >= self.get_n_events()):
+        
+        if event_number < 0 or event_number >= self.get_n_events():
             self.logger.error('event number {} out of bounds, only {} present in file'.format(event_number, self.get_n_events()))
             self.__read_lock = False
             return None
+        
         # determine in which file event i is
         istart = 0
         file_id = 0
         for iF in range(len(self._filenames)):
             istop = istart + len(self._bytes_start[iF])
-            if((event_number >= istart) and (event_number < istop)):
+            if (event_number >= istart) and (event_number < istop):
                 file_id = iF
                 event_id = event_number - istart
                 break
@@ -265,24 +290,22 @@ class NuRadioRecoio(object):
         self._current_file_id = file_id
         self._current_event_id = event.get_id()
         self._current_run_number = event.get_run_number()
-        # # If the event file contains a detector description that is a
-        # # generic detector, it might have event-specific properties and we
-        # # need to set the detector to the right event
-        if self._current_file_id in self.__detectors.keys():
-            if 'generic_detector' in self._detector_dicts[self._current_file_id]:
-                if self._detector_dicts[self._current_file_id]['generic_detector']:
-                    self.__detectors[self._current_file_id].set_event(self._current_run_number, self._current_event_id)
+        
+        self.__set_event_to_detector()
         return event
 
     def get_event(self, event_id):
-        if(not self.__file_scanned):
+        if not self.__file_scanned:
             self.__scan_files()
+        
         mask = (self.__event_ids[:, 0] == event_id[0]) & (self.__event_ids[:, 1] == event_id[1])
-        if(np.sum(mask) == 0):
+        if np.sum(mask) == 0:
             self.logger.error('event number {} not found in file'.format(event_id))
             return None
-        elif(np.sum(mask) > 1):
+        
+        elif np.sum(mask) > 1:
             self.logger.warning(f"{np.sum(mask):d} events with the same run event id pair found. Returning first occurence.")
+        
         self._current_run_number = event_id[0]
         self._current_event_id = event_id[1]
         i = np.argwhere(mask)[0][0]
@@ -294,11 +317,17 @@ class NuRadioRecoio(object):
         for event in self.__iter_events(self):
             self._current_event_id = event.get_id()
             self._current_run_number = event.get_run_number()
-            if self._current_file_id in self.__detectors.keys():
-                if 'generic_detector' in self._detector_dicts[self._current_file_id]:
-                    if self._detector_dicts[self._current_file_id]['generic_detector']:
-                        self.__detectors[self._current_file_id].set_event(self._current_run_number, self._current_event_id)
+            self.__set_event_to_detector()
             yield event
+            
+    def __set_event_to_detector(self):
+        # If the event file contains a detector description that is a
+        # generic detector, it might have event-specific properties and we
+        # need to set the detector to the right event
+        if self._current_file_id in self.__detectors.keys():
+            if 'generic_detector' in self._detector_dicts[self._current_file_id]:
+                if self._detector_dicts[self._current_file_id]['generic_detector']:
+                    self.__detectors[self._current_file_id].set_event(self._current_run_number, self._current_event_id)
 
     def get_detector(self):
         """
@@ -307,13 +336,22 @@ class NuRadioRecoio(object):
         files with different detectors are read, the detector for the last returned
         event is given.
         """
+        
+        if not self.__parse_detector:
+            self.logger.warn(f"You called \"get_detector\", however, \"parse_detector\" is set to false. Return None!")
+            return None
+        
         # Check if detector object for current file already exists
         if self._current_file_id not in self.__detectors.keys():
             # Detector object for current file does not exist, so we create it
             if self._current_file_id not in self._detector_dicts:
-                self.__scan_files()  # Maybe we just forgot to scan the file
+                
+                if not self.__file_scanned:
+                    self.__scan_files()  # Maybe we just forgot to scan the file
+
                 if self._current_file_id not in self._detector_dicts:
                     raise AttributeError('The current file does not contain a detector description.')
+            
             detector_dict = self._detector_dicts[self._current_file_id]
             if 'generic_detector' in detector_dict.keys():
                 if detector_dict['generic_detector']:
@@ -325,29 +363,36 @@ class NuRadioRecoio(object):
                         detector_dict['default_station'] = None
                     if 'default_channel' not in detector_dict:
                         detector_dict['default_channel'] = None
-                    self.__detectors[self._current_file_id].__init__(source='dictionary', json_filename='', dictionary=detector_dict, default_station=detector_dict['default_station'], default_channel=detector_dict['default_channel'])
+                    self.__detectors[self._current_file_id].__init__(
+                        source='dictionary', json_filename='', dictionary=detector_dict, 
+                        default_station=detector_dict['default_station'], default_channel=detector_dict['default_channel'])
+                    
                     if self._current_file_id in self._event_specific_detector_changes.keys():
                         for change in self._event_specific_detector_changes[self._current_file_id]:
                             self.__detectors[self._current_file_id].add_station_properties_for_event(
                                 properties=change['properties'],
                                 station_id=change['station_id'],
                                 run_number=change['run_number'],
-                                event_id=change['event_id']
-                            )
+                                event_id=change['event_id'])
+                    
                     self.__detectors[self._current_file_id].set_event(self._current_run_number, self._current_event_id)
                     return self.__detectors[self._current_file_id]
+            
             # Detector is a normal detector
             self.__detectors[self._current_file_id] = NuRadioReco.detector.detector.Detector.__new__(NuRadioReco.detector.detector.Detector)
             self.__detectors[self._current_file_id].__init__(source='dictionary', json_filename='', dictionary=self._detector_dicts[self._current_file_id])
+        
         # Detector object for current file already exists. If it is a generic detector,
         # we update it to the run number and ID of the last event that was requested
         # (in case there are event-specific changes) and return  it
         if 'generic_detector' in self._detector_dicts[self._current_file_id].keys():
             if self._detector_dicts[self._current_file_id]['generic_detector']:
                 self.__detectors[self._current_file_id].set_event(self._current_run_number, self._current_event_id)
+        
         return self.__detectors[self._current_file_id]
 
     def get_n_events(self):
-        if(not self.__file_scanned):
+        if not self.__file_scanned:
             self.__scan_files()
+
         return self.__n_events

--- a/NuRadioReco/modules/io/NuRadioRecoio.py
+++ b/NuRadioReco/modules/io/NuRadioRecoio.py
@@ -73,7 +73,7 @@ class NuRadioRecoio(object):
         self.__fail_on_version_mismatch = fail_on_version_mismatch
         self.__fail_on_minor_version_mismatch = fail_on_minor_version_mismatch
         self.__parse_header = parse_header
-        self.__parse_detector = parse_detector
+        self._parse_detector = parse_detector
         self.__read_lock = False
         self.__max_open_files = max_open_files
         self.__buffer_size = buffer_size
@@ -215,18 +215,18 @@ class NuRadioRecoio(object):
         iF_prev = None
         while True:
             if iF_prev != iF:
-                self.logger.info(f"Start scanning file {iF} ...")
+                self.logger.debug(f"Start scanning file {iF} ...")
                 iF_prev = iF
 
             self._get_file(iF).seek(current_byte)
             continue_loop, iF, current_byte = self.__scan_files_versioned(self, iF, current_byte)
 
             if iF_prev != iF:
-                self.logger.info(f"Finished scanning file {iF_prev}.")
+                self.logger.debug(f"Finished scanning file {iF_prev}.")
 
             if not continue_loop:
                 break
-        self.logger.info(f"Finished scanning file {iF}. Finished all")
+        self.logger.debug(f"Finished scanning file {iF}. Finished all")
 
         self.__event_ids = np.array(self.__event_ids)
         self.__file_scanned = True
@@ -341,7 +341,7 @@ class NuRadioRecoio(object):
         event is given.
         """
 
-        if not self.__parse_detector:
+        if not self._parse_detector:
             self.logger.warn(f"You called \"get_detector\", however, \"parse_detector\" is set to false. Return None!")
             return None
 
@@ -354,7 +354,8 @@ class NuRadioRecoio(object):
                     self.__scan_files()  # Maybe we just forgot to scan the file
 
                 if self._current_file_id not in self._detector_dicts:
-                    raise AttributeError('The current file does not contain a detector description.')
+                    self.logger.warn('The current file does not contain a detector description. Return None')
+                    return None
 
             detector_dict = self._detector_dicts[self._current_file_id]
             if 'generic_detector' in detector_dict.keys():

--- a/NuRadioReco/modules/io/event_parser_factory.py
+++ b/NuRadioReco/modules/io/event_parser_factory.py
@@ -10,7 +10,7 @@ def scan_files_function(version_major, version_minor):
     """
     def scan_files_2_0(self, iF, current_byte):
         
-        if self.__parse_detector:
+        if self._parse_detector:
             self.logger(f"Scanning a file of version 2.0 which does not contain a detector object. "
                         f"However, \"parse_detector\" is true.")
         
@@ -90,7 +90,7 @@ def scan_files_function(version_major, version_minor):
             self._bytes_start[iF].append(current_byte)
             self._bytes_length[iF].append(bytes_to_read)
         
-        elif object_type == 1 and self.__parse_detector:  # object is detector info
+        elif object_type == 1 and self._parse_detector:  # object is detector info
             self.logger.debug("Read detector ...")
 
             detector_dict = pickle.loads(self._get_file(iF).read(bytes_to_read))

--- a/NuRadioReco/modules/io/event_parser_factory.py
+++ b/NuRadioReco/modules/io/event_parser_factory.py
@@ -9,11 +9,16 @@ def scan_files_function(version_major, version_minor):
     specifying the first version that function is for
     """
     def scan_files_2_0(self, iF, current_byte):
+        
+        if self.__parse_detector:
+            self.logger(f"Scanning a file of version 2.0 which does not contain a detector object. "
+                        f"However, \"parse_detector\" is true.")
+        
         bytes_to_read_hex = self._get_file(iF).read(6)
         bytes_to_read = int.from_bytes(bytes_to_read_hex, 'little')
-        if(bytes_to_read == 0):
+        if bytes_to_read == 0:
             # we are at the end of the file
-            if(iF < (len(self._filenames) - 1)):  # are there more files to be parsed?
+            if iF < (len(self._filenames) - 1):  # are there more files to be parsed?
                 iF += 1
                 current_byte = 12  # skip datafile header
                 self._get_file(iF).seek(current_byte)
@@ -25,6 +30,7 @@ def scan_files_function(version_major, version_minor):
                 self._bytes_length.append([])
             else:
                 return False, iF, current_byte
+        
         current_byte += 6
         self._bytes_start_header[iF].append(current_byte)
         self._bytes_length_header[iF].append(bytes_to_read)
@@ -48,9 +54,9 @@ def scan_files_function(version_major, version_minor):
         current_byte += 6
         bytes_to_read_hex = self._get_file(iF).read(6)
         bytes_to_read = int.from_bytes(bytes_to_read_hex, 'little')
-        if(bytes_to_read == 0):
+        if bytes_to_read == 0:
             # we are at the end of the file
-            if(iF < (len(self._filenames) - 1)):  # are there more files to be parsed?
+            if iF < (len(self._filenames) - 1):  # are there more files to be parsed?
                 iF += 1
                 current_byte = 12  # skip datafile header
                 self._get_file(iF).seek(current_byte)
@@ -65,8 +71,11 @@ def scan_files_function(version_major, version_minor):
                 current_byte += 6
             else:
                 return False, iF, current_byte
+        
         current_byte += 6
         if object_type == 0:    # object is an event
+            self.logger.debug("Read Event ...")
+
             self._bytes_start_header[iF].append(current_byte)
             self._bytes_length_header[iF].append(bytes_to_read)
             current_byte += bytes_to_read
@@ -80,18 +89,23 @@ def scan_files_function(version_major, version_minor):
             bytes_to_read = int.from_bytes(bytes_to_read_hex, 'little')
             self._bytes_start[iF].append(current_byte)
             self._bytes_length[iF].append(bytes_to_read)
-        elif object_type == 1:  # object is detector info
+        
+        elif object_type == 1 and self.__parse_detector:  # object is detector info
+            self.logger.debug("Read detector ...")
+
             detector_dict = pickle.loads(self._get_file(iF).read(bytes_to_read))
             if 'generic_detector' not in detector_dict.keys():
                 is_generic_detector = False
             else:
                 is_generic_detector = detector_dict['generic_detector']
+            
             if iF not in self._detector_dicts.keys():
                 self._detector_dicts[iF] = {
                     'generic_detector': is_generic_detector,
                     'channels': {},
                     'stations': {}
                 }
+                
             if is_generic_detector:
                 # add default_station and default_channel to the dict to support older files using these
                 if 'default_station' not in detector_dict:
@@ -100,24 +114,28 @@ def scan_files_function(version_major, version_minor):
                     detector_dict['default_channel'] = None                    
                 self._detector_dicts[iF]['default_station'] = detector_dict['default_station']
                 self._detector_dicts[iF]['default_channel'] = detector_dict['default_channel']
+            
             for station in detector_dict['stations'].values():
                 if len(self._detector_dicts[iF]['stations'].keys()) == 0:
                     index = 0
                 else:
                     index = max(self._detector_dicts[iF]['stations'].keys()) + 1
                 self._detector_dicts[iF]['stations'][index] = station
+            
             for channel in detector_dict['channels'].values():
                 if len(self._detector_dicts[iF]['channels'].keys()) == 0:
                     index = 0
                 else:
                     index = max(self._detector_dicts[iF]['channels'].keys()) + 1
                 self._detector_dicts[iF]['channels'][index] = channel
+        
         elif object_type == 2:   # object is list of event-specific changes to the detector
             changes_dict = pickle.loads(self._get_file(iF).read(bytes_to_read))
             if iF not in self._event_specific_detector_changes.keys():
                 self._event_specific_detector_changes[iF] = []
             for change in changes_dict:
                 self._event_specific_detector_changes[iF].append(change)
+        
         current_byte += bytes_to_read
         return True, iF, current_byte
 
@@ -126,10 +144,12 @@ def scan_files_function(version_major, version_minor):
             return scan_files_2_0
         else:
             return scan_files_2_2
+    
     elif version_major == 0:
         raise ValueError(f'File version is {version_major}.{version_major} which might indicate the file is empty')
     else:
-        raise ValueError('File version {}.{} is not supported. Major version needs to be 2 but is {}.'.format(version_major, version_minor, version_major))
+        raise ValueError('File version {}.{} is not supported. Major version needs to be 2 but is {}.'.format(
+            version_major, version_minor, version_major))
 
 
 


### PR DESCRIPTION
Implements a proper logic with the argument 'parse_detector', avoid overwriting functions. Refactoring.