### PR TITLE
Bugfix for antennapattern.py

### DIFF
--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -1395,7 +1395,7 @@ class AntennaPatternAnalytic(AntennaPatternBase):
 
             # Assuming simple cosine, sine falls-off for dummy module
             H_eff_t = np.zeros_like(Gain)
-            fmask = freq >= 0
+            fmask = freq > 0
             H_eff_t[fmask] = Gain[fmask] * max_gain_cross * 1 / freq[fmask]
             H_eff_t *= np.cos(theta) * np.sin(phi)
             H_eff_t *= constants.c * units.m / units.s * Z_ant / Z_0 / np.pi

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@ please update the categories "new features" and "bugfixes" before a pull request
 
 version 2.2.1-dev
 bugfix:
--in antennapattern.py, fixed line 1410; was masking frequencies <= 0 instead of frequencies < 0, causing NaN errors
+-in antennapattern.py, fixed line 1398; was masking frequencies >= 0 instead of frequencies > 0, causing NaN errors
 
 version 2.2.0-dev
 new features:

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,10 @@ Changelog - to keep track of all relevant changes
 
 please update the categories "new features" and "bugfixes" before a pull request merge!
 
+version 2.2.1-dev
+bugfix:
+-in antennapattern.py, fixed line 1410; was masking frequencies <= 0 instead of frequencies < 0, causing NaN errors
+
 version 2.2.0-dev
 new features:
 - added getting to query ARZ charge-excess profiles

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,10 +2,6 @@ Changelog - to keep track of all relevant changes
 
 please update the categories "new features" and "bugfixes" before a pull request merge!
 
-version 2.2.1-dev
-bugfix:
--in antennapattern.py, fixed line 1398; was masking frequencies >= 0 instead of frequencies > 0, causing NaN errors
-
 version 2.2.0-dev
 new features:
 - added getting to query ARZ charge-excess profiles
@@ -21,6 +17,8 @@ new features:
 bugfixes:
 - fixed/improved C++ raytracer not finding solutions for some near-horizontal or near-shadowzone vertices
 - fixed wrong number in Feldman-Cousins upper limit
+- in antennapattern.py, fixed line 1398; was masking frequencies >= 0 instead of frequencies > 0, causing NaN errors
+
 
 version 2.1.8
 bugfixes:


### PR DESCRIPTION
antennapattern.py had a bug in line 1398 where the frequencies were allowed to be >= 0 for specifically the AnalyticLPDA model, causing NaN errors down the line.

The only change (outside of the changelog) is 
`freq > 0`

