### PR TITLE
revert variable change to assure backward compatibility with Gen2 TDR…

### DIFF
--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -41,6 +41,7 @@ from NuRadioReco.framework.parameters import particleParameters as simp
 from NuRadioReco.framework.parameters import generatorAttributes as genattrs
 import datetime
 import logging
+import warnings
 from six import iteritems
 import yaml
 import os
@@ -263,11 +264,12 @@ class simulation:
             logger.status(f"input file {self._inputfilename} is empty")
             return
 
-        ################################
-        # perfom a dummy detector simulation to determine how the signals are filtered
-        self._bandwidth_per_channel = {}  # this variable stores the integrated channel response for each channel, i.e.
-        # the integral of the squared signal chain response over all frequencies, int S21^2 df. For a system without
-        # amplification, it is equivalent to the bandwidth of the system. 
+        # Perfom a dummy detector simulation to determine how the signals are filtered.
+        # This variable stores the integrated channel response for each channel, i.e.
+        # the integral of the squared signal chain response over all frequencies, int S21^2 df.
+        # For a system without amplification, it is equivalent to the bandwidth of the system.
+        self._integrated_channel_response = {}
+
         self._integrated_channel_response_normalization = {}
         self._max_amplification_per_channel = {}
         self.__noise_adder_normalization = {}
@@ -307,7 +309,7 @@ class simulation:
             # run detector simulation
             self._detector_simulation_filter_amp(self._evt, self._station, self._det)
 
-            self._bandwidth_per_channel[self._station_id] = {}
+            self._integrated_channel_response[self._station_id] = {}
             self._integrated_channel_response_normalization[self._station_id] = {}
             self._max_amplification_per_channel[self._station_id] = {}
 
@@ -325,14 +327,14 @@ class simulation:
                 self._integrated_channel_response_normalization[self._station_id][channel_id] = mean_integrated_response
 
                 integrated_channel_response = np.trapz(np.abs(filt) ** 2, ff)
-                self._bandwidth_per_channel[self._station_id][channel_id] = integrated_channel_response
+                self._integrated_channel_response[self._station_id][channel_id] = integrated_channel_response
 
                 logger.debug(f"Station.channel {self._station_id}.{channel_id} estimated bandwidth is "
                              f"{integrated_channel_response / mean_integrated_response / units.MHz:.1f} MHz")
 
         ################################
 
-        self._bandwidth = next(iter(next(iter(self._bandwidth_per_channel.values())).values()))  # get value of first station/channel key pair
+        self._bandwidth = next(iter(next(iter(self._integrated_channel_response.values())).values()))  # get value of first station/channel key pair
         norm = next(iter(next(iter(self._integrated_channel_response_normalization.values())).values()))
         amplification = next(iter(next(iter(self._max_amplification_per_channel.values())).values()))
 
@@ -355,8 +357,8 @@ class simulation:
                 logger.status(f"Use a noise temperature of {noise_temp / units.kelvin:.1f} K for each channel to determine noise Vrms.")
 
             self._noiseless_channels = collections.defaultdict(list)
-            for station_id in self._bandwidth_per_channel:
-                for channel_id in self._bandwidth_per_channel[station_id]:
+            for station_id in self._integrated_channel_response:
+                for channel_id in self._integrated_channel_response[station_id]:
                     if self._noise_temp is None:
                         noise_temp_channel = self._det.get_noise_temperature(station_id, channel_id)
                     else:
@@ -369,7 +371,7 @@ class simulation:
                     # (last two Eqs. in "noise voltage and power" section) or our wiki https://nu-radio.github.io/NuRadioMC/NuRadioMC/pages/HDF5_structure.html
 
                     # Bandwidth, i.e., \Delta f in equation
-                    integrated_channel_response = self._bandwidth_per_channel[station_id][channel_id]
+                    integrated_channel_response = self._integrated_channel_response[station_id][channel_id]
                     max_amplification = self._max_amplification_per_channel[station_id][channel_id]
 
                     self._Vrms_per_channel[station_id][channel_id] = (noise_temp_channel * 50 * constants.k * integrated_channel_response / units.Hz) ** 0.5
@@ -391,15 +393,15 @@ class simulation:
             self._noise_temp = None
             logger.status(f"Use a fix noise Vrms of {self._Vrms / units.mV:.2f} mV in each channel.")
 
-            for station_id in self._bandwidth_per_channel:
+            for station_id in self._integrated_channel_response:
 
-                for channel_id in self._bandwidth_per_channel[station_id]:
+                for channel_id in self._integrated_channel_response[station_id]:
                     max_amplification = self._max_amplification_per_channel[station_id][channel_id]
                     self._Vrms_per_channel[station_id][channel_id] = self._Vrms  # to be stored in the hdf5 file
                     self._Vrms_efield_per_channel[station_id][channel_id] = self._Vrms / max_amplification / units.m  # VEL = 1m
 
                     # for logging
-                    integrated_channel_response = self._bandwidth_per_channel[station_id][channel_id]
+                    integrated_channel_response = self._integrated_channel_response[station_id][channel_id]
                     mean_integrated_response = self._integrated_channel_response_normalization[self._station_id][channel_id]
 
                     logger.status(f'Station.channel {station_id}.{channel_id:02d}: '
@@ -1008,7 +1010,7 @@ class simulation:
                             channel_ids = self._det.get_channel_ids(self._station.get_id())
                             Vrms = {}
                             for channel_id in channel_ids:
-                                norm = self._bandwidth_per_channel[self._station.get_id()][channel_id]
+                                norm = self._integrated_channel_response[self._station.get_id()][channel_id]
                                 Vrms[channel_id] = self._Vrms_per_channel[self._station.get_id()][channel_id] / (norm / max_freq) ** 0.5  # normalize noise level to the bandwidth its generated for
                             channelGenericNoiseAdder.run(self._evt, self._station, self._det, amplitude=Vrms, min_freq=0 * units.MHz,
                                                          max_freq=max_freq, type='rayleigh', excluded_channels=self._noiseless_channels[station_id])
@@ -1505,7 +1507,7 @@ class simulation:
                     positions[channel_id] = self._det.get_relative_position(station_id, channel_id) + self._det.get_absolute_position(station_id)
                 fout["station_{:d}".format(station_id)].attrs['antenna_positions'] = positions
                 fout["station_{:d}".format(station_id)].attrs['Vrms'] = list(self._Vrms_per_channel[station_id].values())
-                fout["station_{:d}".format(station_id)].attrs['bandwidth'] = list(self._bandwidth_per_channel[station_id].values())
+                fout["station_{:d}".format(station_id)].attrs['bandwidth'] = list(self._integrated_channel_response[station_id].values())
 
             fout.attrs.create("Tnoise", self._noise_temp, dtype=float)
             fout.attrs.create("Vrms", self._Vrms, dtype=float)
@@ -1567,3 +1569,23 @@ class simulation:
             msg = "{} for config.signal.polarization is not a valid option".format(self._cfg['signal']['polarization'])
             logger.error(msg)
             raise ValueError(msg)
+
+    @property
+    def _bandwidth_per_channel(self):
+        warnings.warn("This variable `_bandwidth_per_channel` is deprecated. "
+                      "Please use `integrated_channel_response` instead.", DeprecationWarning)
+        return self._integrated_channel_response
+
+    @_bandwidth_per_channel.setter
+    def _bandwidth_per_channel(self, value):
+        warnings.warn("This variable `_bandwidth_per_channel` is deprecated. "
+                        "Please use `integrated_channel_response` instead.", DeprecationWarning)
+        self._integrated_channel_response = value
+
+    @property
+    def integrated_channel_response(self):
+        return self._integrated_channel_response
+
+    @integrated_channel_response.setter
+    def integrated_channel_response(self, value):
+        self._integrated_channel_response = value


### PR DESCRIPTION
… simulation scripts

The recent change renaming the _bandwidth variables in simulation.py https://github.com/nu-radio/NuRadioMC/pull/594/files breaks the Gen2 TDR simulations https://github.com/nu-radio/analysis-scripts/blob/gen2-tdr-2021/gen2-tdr-2021/detsim/D01detector_sim.py#L144 This is quite annoying and super confusing for all users. In principle, it is a simple fix, renaming _bandwidth_per_channel to _integrated_channel_response, but only if you know exactly what to do, which only a few people know. 

This PR reverts the variable renaming and adds additional documentation to the code to define the meaning of the variable. 
