### PR TITLE
hotfix for GenericDetectors in detector_browser

### DIFF
--- a/NuRadioReco/detector/detector_browser/detector_provider.py
+++ b/NuRadioReco/detector/detector_browser/detector_provider.py
@@ -47,9 +47,9 @@ class DetectorProvider(object):
             ID of the channel to be set as default channel
         """
         import NuRadioReco.detector.generic_detector
-        self.__detector = NuRadioReco.detector.generic_detector.GenericDetector.__new__(
-            NuRadioReco.detector.generic_detector.GenericDetector, filename, default_station, 
-            default_channel, assume_inf=assume_inf, antenna_by_depth=antenna_by_depth)
+        self.__detector = NuRadioReco.detector.generic_detector.GenericDetector(
+            filename, default_station, default_channel, assume_inf=assume_inf,
+            antenna_by_depth=antenna_by_depth, create_new=True)
 
     def set_event_file(self, filename):
         """


### PR DESCRIPTION
Disclaimer - I didn't think about this too hard, and this may need a more thorough rework to really take advantage of the 'new' capability to open both Detector and GenericDetector objects through `NuRadioReco.detector.detector.Detector`. But for some reason the existing interface (using `__new__`) raised an error when trying to open a GenericDetector in the detector_browser:
```
(...)
  File "/home/sb/Python/software/nu-radio/NuRadioMC/NuRadioReco/detector/detector_browser/detector_map.py", line 67, in draw_station_position_map
    for station_id in detector.get_station_ids():
  File "/home/sb/Python/software/nu-radio/NuRadioMC/NuRadioReco/detector/detector_base.py", line 277, in get_station_ids
    res = self._stations.all()
AttributeError: 'GenericDetector' object has no attribute '_stations'

```
Simply using the `__init__` and explicitly passing `create_new=True` seems to work fine, hence this PR.