### PR TITLE
Feature/galactic noise adder upgrade channel dts

### DIFF
--- a/NuRadioReco/modules/channelGalacticNoiseAdder.py
+++ b/NuRadioReco/modules/channelGalacticNoiseAdder.py
@@ -8,7 +8,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import scipy.constants
 import scipy.interpolate
-from radiocalibrationtoolkit import * #Documentation: https://github.com/F-Tomas/radiocalibrationtoolkit/tree/main contains SSM, GMOSS, ULSA
+#from radiocalibrationtoolkit import * #Documentation: https://github.com/F-Tomas/radiocalibrationtoolkit/tree/main contains SSM, GMOSS, ULSA
 from pygdsm import (
     GlobalSkyModel2016,
     GlobalSkyModel,
@@ -16,7 +16,7 @@ from pygdsm import (
     HaslamSkyModel,
 )
 
-from pylfmap import LFmap #Documentation: https://github.com/F-Tomas/pylfmap needs cfitsio installation
+#from pylfmap import LFmap #Documentation: https://github.com/F-Tomas/pylfmap needs cfitsio installation
 import healpy
 import astropy.coordinates
 import astropy.units
@@ -36,6 +36,7 @@ class channelGalacticNoiseAdder:
     would be too slow, the model is evaluated for a few frequencies and the log10
     of the brightness temperature is interpolated in between.
     """
+    
     def __init__(self):
         self.__debug = None
         self.__zenith_sample = None
@@ -74,11 +75,12 @@ class channelGalacticNoiseAdder:
             The interpolation_frequencies have to cover the entire passband
             specified in the run method.
         """
+        
         self.__debug = debug
         self.__n_side = n_side
 
-        #define interpolation frequencies. Set in logarithmic range from 30 to 400MHz, rounded to 0 decimal places to avoid import errors from LFmap abd tabulated models.
-        self.__interpolation_frequencies = np.around(np.logspace(np.log(30)/np.log(10), np.log(400)/np.log(10), num=30),0) * units.MHz
+        #define interpolation frequencies. Set in logarithmic range from 10 to 1010MHz, rounded to 0 decimal places to avoid import errors from LFmap abd tabulated models.
+        self.__interpolation_frequencies = np.around(np.logspace(np.log(10)/np.log(10), np.log(1010)/np.log(10), num=30),0) * units.MHz
 
         # initialise sky model
         if skymodel == 'lfmap':
@@ -117,11 +119,13 @@ class channelGalacticNoiseAdder:
         
         self.__noise_temperatures = np.zeros((len(self.__interpolation_frequencies), healpy.pixelfunc.nside2npix(self.__n_side)))
         print("generating noise temperatures")
-        #generating sky maps and noise temperatures from chosen sky model in given frequency range
+        
+        # generating sky maps and noise temperatures from chosen sky model in given frequency range
         for i_freq, noise_freq in enumerate(self.__interpolation_frequencies):
             self.__radio_sky = sky_model.generate(noise_freq / units.MHz)
             self.__radio_sky = healpy.pixelfunc.ud_grade(self.__radio_sky, self.__n_side)
             self.__noise_temperatures[i_freq] = self.__radio_sky
+            
             print('%s MHz'% (noise_freq*1000))
       
                 
@@ -136,9 +140,6 @@ class channelGalacticNoiseAdder:
         passband=None
     ):
         
-
-
-
         """
         Adds noise resulting from galactic radio emission to the channel traces
 
@@ -154,9 +155,26 @@ class channelGalacticNoiseAdder:
             Lower and upper bound of the frequency range in which noise shall be
             added
         """
+        
+        
+        
+        # check that or all channels channel.get_frequencies() is identical
+        last_freqs = None
+        for channel in station.iter_channels():
+            if (not last_freqs is None) and (not np.allclose(last_freqs, channel.get_frequencies(), rtol = 0, atol = 0.1 * units.MHz)):
+                logger.error("The frequencies of each channel must be the same, but they are not!")
+                return
+                
+            last_freqs = channel.get_frequencies()
+        
+        freqs = last_freqs
+        d_f = freqs[2] - freqs[1]
+        
+        
         if passband is None:
             passband = [10 * units.MHz, 1000 * units.MHz]
-
+        passband_filter = (freqs > passband[0]) & (freqs < passband[1])
+            
                 
         site_latitude, site_longitude = detector.get_site_coordinates(station.get_id())
         site_location = astropy.coordinates.EarthLocation(lat=site_latitude * astropy.units.deg, lon=site_longitude * astropy.units.deg)
@@ -165,120 +183,99 @@ class channelGalacticNoiseAdder:
         
         local_cs = astropy.coordinates.AltAz(location=site_location, obstime=station_time)
         solid_angle = healpy.pixelfunc.nside2pixarea(self.__n_side, degrees=False)
+        
         pixel_longitudes, pixel_latitudes = healpy.pixelfunc.pix2ang(self.__n_side, range(healpy.pixelfunc.nside2npix(self.__n_side)), lonlat=True)
         pixel_longitudes *= units.deg
         pixel_latitudes *= units.deg
+        
         galactic_coordinates = astropy.coordinates.Galactic(l=pixel_longitudes * astropy.units.rad, b=pixel_latitudes * astropy.units.rad)
         local_coordinates = galactic_coordinates.transform_to(local_cs)
+        
+        
         n_ice = ice.get_refractive_index(-0.01, detector.get_site(station.get_id()))
-        # save noise temperatures for all directions and frequencies
+        n_air = 1.000292 # TODO: This value applies under standard conditions. Does it hold for Greenland?
+        
+        
+        for i_pixel in range(healpy.pixelfunc.nside2npix(self.__n_side)):
+            azimuth = local_coordinates[i_pixel].az.rad
+            zenith = np.pi / 2. - local_coordinates[i_pixel].alt.rad
+            
+            if zenith > 90. * units.deg:
+                continue
+                
+            # consider signal reflection at ice surface
+            t_theta = geometryUtilities.get_fresnel_t_p(zenith, n_ice, 1)
+            t_phi = geometryUtilities.get_fresnel_t_s(zenith, n_ice, 1)
+            fresnel_zenith = geometryUtilities.get_fresnel_angle(zenith, n_ice, 1.)
 
+            if fresnel_zenith is None:
+                continue
+            
+            
+            temperature_interpolator = scipy.interpolate.interp1d(self.__interpolation_frequencies, np.log10(self.__noise_temperatures[:, i_pixel]), kind='quadratic')
+            noise_temperature = np.power(10, temperature_interpolator(freqs[passband_filter]))
+                
+            
+            # calculate spectral radiance of radio signal using rayleigh-jeans law
+            S = 2. * (scipy.constants.Boltzmann * units.joule / units.kelvin) * freqs[passband_filter]**2 / (scipy.constants.c * units.m / units.s)**2 * noise_temperature * solid_angle
+            S[np.isnan(S)] = 0
 
-        for channel in station.iter_channels():
-            antenna_pattern = self.__antenna_pattern_provider.load_antenna_pattern(detector.get_antenna_model(station.get_id(), channel.get_id()))
-            freqs = channel.get_frequencies()
-            d_f = freqs[2] - freqs[1]
-            sampling_rate = channel.get_sampling_rate()
-            channel_spectrum = channel.get_frequency_spectrum()
-            passband_filter = (freqs > passband[0]) & (freqs < passband[1])
-            noise_spec_sum = np.zeros_like(channel.get_frequency_spectrum())
-            flux_sum = np.zeros(freqs[passband_filter].shape)
-            efield_sum = np.zeros((3, freqs.shape[0]), dtype=np.complex128)
-            if self.__debug:
-                plt.close('all')
-                fig = plt.figure(figsize=(12, 8))
-                ax_1 = fig.add_subplot(221)
-                ax_2 = fig.add_subplot(222)
-                ax_3 = fig.add_subplot(223)
-                ax_4 = fig.add_subplot(224)
-                ax_1.grid()
-                ax_1.set_yscale('log')
-                ax_2.grid()
-                ax_2.set_yscale('log')
-                ax_3.grid()
-                ax_3.set_yscale('log')
-                ax_4.grid()
-                ax_4.set_yscale('log')
-                ax_1.set_xlabel('f [MHz]')
-                ax_2.set_xlabel('f [MHz]')
-                ax_3.set_xlabel('f [MHz]')
-                ax_4.set_xlabel('f [MHz]')
-                ax_1.set_ylabel('T [K]')
-                ax_2.set_ylabel('S [W/m²/MHz]')
-                ax_3.set_ylabel('E [V/m]')
-                ax_4.set_ylabel('U [V]')
-                ax_4.plot(channel.get_frequencies() / units.MHz, np.abs(channel.get_frequency_spectrum()), c='C0')
-                ax_4.set_ylim([1.e-8, None])
-                fig1 = plt.figure()
-                ax1 = fig1.add_subplot(211)
-                ax2 = fig1.add_subplot(212)
-                ax1.plot(channel.get_times(), channel.get_trace(), label='original trace')
-                ax2.plot(channel.get_frequencies() / units.MHz, np.abs(channel.get_frequency_spectrum()), label='original spectrum')
-                ax1.grid()
-                ax2.grid()
-            for i_pixel in range(healpy.pixelfunc.nside2npix(self.__n_side)):
-                azimuth = local_coordinates[i_pixel].az.rad
-                zenith = np.pi / 2. - local_coordinates[i_pixel].alt.rad
-                if zenith > 90. * units.deg:
-                    continue
-                temperature_interpolator = scipy.interpolate.interp1d(self.__interpolation_frequencies, np.log10(self.__noise_temperatures[:, i_pixel]), kind='quadratic')
-                noise_temperature = np.power(10, temperature_interpolator(freqs[passband_filter]))
-                # calculate spectral radiance of radio signal using rayleigh-jeans law
-                S = (2. * (scipy.constants.Boltzmann * units.joule / units.kelvin) * freqs[passband_filter]**2 / (scipy.constants.c * units.m / units.s)**2 * (noise_temperature) * solid_angle)
-                S[np.isnan(S)] = 0
-                # calculate radiance per energy bin
-                S_per_bin = S * d_f
-                flux_sum += S_per_bin
-                # calculate electric field per energy bin from the radiance per bin
-                E = np.sqrt(S_per_bin / (scipy.constants.c * units.m / units.s * scipy.constants.epsilon_0 * (units.coulomb / units.V / units.m))) / (d_f)
-                if self.__debug:
-                    ax_1.scatter(self.__interpolation_frequencies / units.MHz, self.__noise_temperatures[:, i_pixel] / units.kelvin, c='k', alpha=.01)
-                    ax_1.plot(freqs[passband_filter] / units.MHz, noise_temperature, c='k', alpha=.02)
-                    ax_2.plot(freqs[passband_filter] / units.MHz, S_per_bin / d_f / (units.watt / units.m**2 / units.MHz), c='k', alpha=.02)
-                    ax_3.plot(freqs[passband_filter] / units.MHz, E / (units.V / units.m), c='k', alpha=.02)
+            # calculate radiance per energy bin
+            S_per_bin = S * d_f
 
-                # assign random phases and polarizations to electric field
-                noise_spectrum = np.zeros((3, freqs.shape[0]), dtype=np.complex128)
-                phases = np.random.uniform(0, 2. * np.pi, len(S))
-                polarizations = np.random.uniform(0, 2. * np.pi, len(S))
+            # calculate electric field per energy bin from the radiance per bin
+            E = np.sqrt(S_per_bin / (scipy.constants.c * units.m / units.s * scipy.constants.epsilon_0 * (units.coulomb / units.V / units.m))) / d_f
+            
+            
+            # assign random phases to electric field
+            noise_spectrum = np.zeros((3, freqs.shape[0]), dtype=np.complex128)
+            phases = np.random.uniform(0, 2. * np.pi, len(S))
 
-                noise_spectrum[1][passband_filter] = np.exp(1j * phases) * E * np.cos(polarizations)
-                noise_spectrum[2][passband_filter] = np.exp(1j * phases) * E * np.sin(polarizations)
-                efield_sum += noise_spectrum
-                antenna_orientation = detector.get_antenna_orientation(station.get_id(), channel.get_id())
-                # consider signal reflection at ice surface
+            noise_spectrum[1][passband_filter] = np.exp(1j * phases) * E
+            noise_spectrum[2][passband_filter] = np.exp(1j * phases) * E
+            
+            
+            channel_noise_spec = np.zeros_like(noise_spectrum)
+            
+            for channel in station.iter_channels():
                 if detector.get_relative_position(station.get_id(), channel.get_id())[2] < 0:
-                    t_theta = geometryUtilities.get_fresnel_t_p(zenith, n_ice, 1)
-                    t_phi = geometryUtilities.get_fresnel_t_s(zenith, n_ice, 1)
-                    fresnel_zenith = geometryUtilities.get_fresnel_angle(zenith, n_ice, 1.)
-                    if fresnel_zenith is None:
-                        continue
+                    curr_t_theta = t_theta
+                    curr_t_phi = t_phi
+                    curr_fresnel_zenith = fresnel_zenith
                 else:
-                    t_theta = 1
-                    t_phi = 1
-                    fresnel_zenith = zenith
+                    curr_t_theta = 1
+                    curr_t_phi = 1
+                    curr_fresnel_zenith = zenith
+                
+                
+                antenna_pattern = self.__antenna_pattern_provider.load_antenna_pattern(detector.get_antenna_model(station.get_id(), channel.get_id()))
+                antenna_orientation = detector.get_antenna_orientation(station.get_id(), channel.get_id())
+                
+                # calculate the phase offset in comparison to station center
+                # consider additional distance in air & ice
+                # assume for air & ice constant index of refraction
+                channel_pos_x, channel_pos_y = detector.get_relative_position(station.get_id(), channel.get_id())[[0, 1]]
+                channel_depth = abs(min(detector.get_relative_position(station.get_id(), channel.get_id())[2], 0))
+                sin_zenith = np.sin(zenith)
+                delta_phases = 2 * np.pi * freqs[passband_filter] / (scipy.constants.c * units.m / units.s) * n_air * ( sin_zenith * (np.cos(azimuth) * channel_pos_x + channel_pos_y * np.sin(azimuth)) + channel_depth * ((n_ice / n_air)**2 + sin_zenith**2) / np.sqrt((n_ice / n_air)**2 - sin_zenith**2) )
+                
+                
+                # add random polarizations and phase to electric field
+                polarizations = np.random.uniform(0, 2. * np.pi, len(S))
+                
+                channel_noise_spec[1][passband_filter] = noise_spectrum[1][passband_filter] * np.exp(1j * delta_phases) * np.cos(polarizations)
+                channel_noise_spec[2][passband_filter] = noise_spectrum[2][passband_filter] * np.exp(1j * delta_phases) * np.sin(polarizations)
+                
+                
                 # fold electric field with antenna response
-                antenna_response = antenna_pattern.get_antenna_response_vectorized(freqs, fresnel_zenith, azimuth, *antenna_orientation)
-                channel_noise_spectrum = antenna_response['theta'] * noise_spectrum[1] * t_theta + antenna_response['phi'] * noise_spectrum[2] * t_phi
-                if self.__debug:
-                    ax_4.plot(freqs / units.MHz, np.abs(channel_noise_spectrum) / units.V, c='k', alpha=.01)
+                antenna_response = antenna_pattern.get_antenna_response_vectorized(freqs, curr_fresnel_zenith, azimuth, *antenna_orientation)
+                channel_noise_spectrum = antenna_response['theta'] * channel_noise_spec[1] * curr_t_theta + antenna_response['phi'] * channel_noise_spec[2] * curr_t_phi
+                
+                
+                # add noise spectrum to channel freq spectrum
+                channel_spectrum = channel.get_frequency_spectrum()
                 channel_spectrum += channel_noise_spectrum
-                noise_spec_sum += channel_noise_spectrum
-            channel.set_frequency_spectrum(channel_spectrum, sampling_rate)
-
-            if self.__debug:
-                ax_2.plot(freqs[passband_filter] / units.MHz, flux_sum / d_f / (units.watt / units.m**2 / units.MHz), c='C0', label='total flux')
-                ax_3.plot(freqs[passband_filter] / units.MHz, np.sqrt(np.abs(efield_sum[1])**2 + np.abs(efield_sum[2])**2)[passband_filter] / (units.V / units.m), c='k', linestyle='-', label='sum of E-fields')
-                ax_3.plot(freqs[passband_filter] / units.MHz, np.sqrt(flux_sum / (scipy.constants.c * (units.m / units.s)) / (scipy.constants.epsilon_0 * (units.farad / units.m))) / d_f / (units.V / units.m), c='C2', label='E-field from total flux')
-                ax_4.plot(channel.get_frequencies() / units.MHz, np.abs(noise_spec_sum), c='k', linestyle=':', label='total noise')
-                ax_2.legend()
-                ax_3.legend()
-                ax_4.legend()
-                fig.tight_layout()
-                ax1.plot(channel.get_times(), channel.get_trace(), label='new trace')
-                ax1.plot(channel.get_times(), fft.freq2time(noise_spec_sum, channel.get_sampling_rate()), label='noise')
-                ax2.plot(channel.get_frequencies() / units.MHz, np.abs(channel.get_frequency_spectrum()), label='new spectrum')
-                ax2.plot(channel.get_frequencies() / units.MHz, np.abs(noise_spec_sum), label='noise')
-                ax1.legend()
-                ax2.legend()
-                plt.show()
+                channel.set_frequency_spectrum(channel_spectrum, channel.get_sampling_rate())
+        
+        
+        return


### PR DESCRIPTION
Previously, the galactic noise adder generated random galactic noise for each channel. This PR expands the selection of available galactic sky models (thanks @karenterveer) and uses consistent galactic noise between all channels (thanks @MoritzReichert), taking into account the phase differences due to the different antenna positions.

TODO:

- [ ] fix imports of optional sky models; probably wrap them in `try:... except ImportError:...` clauses
- [ ] check that the phase adjustment is correct, or at least a good approximation for antennas at different depths
- [ ] update docstrings
- [ ] is it correct to have random polarizations for each channel still?
- [ ] Replace print statements with logger
