### PR TITLE
Feature/arbitrary noise spectra

### DIFF
--- a/NuRadioReco/modules/channelGenericNoiseAdder.py
+++ b/NuRadioReco/modules/channelGenericNoiseAdder.py
@@ -143,7 +143,10 @@ class channelGenericNoiseAdder:
         else:
             ampl[selection] = amplitude
 
-        sigscale = (1. * n_samples) / np.sqrt(nbinsactive)
+        if callable(amplitude):
+            sigscale = sampling_rate
+        else:    
+            sigscale = (1. * n_samples) / np.sqrt(nbinsactive)
         if type == 'perfect_white':
             ampl *= sigscale
         elif type == 'rayleigh':


### PR DESCRIPTION
New feature - rather than simulating only flat noise spectra with the channelGenericNoiseAdder, I added the option to specify the desired frequency spectrum as a function of frequency. Note that this (somewhat by design) is not compatible with specifying a desired Vrms. 

Just sharing in case someone else thinks this might be useful - happy to refine the implementation if desired.