### PR TITLE
Implement Detector channel group ID for LOFAR

### DIFF
--- a/NuRadioReco/detector/detector_base.py
+++ b/NuRadioReco/detector/detector_base.py
@@ -79,7 +79,6 @@ def buffer_db(in_memory, filename=None):
     table_channels = db.table('channels')
     table_channels.truncate()
     results = sqldet.get_everything_channels()
-    # TODO: add channel_group_id feature
     for channel in results:
         table_channels.insert({'station_id': channel['st.station_id'],
                                'channel_id': channel['ch.channel_id'],

--- a/NuRadioReco/detector/detector_base.py
+++ b/NuRadioReco/detector/detector_base.py
@@ -909,6 +909,31 @@ class DetectorBase(object):
             antenna_model = antenna_type
         return antenna_model
 
+    def get_channel_group_id(self, station_id, channel_id):
+        """
+        returns the group ID of a channel
+
+        Parameters
+        ----------
+        station_id: int
+            the station id
+        channel_id: int
+            the channel id
+
+        Returns
+        -------
+        group_id : int
+            the channel group ID
+        """
+        res = self.__get_channel(station_id, channel_id)
+        if 'channel_group_id' not in res.keys():
+            logger.warning(
+                'Channel group ID not set for channel {} in station {}, returning -1'.format(
+                    channel_id, station_id))
+            return -1
+        else:
+            return res['channel_group_id']
+
     def get_noise_RMS(self, station_id, channel_id, stage='amp'):
         """
         returns the noise RMS that was precomputed from forced triggers

--- a/NuRadioReco/detector/detector_base.py
+++ b/NuRadioReco/detector/detector_base.py
@@ -79,6 +79,7 @@ def buffer_db(in_memory, filename=None):
     table_channels = db.table('channels')
     table_channels.truncate()
     results = sqldet.get_everything_channels()
+    # TODO: add channel_group_id feature
     for channel in results:
         table_channels.insert({'station_id': channel['st.station_id'],
                                'channel_id': channel['ch.channel_id'],


### PR DESCRIPTION
This PR implements the core changes to the Detector class which allow for the "channel_group_id" keyword. This reflects the `channel_group_id` implemented in the Channel class in PR #556 .

After this branch is pulled into the LOFAR branch, the latter can be pulled onto develop.