### PR TITLE
hotfix for python compatibility workflow

### DIFF
--- a/.github/workflows/python_version_compatibility.yaml
+++ b/.github/workflows/python_version_compatibility.yaml
@@ -1,4 +1,4 @@
-name: Check python version compatibility
+name: Check compatibility
 
 on:
   push:
@@ -8,11 +8,11 @@ on:
 
 
 jobs:
-  pythonversionsmatrix:
+  version:
     strategy:
       fail-fast: false # continue even if one of the versions fails
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.x"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.x"] # 3.x = latest available
         os: [ubuntu-latest]
         include:
           - python_version: "3.6"

--- a/.github/workflows/python_version_compatibility.yaml
+++ b/.github/workflows/python_version_compatibility.yaml
@@ -10,12 +10,14 @@ on:
 jobs:
   pythonversionsmatrix:
     strategy:
+      fail-fast: false # continue even if one of the versions fails
       matrix:
-        python_version: [3.8, 3.9, 3.10, 3.11, 3.12, 3.x]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.x"]
         os: [ubuntu-latest]
         include:
-          - os: ubuntu-20.04
-            python_version: 3.6
+          - python_version: "3.6"
+            os: ubuntu-20.04 # python 3.6 is not available with 22.04 on github actions
     uses: ./.github/workflows/run_tests.yaml
     with:
       python_version: ${{ matrix.python_version }}
+      os: ${{ matrix.os }}


### PR DESCRIPTION
- added missing os variable to workflow (so Python 3.6 is also tested)
- fixed python version specifications (3.10 was interpreted as 3.1 -> "3.10"); removed 3.12 for now as 3.x (latest) = 3.12
- added `fail-fast: false` - check now runs on all specified python versions instead of cancelling as soon as any one of them fails.

I should probably have tested this more thoroughly before #614, but hopefully it now works as intended.