### PR TITLE
Does not allow to specifty the sampling rate to unrealisticly high va…

### DIFF
--- a/NuRadioReco/modules/channelGenericNoiseAdder.py
+++ b/NuRadioReco/modules/channelGenericNoiseAdder.py
@@ -106,6 +106,11 @@ class channelGenericNoiseAdder:
         *   Add 'multi_white' noise option on 20-Sept-2018 (RL)
 
         """
+        if sampling_rate > 100:
+            raise ValueError(f"The sampling rate can not be set to values larger than 100 (is set to {sampling_rate}). "
+                             "The sampling rate is interpreted as giga samples per second (since the base unit for "
+                             "time in NuRadioReco is nano second).")
+        
         frequencies = np.fft.rfftfreq(n_samples, 1. / sampling_rate)
 
         n_samples_freq = len(frequencies)
@@ -124,6 +129,7 @@ class channelGenericNoiseAdder:
         selection = (frequencies >= min_freq) & (frequencies <= max_freq)
 
         nbinsactive = np.sum(selection)
+        print(nbinsactive)
         self.logger.debug('Total number of frequency bins (bilateral spectrum) : {} , of those active: {} '.format(n_samples, nbinsactive))
 
         # Debug plots


### PR DESCRIPTION
…lues > 100 Gs. However, this often happens when one missinterpret the unit

I use the function sometimes outside of NuRadioReco. I keep forgetting that one have to give the sampling rate in units of Gsamples. Hence this small check.