### PR TITLE
fix astropy bug

### DIFF
--- a/NuRadioReco/modules/io/NuRadioRecoio.py
+++ b/NuRadioReco/modules/io/NuRadioRecoio.py
@@ -8,6 +8,7 @@ import numpy as np
 import astropy.time
 
 import logging
+from NuRadioReco.utilities.logging import setup_logger
 
 import time
 import os
@@ -49,7 +50,7 @@ class NuRadioRecoio(object):
             filenames = [filenames]
 
         self.__file_scanned = False
-        self.logger = logging.getLogger('NuRadioReco.NuRadioRecoio')
+        self.logger = setup_logger('NuRadioReco.NuRadioRecoio')
         self.logger.info("initializing NuRadioRecoio with file {}".format(filenames))
         t = time.time()
         if log_level is not None:
@@ -202,8 +203,11 @@ class NuRadioRecoio(object):
                                 err = f"Station time not stored as dict or astropy.time.Time: ({type(value)})"
                                 self.logger.error(err)
                                 raise ValueError(err)
-
-                            station_time.format = 'isot'
+                            try:
+                                station_time.format = 'isot'
+                            except AttributeError:
+                                self.logger.warning(f"setting format to 'isot' resulted in error.")
+                                pass
 
                         self.__event_headers[station_id][key].append(station_time)
                     else:

--- a/NuRadioReco/modules/io/NuRadioRecoio.py
+++ b/NuRadioReco/modules/io/NuRadioRecoio.py
@@ -8,7 +8,6 @@ import numpy as np
 import astropy.time
 
 import logging
-from NuRadioReco.utilities.logging import setup_logger
 
 import time
 import os
@@ -50,7 +49,7 @@ class NuRadioRecoio(object):
             filenames = [filenames]
 
         self.__file_scanned = False
-        self.logger = setup_logger('NuRadioReco.NuRadioRecoio')
+        self.logger = logging.getLogger('NuRadioReco.NuRadioRecoio')
         self.logger.info("initializing NuRadioRecoio with file {}".format(filenames))
         t = time.time()
         if log_level is not None:
@@ -206,8 +205,12 @@ class NuRadioRecoio(object):
                             try:
                                 station_time.format = 'isot'
                             except AttributeError:
-                                self.logger.warning(f"setting format to 'isot' resulted in error.")
-                                pass
+                                try:
+                                    station_time.precision = station_time._time.__dict__["precision"]
+                                    station_time.format = 'isot'
+                                except AttributeError:
+                                    self.logger.warning("setting format to 'isot' resulted in error.")
+                                    pass
 
                         self.__event_headers[station_id][key].append(station_time)
                     else:


### PR DESCRIPTION
setting the time format to 'isot' results in an error when older nur files are read with a newer version of astropy (I have 5.2.2). I don't know with which version the original nur file was created. 

The expected behavior is that order nur files can always be read in. This is high priority as e.g. ARIANNA data is stored as nur files.

Before merging, I will remove the warning message, but I thought I would keep it in for now in case someone wants to investigate the underlying problem. It seems that not setting the format explicitly works just fine. 