### PR TITLE
Automatically check compatibility with different python versions

### DIFF
--- a/.github/workflows/python_version_compatibility.yaml
+++ b/.github/workflows/python_version_compatibility.yaml
@@ -11,7 +11,11 @@ jobs:
   pythonversionsmatrix:
     strategy:
       matrix:
-        python_version: [3.6, 3.8, 3.9, 3.10, 3.11, 3.12, 3.x]
+        python_version: [3.8, 3.9, 3.10, 3.11, 3.12, 3.x]
+        os: [ubuntu-latest]
+        include:
+          - os: ubuntu-20.04
+            python_version: 3.6
     uses: ./.github/workflows/run_tests.yaml
     with:
       python_version: ${{ matrix.python_version }}

--- a/.github/workflows/python_version_compatibility.yaml
+++ b/.github/workflows/python_version_compatibility.yaml
@@ -1,0 +1,17 @@
+name: Check python version compatibility
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+
+jobs:
+  pythonversionsmatrix:
+    strategy:
+      matrix:
+        python_version: [3.6, 3.8, 3.9, 3.10, 3.11, 3.12, 3.x]
+    uses: ./.github/workflows/run_tests.yaml
+    with:
+      python_version: ${{ matrix.python_version }}

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -1,6 +1,25 @@
 name: Unit tests
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      python_version:
+        description: Specify Python version to run tests on
+        type: string
+        required: true
+        default: '3.7'
+  workflow_call:
+    inputs:
+      python_version:
+        description: Specify Python version to run tests on
+        type: string
+        required: true
+        default: '3.7'
+
+env: # set the python_version to 3.7 if the workflow is not triggered by workflow_call or workflow_dispatch
+  PYTHON_VERSION: ${{ inputs.python_version || '3.7' }}
 
 jobs:
   build:
@@ -9,10 +28,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.7
+    - name: Set up Python [${{ env.PYTHON_VERSION }}]
       uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: ${{ env.PYTHON_VERSION }}
     - name: Cache pip
       uses: actions/cache@v4
       with:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -10,6 +10,10 @@ on:
         type: string
         required: true
         default: '3.7'
+      os:
+        description: OS to run tests on
+        type: string
+        default: ubuntu-latest
   workflow_call:
     inputs:
       python_version:
@@ -17,13 +21,17 @@ on:
         type: string
         required: true
         default: '3.7'
+      os:
+        description: OS to run tests on
+        type: string
+        default: ubuntu-latest
 
 env: # set the python_version to 3.7 if the workflow is not triggered by workflow_call or workflow_dispatch
   PYTHON_VERSION: ${{ inputs.python_version || '3.7' }}
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.os || 'ubuntu-latest' }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     steps:


### PR DESCRIPTION
Minor update to the unit tests:
- It's now possible to specify the python version and os to run the tests on;
- There is a new action that runs the unit tests on 'all' python versions (3.6 - latest 3.x). For now, I've made it such that this test runs only on push to develop (i.e. after a PR has been merged into develop) or manually, as running it on every pull request / push would probably cause our runner time to balloon very quickly. Happy to take suggestions if someone prefers an alternative strategy.

I've already used this to check our Python 3.6 compatibility [here](https://github.com/nu-radio/NuRadioMC/actions/runs/7728595096). It fails, but the errors are (as far as I can see) all from test output deviating from the reference files. Would be good if someone had time to investigate this...