### PR TITLE
hotfix: detectorbrowser

### DIFF
--- a/NuRadioReco/detector/detector_browser/detector_provider.py
+++ b/NuRadioReco/detector/detector_browser/detector_provider.py
@@ -29,8 +29,8 @@ class DetectorProvider(object):
         filename: string
             Path to the .json file containing the detector description
         """
-        self.__detector = NuRadioReco.detector.detector.Detector.__new__(
-            NuRadioReco.detector.detector.Detector, source='json', json_filename=filename, assume_inf=assume_inf, 
+        self.__detector = NuRadioReco.detector.detector.Detector(
+            source='json', json_filename=filename, assume_inf=assume_inf,
             antenna_by_depth=antenna_by_depth)
 
     def set_generic_detector(self, filename, default_station, default_channel, assume_inf, antenna_by_depth):

--- a/NuRadioReco/detector/detector_browser/index.py
+++ b/NuRadioReco/detector/detector_browser/index.py
@@ -13,7 +13,7 @@ from NuRadioReco.detector.detector_browser.app import app
 argparser = argparse.ArgumentParser(description="Visualization for the detector")
 argparser.add_argument('file_location', type=str, help="Path of folder or filename.")
 argparser.add_argument('--port', default=8081, help="Specify the port the detector browser will run on.")
-argparser.add_argument('--debug', default=False, help="Turn on debug mode")
+argparser.add_argument('--debug', const=True, default=False, action='store_const', help="Turn on debug mode")
 parsed_args = argparser.parse_args()
 data_folder = os.path.dirname(parsed_args.file_location)
 

--- a/NuRadioReco/detector/detector_browser/open_file.py
+++ b/NuRadioReco/detector/detector_browser/open_file.py
@@ -99,10 +99,11 @@ layout = html.Div([
                 html.Div([
                     dcc.Slider(
                         id='detector-time-slider',
-                        value=10000,
+                        value=0,
                         min=0,
-                        max=1551092200,
-                        step=1000
+                        max=1000,
+                        step=1000,
+                        marks = {}
                     )
                 ], style={'flex': '1'}),
                 html.Button(
@@ -342,7 +343,7 @@ def toggle_open_button_active(filename, detector_type, default_station, need_def
 
 @app.callback(
     Output('detector-time-div', 'style'),
-    [Input('load-detector-button', 'n_clicks'),
+    [Input('output-dummy', 'children'),
      Input('file-type-dropdown', 'value')]
 )
 def show_detector_time_slider(load_detector_click, detector_type):
@@ -376,15 +377,16 @@ def set_detector_time_slider(load_detector_click, detector_type):
     detector_provider = NuRadioReco.detector.detector_browser.detector_provider.DetectorProvider()
     detector = detector_provider.get_detector()
     if detector is None:
-        return None, 0, 1, {}
+        return 0, 0, 1, {}
     if detector_type != 'detector':
-        return None, 0, 1, {}
+        return 0, 0, 1, {}
     unix_times, datetimes = detector_provider.get_time_periods()
     marks = {}
     for i_time, unix_time in enumerate(unix_times):
         datetimes[i_time].format = 'iso'
-        marks[unix_time] = {'label': str(datetimes[i_time].value)}
-    return detector.get_detector_time().unix, np.min(unix_times), np.max(unix_times), marks
+        marks[str(int(unix_time))] = datetimes[i_time].iso.split()[0]
+
+    return int(detector.get_detector_time().unix), int(np.min(unix_times)), int(np.max(unix_times)), marks
 
 
 @app.callback(


### PR DESCRIPTION
...more of a hotfix, really. Wanted to look at a detector and noticed the detectorbrowser didn't work with the updated interface for `detector.Detector`. Still needs to be updated to account for the automatic detection of detector vs generic_detector descriptions, if anyone fancies doing this. But at least it should now be somewhat functional again.