### PR TITLE
Add coreasReader for an detector array with interpolated efields

### DIFF
--- a/NuRadioReco/detector/detector_base.py
+++ b/NuRadioReco/detector/detector_base.py
@@ -930,7 +930,7 @@ class DetectorBase(object):
         """
         res = self.__get_channel(station_id, channel_id)
         if 'channel_group_id' not in res.keys():
-            logger.warning(
+            logger.info(
                 'Channel group ID not set for channel {} in station {}, returning channel id'.format(
                     channel_id, station_id))
             return channel_id

--- a/NuRadioReco/detector/detector_base.py
+++ b/NuRadioReco/detector/detector_base.py
@@ -931,9 +931,9 @@ class DetectorBase(object):
         res = self.__get_channel(station_id, channel_id)
         if 'channel_group_id' not in res.keys():
             logger.warning(
-                'Channel group ID not set for channel {} in station {}, returning -1'.format(
+                'Channel group ID not set for channel {} in station {}, returning channel id'.format(
                     channel_id, station_id))
-            return -1
+            return channel_id
         else:
             return res['channel_group_id']
 

--- a/NuRadioReco/framework/parameters.py
+++ b/NuRadioReco/framework/parameters.py
@@ -41,6 +41,7 @@ class stationParameters(Enum):
     flagged_channels = 60  #: a set of flagged channel ids (calculated by readLOFARData and adjusted by stationRFIFilter)
     cr_dominant_polarisation = 61  #: the channel orientation containing the dominant cosmic ray signal (calculated by stationPulseFinder)
     dirty_fft_channels = 62  #: a list of FFT channels flagged as RFI (calculated by stationRFIFilter)
+    distance_to_core = 33 #: distance to the shower core
 
 class channelParameters(Enum):
     zenith = 1  #: zenith angle of the incoming signal direction
@@ -60,7 +61,7 @@ class channelParameters(Enum):
     signal_ray_type = 16        #: type of the ray propagation path of the signal received by this channel. Options are direct, reflected and refracted
     signal_receiving_azimuth = 17   #: the azimuth angle of direction at which the radio signal arrived at the antenna
     block_offsets = 18 #: 'block' or pedestal offsets. See `NuRadioReco.modules.RNO_G.channelBlockOffsetFitter`
-
+    radiant_aux_trigger_threshold = 19  #: the threshold of the radiant aux trigger
 
 class electricFieldParameters(Enum):
     ray_path_type = 1  #: the type of the ray tracing solution ('direct', 'refracted' or 'reflected')

--- a/NuRadioReco/modules/io/coreas/coreas.py
+++ b/NuRadioReco/modules/io/coreas/coreas.py
@@ -21,15 +21,22 @@ conversion_fieldstrength_cgs_to_SI = 2.99792458e10 * units.micro * units.volt / 
 
 def get_angles(corsika):
     """
-    Converting angles in corsika coordinates to local coordinates
+    Converting angles in corsika coordinates to local coordinates. 
+    
+    Corsika positiv x-axis points to the magnetic north, NuRadio coordinates positiv x-axis points to the geographic east.
+    Corsika positiv y-axis points to the west, and the z-axis upwards. NuRadio coordinates positiv y-axis points to the geographic north, and the z-axis upwards.
+    Corsikas zenith angle of a particle trajectory is defined between the particle momentum vector and the negativ z-axis, meaning that
+    the particle is described in the direction where it is going to. The azimuthal angle is described between the positive X-axis and the horizontal component of the particle momentum vector (i.e. with respect to North) 
+    proceeding counterclockwise. NuRadio describes the particle zenith and azimuthal angle in the direction where the particle is coming from. Therefore 
+    the zenith angle is the same, but the azimuthal angle has to be shifted by 180 + 90 degrees. The north has to be shifted by 90 degrees plus difference in geomagetic and magnetic north.
+
     """
     zenith = np.deg2rad(corsika['inputs'].attrs["THETAP"][0])
-    azimuth = hp.get_normalized_angle(np.pi / 2. + np.deg2rad(corsika['inputs'].attrs["PHIP"][0]))
+    azimuth = hp.get_normalized_angle(3 * np.pi / 2. + np.deg2rad(corsika['inputs'].attrs["PHIP"][0]))
     Bx, Bz = corsika['inputs'].attrs["MAGNET"]
     B_inclination = np.arctan2(Bz, Bx)
 
     B_strength = (Bx ** 2 + Bz ** 2) ** 0.5 * units.micro * units.tesla
-
     # in local coordinates north is + 90 deg
     magnetic_field_vector = B_strength * hp.spherical_to_cartesian(np.pi * 0.5 + B_inclination, 0 + np.pi * 0.5)
     return zenith, azimuth, magnetic_field_vector

--- a/NuRadioReco/modules/io/coreas/coreas.py
+++ b/NuRadioReco/modules/io/coreas/coreas.py
@@ -378,7 +378,7 @@ def make_empty_sim_station(station_id, corsika, weight=None):
     sim_station.set_simulation_weight(weight)
     return sim_station
 
-def add_sim_channel(sim_station, corsika, efield, efield_times, channel_id):
+def add_sim_channel(sim_station, channel_id, efield, efield_times, corsika):
     """
     adds an electric field trace to an existing sim station
 
@@ -397,7 +397,7 @@ def add_sim_channel(sim_station, corsika, efield, efield_times, channel_id):
     """
     zenith, azimuth, magnetic_field_vector = get_angles(corsika)
     sampling_rate = 1. / (corsika['CoREAS'].attrs['TimeResolution'] * units.second)
-    electric_field = NuRadioReco.framework.electric_field.ElectricField(channel_id)
+    electric_field = NuRadioReco.framework.electric_field.ElectricField([channel_id])
     electric_field.set_trace(efield, sampling_rate)
     electric_field.set_trace_start_time(efield_times[0])
     electric_field.set_parameter(efp.ray_path_type, 'direct')

--- a/NuRadioReco/modules/io/coreas/coreas.py
+++ b/NuRadioReco/modules/io/coreas/coreas.py
@@ -24,8 +24,7 @@ def get_angles(corsika):
     Converting angles in corsika coordinates to local coordinates
     """
     zenith = np.deg2rad(corsika['inputs'].attrs["THETAP"][0])
-    azimuth = hp.get_normalized_angle(3 * np.pi / 2. + np.deg2rad(corsika['inputs'].attrs["PHIP"][0]))
-
+    azimuth = hp.get_normalized_angle(np.pi / 2. + np.deg2rad(corsika['inputs'].attrs["PHIP"][0]))
     Bx, Bz = corsika['inputs'].attrs["MAGNET"]
     B_inclination = np.arctan2(Bz, Bx)
 
@@ -33,7 +32,6 @@ def get_angles(corsika):
 
     # in local coordinates north is + 90 deg
     magnetic_field_vector = B_strength * hp.spherical_to_cartesian(np.pi * 0.5 + B_inclination, 0 + np.pi * 0.5)
-
     return zenith, azimuth, magnetic_field_vector
 
 
@@ -123,7 +121,7 @@ def calculate_simulation_weights(positions, zenith, azimuth, site='summit', debu
     return weights
 
 
-def make_sim_station(station_id, corsika, observer, channel_ids, weight=None):
+def make_sim_station(station_id, corsika, observer, channel_ids, weight=None,  interpFlag = False):
     """
     creates an NuRadioReco sim station from the (interpolated) observer object of the coreas hdf5 file
 
@@ -147,21 +145,25 @@ def make_sim_station(station_id, corsika, observer, channel_ids, weight=None):
     zenith, azimuth, magnetic_field_vector = get_angles(corsika)
 
     if(observer is None):
-        data = np.zeros((512, 4))
-        data[:, 0] = np.arange(0, 512) * units.ns / units.second
-    else:
+        observer = np.zeros((512, 4))
+        observer[:, 0] = np.arange(0, 512) * units.ns / units.second
+        efield = observer
+    elif interpFlag == False and observer is not None:
         data = np.copy(observer)
         data[:, 1], data[:, 2] = -observer[:, 2], observer[:, 1]
 
-    # convert to SI units
-    data[:, 0] *= units.second
-    data[:, 1] *= conversion_fieldstrength_cgs_to_SI
-    data[:, 2] *= conversion_fieldstrength_cgs_to_SI
-    data[:, 3] *= conversion_fieldstrength_cgs_to_SI
+        # convert to SI units
+        data[:, 0] *= units.second
+        data[:, 1] *= conversion_fieldstrength_cgs_to_SI
+        data[:, 2] *= conversion_fieldstrength_cgs_to_SI
+        data[:, 3] *= conversion_fieldstrength_cgs_to_SI
 
-    cs = coordinatesystems.cstrafo(zenith, azimuth, magnetic_field_vector=magnetic_field_vector)
-    efield = cs.transform_from_magnetic_to_geographic(data[:, 1:].T)
-    efield = cs.transform_from_ground_to_onsky(efield)
+        cs = coordinatesystems.cstrafo(zenith, azimuth, magnetic_field_vector=magnetic_field_vector)
+        efield = cs.transform_from_magnetic_to_geographic(data[:, 1:].T)
+        efield = cs.transform_from_ground_to_onsky(efield)
+
+    elif interpFlag == True and observer is not None:
+        efield = observer
 
     # prepend trace with zeros to not have the pulse directly at the start
     n_samples_prepend = efield.shape[1]
@@ -174,7 +176,7 @@ def make_sim_station(station_id, corsika, observer, channel_ids, weight=None):
     sim_station = NuRadioReco.framework.sim_station.SimStation(station_id)
     electric_field = NuRadioReco.framework.electric_field.ElectricField(channel_ids)
     electric_field.set_trace(efield2, sampling_rate)
-    electric_field.set_trace_start_time(data[0, 0])
+    electric_field.set_trace_start_time(observer[0, 0])
     electric_field.set_parameter(efp.ray_path_type, 'direct')
     electric_field.set_parameter(efp.zenith, zenith)
     electric_field.set_parameter(efp.azimuth, azimuth)

--- a/NuRadioReco/modules/io/coreas/coreas.py
+++ b/NuRadioReco/modules/io/coreas/coreas.py
@@ -42,6 +42,28 @@ def get_angles(corsika):
     magnetic_field_vector = B_strength * hp.spherical_to_cartesian(np.pi * 0.5 + B_inclination, 0 + np.pi * 0.5)
     return zenith, azimuth, magnetic_field_vector
 
+def get_geomagnetic_angle(zenith, azimuth, magnetic_field_vector):
+    """
+    Calculates the angle between the geomagnetic field and the shower axis.
+
+    Parameters
+    ----------
+    zenith : float
+        zenith angle in radians
+    azimuth : float
+        azimuth angle in radians
+    magnetic_field_vector : np.array (3)
+        magnetic field vector in cartesian coordinates
+
+    Returns
+    -------
+    geomagnetic_angle : float
+        geomagnetic angle in radians
+    """
+    shower_axis_vector = hp.spherical_to_cartesian(zenith, azimuth)
+    geomagnetic_angle = hp.get_angle(magnetic_field_vector, shower_axis_vector)
+    return geomagnetic_angle
+
 def coreas_observer_to_nuradio_efield(corsika, out_dir=None, save_dict=False):
     """
     converts the electric field from the corsika file to NuRadio units

--- a/NuRadioReco/modules/io/coreas/coreas.py
+++ b/NuRadioReco/modules/io/coreas/coreas.py
@@ -272,6 +272,8 @@ def make_sim_station(station_id, corsika, observer, channel_ids, fluence=None, w
 
     Parameters
     ----------
+    station_id : station id
+        the id of the station to create
     corsika : hdf5 file object
         the open hdf5 file object of the corsika hdf5 file
     observer : hdf5 observer object or 4d array
@@ -290,9 +292,8 @@ def make_sim_station(station_id, corsika, observer, channel_ids, fluence=None, w
 
     Returns
     -------
-    efield: np.array (3, n_samples)
-        efield with three polarizations (r, theta, phi)
-    efield_times: np.array (n_samples)
+    sim_station: sim station
+        simulated station object
     """
     zenith, azimuth, magnetic_field_vector = get_angles(corsika)
 

--- a/NuRadioReco/modules/io/coreas/readCoREASDetector.py
+++ b/NuRadioReco/modules/io/coreas/readCoREASDetector.py
@@ -1,23 +1,21 @@
-from NuRadioReco.modules.base.module import register_run
+from datetime import timedelta
+import logging
+import os
+import time
 import h5py
+import numpy as np
+from radiotools import coordinatesystems as cstrafo
+import cr_pulse_interpolator.signal_interpolation_fourier
+import matplotlib.pyplot as plt
+from NuRadioReco.modules.base.module import register_run
 import NuRadioReco.framework.event
 import NuRadioReco.framework.station
 import NuRadioReco.framework.radio_shower
-from radiotools import coordinatesystems as cstrafo
 from NuRadioReco.framework.parameters import showerParameters as shp
 from NuRadioReco.modules.io.coreas import coreas
 from NuRadioReco.utilities import units
-import numpy as np
-import numpy.random
-import logging
-import time
-import os
-import cr_pulse_interpolator.interpolation_fourier
-import cr_pulse_interpolator.signal_interpolation_fourier
-import matplotlib.pyplot as plt
 
-conversion_fieldstrength_cgs_to_SI = 2.99792458e10 * units.micro * units.volt / units.meter 
-
+conversion_fieldstrength_cgs_to_SI = 2.99792458e10 * units.micro * units.volt / units.meter
 debug = True
 
 class readCoREASDetector:
@@ -40,10 +38,11 @@ class readCoREASDetector:
             self.__random_generator = None
             self.__interp_lowfreq = None
             self.__interp_highfreq = None
-            self.logger = logging.getLogger('NuRadioReco.readCoREAS')
+            self.logger = logging.getLogger('NuRadioReco.readCoREASDetector')
 
-    def begin(self, input_files, xmin, xmax, ymin, ymax, n_cores=10, seed=None,  
-              interp_lowfreq = 30, interp_highfreq = 500, sampling_period = 0.2e-9, log_level=logging.INFO, efield_for_station = False):
+    def begin(self, input_files, xmin, xmax, ymin, ymax, n_cores=10, seed=None,
+                interp_lowfreq=30, interp_highfreq=500, sampling_period=0.2e-9, log_level=logging.INFO, efield_for_station=True):
+            
         """
         begin method
         initialize readCoREAS module
@@ -78,9 +77,9 @@ class readCoREASDetector:
         self.__interp_highfreq = interp_highfreq
         self.__sampling_period = sampling_period
         self.__efield_for_station = efield_for_station
-        self.__random_generator = numpy.random.RandomState(seed)
+        self.__random_generator = np.random.RandomState(seed)
         self.logger.setLevel(log_level)
-
+     
     @register_run()
     def run(self, detector, output_mode=0):
         """
@@ -175,6 +174,32 @@ class readCoREASDetector:
 
             station_ids = detector.get_station_ids()
 
+            def get_interpolated_efield(position, core, ddmax, efield_interpolator):
+                antenna_position = position
+                antenna_position[2] = 0
+
+                # transform antenna position into shower plane with respect to core position
+                antenna_pos_vBvvB = cs.transform_to_vxB_vxvxB(antenna_position, core=core)
+                # calculate distance between core position and antenna positions in shower plane
+                if debug:
+                    ax.plot(antenna_position[0], antenna_position[1], '+')
+                    ax2.plot(antenna_pos_vBvvB[0], antenna_pos_vBvvB[1], '.')
+
+                dcore_vBvvB = np.sqrt((core_vBvvB[0] - antenna_pos_vBvvB[0])**2
+                    +(core_vBvvB[1] - antenna_pos_vBvvB[1])**2
+                    +(core_vBvvB[2] - antenna_pos_vBvvB[2])**2)
+
+                # interpolate electric field at antenna position in shower plane which are inside star pattern
+                if dcore_vBvvB > ddmax:
+                    res_efield = None
+                else:
+                    if debug:
+                        print(dcore_vBvvB, 'inside')
+                    efield_interp = efield_interpolator(antenna_pos_vBvvB[0], antenna_pos_vBvvB[1])
+                    res_efield = [efield_interp[:,0], efield_interp[:,1], efield_interp[:,2]]
+                    res_efield = np.array(res_efield)
+                return res_efield  
+
             for iCore, core in enumerate(cores):
                 t = time.time()
                 evt = NuRadioReco.framework.event.Event(self.__current_input_file, iCore)  # create empty event
@@ -183,7 +208,7 @@ class readCoREASDetector:
                 evt.add_sim_shower(sim_shower)
                 rd_shower = NuRadioReco.framework.radio_shower.RadioShower(station_ids=station_ids)
                 evt.add_shower(rd_shower)
-                # basically core is always at (0,0,0) in shower plane
+                # the core is always at (0,0,0) in shower plane
                 core_vBvvB = cs.transform_to_vxB_vxvxB(core, core=core) 
                 for station_id in station_ids:
                     if debug:
@@ -198,57 +223,19 @@ class readCoREASDetector:
                     channel_ids = detector.get_channel_ids(station_id)       
 
                     if self.__efield_for_station:
-                        antenna_position = det_station_position
-                        antenna_position[2] = 0
-
-                        # transform antenna position into shower plane with respect to core position
-                        antenna_pos_vBvvB = cs.transform_to_vxB_vxvxB(antenna_position, core=core)
-                        # calculate distance between core position and antenna positions in shower plane
-                        if debug:
-                            ax.plot(antenna_position[0], antenna_position[1], '+')
-                            ax2.plot(antenna_pos_vBvvB[0], antenna_pos_vBvvB[1], '.')
-
-                        dcore_vBvvB = np.sqrt((core_vBvvB[0] - antenna_pos_vBvvB[0])**2
-                            +(core_vBvvB[1] - antenna_pos_vBvvB[1])**2
-                            +(core_vBvvB[2] - antenna_pos_vBvvB[2])**2)
-
-                        # interpolate electric field at antenna position in shower plane which are inside star pattern
-                        if dcore_vBvvB > ddmax:
-                            res_efield = None
-                        else:
-                            if debug:
-                                print(dcore_vBvvB, 'inside')
-                            efield_interp = efield_interpolator(antenna_pos_vBvvB[0], antenna_pos_vBvvB[1])
-                            res_efield = [efield_interp[:,0], efield_interp[:,1], efield_interp[:,2]]
-                            res_efield = np.array(res_efield)
+                        res_efield = get_interpolated_efield(det_station_position, core, ddmax, efield_interpolator)
                         sim_station = coreas.make_sim_station(station_id, corsika, res_efield, channel_ids, interpFlag=True)
+                        station.set_sim_station(sim_station)
+                        evt.set_station(station)    
                     else:
                         self.logger.debug('interpolate efield at antenna position instead of station')
                         for channel_id in channel_ids:
                             antenna_position_rel = detector.get_relative_position(station_id, channel_id)
                             antenna_position = det_station_position + antenna_position_rel
-                            antenna_pos_vBvvB = cs.transform_to_vxB_vxvxB(antenna_position, core=core)
-                            
-                            if debug:
-                                ax.plot(antenna_position[0], antenna_position[1], '+')
-                                ax2.plot(antenna_pos_vBvvB[0], antenna_pos_vBvvB[1], '.')
-
-                            # calculate distance between core position and antenna positions in shower plane
-                            dcore_vBvvB = np.sqrt((core_vBvvB[0] - antenna_pos_vBvvB[0])**2
-                                +(core_vBvvB[1] - antenna_pos_vBvvB[1])**2
-                                +(core_vBvvB[2] - antenna_pos_vBvvB[2])**2)
-
-                            # interpolate electric field at antenna position in shower plane which are inside star pattern
-                            if dcore_vBvvB > ddmax:
-                                res_efield = None
-                            else:
-                                efield_interp = efield_interpolator(antenna_pos_vBvvB[0], antenna_pos_vBvvB[1])
-                                res_efield = [efield_interp[:,0], efield_interp[:,1], efield_interp[:,2]]
-                                res_efield = np.array(res_efield)
+                            res_efield = get_interpolated_efield(antenna_position, core, ddmax, efield_interpolator)
                             sim_station = coreas.make_sim_station(station_id, corsika, res_efield, channel_id, interpFlag=True)
-       
-                    station.set_sim_station(sim_station)
-                    evt.set_station(station)            
+                            station.set_sim_station(sim_station)
+                            evt.set_station(station)            
                     t_event_structure = time.time()
                 if debug:
                     ax.set_xlabel('east [m]')

--- a/NuRadioReco/modules/io/coreas/readCoREASDetector.py
+++ b/NuRadioReco/modules/io/coreas/readCoREASDetector.py
@@ -14,8 +14,80 @@ import NuRadioReco.framework.radio_shower
 from NuRadioReco.framework.parameters import showerParameters as shp
 from NuRadioReco.modules.io.coreas import coreas
 from NuRadioReco.utilities import units
+from collections import defaultdict
 
 conversion_fieldstrength_cgs_to_SI = 2.99792458e10 * units.micro * units.volt / units.meter
+
+def get_efield_times(efield, sampling_rate):
+    """
+    calculate the time axis of the electric field from the sampling rate
+
+    Parameters
+    ----------
+    efield: array (n_samples, n_polarizations)
+    """
+    efield_times = np.arange(0, len(efield[:,0])) / sampling_rate
+    return efield_times
+
+def apply_hanning(efields):
+    """
+    Apply a hann window to the electric field in the time domain
+
+    Parameters
+    ----------
+    efield in time domain: array (n_samples, n_polarizations)
+
+    Returns
+    ----------
+    smoothed_efield: array (n_samples, n_polarizations)
+    """
+    if efields is None:
+        return None
+    else:
+        smoothed_trace = np.zeros_like(efields)
+        hann_window = np.hanning(efields.shape[0])
+        for pol in range(efields.shape[1]):
+            smoothed_trace[:,pol] = efields[:,pol] * hann_window
+        return smoothed_trace
+
+def get_4d_observer(efields, efield_times):
+    """
+    add the time axis before the efield and transpose the array
+
+    Parameters
+    ----------
+    efield in time domain: array (n_samples, n_polarizations)
+
+    Returns
+    ----------
+    4d_efield: array ((time, n_polarizations), n_samples)
+    """
+    observer = np.zeros((efield_times.shape[0], 4))
+    observer[:, 0] = efield_times
+    observer[:, 1:4] = efields
+    observer = observer.T
+    return observer
+
+def select_channels_per_station(det, station_id, requested_channel_ids):
+    """
+    Returns a defaultdict object containing the requested channel ids that are in the given station.
+    This dict contains the channel group ids as keys with lists of channel ids as values.
+
+    Parameters
+    ----------
+    det : DetectorBase
+        The detector object that contains the station
+    station_id : int
+        The station id to select channels from
+    requested_channel_ids : list
+        List of requested channel ids
+    """
+    channel_ids = defaultdict(list)
+    for channel_id in requested_channel_ids:
+        if channel_id in det.get_channel_ids(station_id):
+            channel_group_id = det.get_channel_group_id(station_id, channel_id)
+            channel_ids[channel_group_id].append(channel_id)
+    return channel_ids
 
 class readCoREASDetector:
     """
@@ -39,8 +111,7 @@ class readCoREASDetector:
         self.__interp_highfreq = None
         self.logger = logging.getLogger('NuRadioReco.readCoREASDetector')
 
-    def begin(self, input_files, xmin, xmax, ymin, ymax, n_cores=10, seed=None,
-                interp_lowfreq=30*units.MHz, interp_highfreq=1000*units.MHz, log_level=logging.INFO, efield_for_station=True, debug=False):
+    def begin(self, input_files, xmin=0, xmax=0, ymin=0, ymax=0, n_cores=10, seed=None, core_position_list=[], selected_station_ids=[], selected_channel_ids=[], interp_lowfreq=30*units.MHz, interp_highfreq=1000*units.MHz, log_level=logging.INFO, debug=False):
             
         """
         begin method
@@ -70,72 +141,47 @@ class readCoREASDetector:
         self.__n_cores = n_cores
         self.__current_input_file = 0
         self.__area = [xmin, xmax, ymin, ymax]
+        self.__core_position_list = core_position_list
         self.__interp_lowfreq = interp_lowfreq
         self.__interp_highfreq = interp_highfreq
-        self.__efield_for_station = efield_for_station
+        self.__selected_station_ids = selected_station_ids
+        self.__selected_channel_ids = selected_channel_ids
         self.__random_generator = np.random.RandomState(seed)
         self.logger.setLevel(log_level)
         self.debug = debug
 
-    def get_efield_times(self, efield, sampling_rate):
-        """
-        calculate the time axis of the electric field from the sampling rate
-        """
-        efield_times = np.arange(0, len(efield[:,0])) / sampling_rate
-        return efield_times
+    def get_random_core_positions(self):
+        # generate core positions randomly within a rectangle
+        cores = np.array([self.__random_generator.uniform(self.__area[0], self.__area[1], self.__n_cores),
+                        self.__random_generator.uniform(self.__area[2], self.__area[3], self.__n_cores),
+                        np.zeros(self.__n_cores)]).T
+        return cores
 
-    def apply_hanning(self, efields):
+    def get_interpolated_efield(self, position, core):
         """
-        Apply a hann window to the electric field in the time domain
+        Accesses the interpolated electric field at the position of the detector on ground. Set pulse_centered to True to
+        shift all pulses to the center of the trace and account for the physical time delay of the signal.
         """
-        if efields is None:
-            return None
-        else:
-            print(f'Smoothen time trace with hann window. Assume efields are {efields.shape[0]} samples and {efields.shape[1]} polarizations')
-            smoothed_trace = np.zeros_like(efields)
-            hann_window = np.hanning(efields.shape[0])
-            for pol in range(efields.shape[1]):
-                smoothed_trace[:,pol] = efields[:,pol] * hann_window
-            return smoothed_trace
-
-    def get_interpolated_efield(self, position, core, ddmax, cs, efield_interpolator):
-        """
-        Accesses the interpolated electric field at the position of the detector. Set nu_radio_timing to True to 
-        shift all pulses to the center of the trace and account for the physical time delay of the signal."""
-
         antenna_position = position
         antenna_position[2] = 0
-
-        # transform antenna position into shower plane with respect to core position, core position is set to 0,0
-        antenna_pos_vBvvB = cs.transform_to_vxB_vxvxB(antenna_position, core=core)
-
+        # transform antenna position into shower plane with respect to core position, core position is set to 0,0 in shower plane
+        antenna_pos_vBvvB = self.cs.transform_to_vxB_vxvxB(antenna_position, core=core)
         # calculate distance between core position (0,0) and antenna positions in shower plane
         dcore_vBvvB = np.linalg.norm(antenna_pos_vBvvB) 
-
         # interpolate electric field at antenna position in shower plane which are inside star pattern
-        if dcore_vBvvB > ddmax:
+        if dcore_vBvvB > self.ddmax:
             efield_interp = None
         else:
-            efield_interp = efield_interpolator(antenna_pos_vBvvB[0], antenna_pos_vBvvB[1],
+            efield_interp = self.efield_interpolator(antenna_pos_vBvvB[0], antenna_pos_vBvvB[1],
                                                 lowfreq=self.__interp_lowfreq/units.MHz,
                                                 highfreq=self.__interp_highfreq/units.MHz,
                                                 filter_up_to_cutoff=False,
                                                 account_for_timing=False,
-                                                nu_radio_timing=True,
+                                                pulse_centered=True,
                                                 const_time_offset=20.0e-9,
                                                 full_output=False)
 
         return efield_interp
-
-    def get_interp_observer(self, efield_interp, efield_times):
-        """
-        add the time axis before the efield and transpose the array
-        """
-        interp_observer = np.zeros((len(efield_times), 4))
-        interp_observer[:, 0] = efield_times
-        interp_observer[:, 1:4] = efield_interp
-        interp_observer = interp_observer.T
-        return interp_observer
 
     @register_run()
     def run(self, detector):
@@ -145,6 +191,12 @@ class readCoREASDetector:
         detector: Detector object
             Detector description of the detector that shall be simulated
         """
+        if len(self.__selected_station_ids) == 0:
+            self.__selected_station_ids = detector.get_station_ids()
+            logging.info(f"using all station ids in detector: {self.__selected_station_ids}")
+        else:
+            logging.info(f"using selected station ids: {self.__selected_station_ids}")
+
         while (self.__current_input_file < len(self.__input_files)):
             t = time.time()
             t_per_event = time.time()
@@ -164,21 +216,19 @@ class readCoREASDetector:
             # NuRadio: x-axis pointing to the east, the positive y-axis geographical north, and the z-axis upwards.
             # NuRadio_x = -coreas_y, NuRadio_y = coreas_x, NuRadio_z = coreas_z and then correct for mag north
             zenith, azimuth, magnetic_field_vector = coreas.get_angles(corsika)
-            cs = cstrafo.cstrafo(zenith, azimuth, magnetic_field_vector)
+            self.cs = cstrafo.cstrafo(zenith, azimuth, magnetic_field_vector)
 
             obs_positions = []
             electric_field_on_sky = []
             for j_obs, observer in enumerate(corsika['CoREAS']['observers'].values()):
                 obs_positions.append(np.array([-observer.attrs['position'][1], observer.attrs['position'][0], 0]) * units.cm)
-
                 efield = np.array([observer[()][:,0]*units.second, 
                                    -observer[()][:,2]*conversion_fieldstrength_cgs_to_SI, 
                                    observer[()][:,1]*conversion_fieldstrength_cgs_to_SI, 
                                    observer[()][:,3]*conversion_fieldstrength_cgs_to_SI])
-
-                efield_geo = cs.transform_from_magnetic_to_geographic(efield[1:,:])
+                efield_geo = self.cs.transform_from_magnetic_to_geographic(efield[1:,:])
                 # convert coreas efield to NuRadio spherical coordinated eR, eTheta, ePhi (on sky)
-                efield_on_sky = cs.transform_from_ground_to_onsky(efield_geo)
+                efield_on_sky = self.cs.transform_from_ground_to_onsky(efield_geo)
                 # insert time column before efield values
                 electric_field_on_sky.append(np.insert(efield_on_sky.T, 0, efield[0,:], axis = 1))
             
@@ -190,12 +240,12 @@ class readCoREASDetector:
 
             obs_positions = np.array(obs_positions)
             # second to last dimension has to be 3 for the transformation
-            obs_positions_geo = cs.transform_from_magnetic_to_geographic(obs_positions.T)
+            obs_positions_geo = self.cs.transform_from_magnetic_to_geographic(obs_positions.T)
             # transforms the coreas observer positions into the vxB, vxvxB shower plane
-            obs_positions_vBvvB = cs.transform_to_vxB_vxvxB(obs_positions_geo).T
+            obs_positions_vBvvB = self.cs.transform_to_vxB_vxvxB(obs_positions_geo).T
             dd = (obs_positions_vBvvB[:, 0] ** 2 + obs_positions_vBvvB[:, 1] ** 2) ** 0.5
             # maximum distance between to observer positions and shower center in shower plane
-            ddmax = dd.max() 
+            self.ddmax = dd.max()
             self.logger.info("star shape from: {} - {}".format(-dd.max(), dd.max()))
 
             if self.debug:
@@ -211,7 +261,7 @@ class readCoREASDetector:
                 plt.close()
 
             # consturct interpolator object for air shower efield in shower plane
-            efield_interpolator = cr_pulse_interpolator.signal_interpolation_fourier.interp2d_signal(
+            self.efield_interpolator = cr_pulse_interpolator.signal_interpolation_fourier.interp2d_signal(
                 obs_positions_vBvvB[:, 0],
                 obs_positions_vBvvB[:, 1],
                 electric_field_r_theta_phi,
@@ -225,48 +275,47 @@ class readCoREASDetector:
                 ignore_cutoff_freq_in_timing=False,
                 verbose=False
             )
-            # generate core positions randomly within a rectangle
-            cores = np.array([self.__random_generator.uniform(self.__area[0], self.__area[1], self.__n_cores),
-                              self.__random_generator.uniform(self.__area[2], self.__area[3], self.__n_cores),
-                              np.zeros(self.__n_cores)]).T
-
             self.__t_per_event += time.time() - t_per_event
             self.__t += time.time() - t
             efield_times = self.get_efield_times(electric_field_r_theta_phi[0,:,:], coreas_sampling_rate)
-            station_ids = detector.get_station_ids()
+
+            if len(self.__core_position_list) > 0:
+                cores = self.__core_position_list
+                logging.info(f"using core positions from list: {cores}")
+            else:
+                cores = self.get_random_core_positions()
+                logging.info(f"using random core positions: {cores}")
+
             for iCore, core in enumerate(cores):
                 t = time.time()
                 evt = NuRadioReco.framework.event.Event(self.__current_input_file, iCore)  # create empty event
                 sim_shower = coreas.make_sim_shower(corsika)
                 sim_shower.set_parameter(shp.core, core)
                 evt.add_sim_shower(sim_shower)
-                rd_shower = NuRadioReco.framework.radio_shower.RadioShower(station_ids=station_ids)
+                rd_shower = NuRadioReco.framework.radio_shower.RadioShower(station_ids=self.__selected_station_ids)
                 evt.add_shower(rd_shower)
-                for station_id in station_ids:
+                for station_id in self.__selected_station_ids:
                     station = NuRadioReco.framework.station.Station(station_id)
+                    sim_station = coreas.make_empty_sim_station(station_id, corsika)
                     det_station_position = detector.get_absolute_position(station_id)
-                    channel_ids = detector.get_channel_ids(station_id)       
-                    if self.__efield_for_station:
-                        res_efield = self.get_interpolated_efield(det_station_position, core, ddmax, cs, efield_interpolator)
-                        smooth_res_efield = self.apply_hanning(res_efield)
-                        interp_observer = self.get_interp_observer(smooth_res_efield, efield_times)
-                        sim_station = coreas.make_sim_station(station_id, corsika, interp_observer, channel_ids, interpFlag=True)
-                        station.set_sim_station(sim_station)
-                        evt.set_station(station) 
-                        t_event_structure = time.time()
-                    else:
-                        self.logger.info('interpolate efield at antenna position instead of station, this is not implemented yet!')
-                        for channel_id in channel_ids:
+                    channel_ids_in_station = detector.get_channel_ids(station_id)
+                    if len(self.__selected_channel_ids) == 0:
+                        self.__selected_channel_ids = channel_ids_in_station
+                    for channel_id in self.__selected_channel_ids:
+                        if channel_id not in channel_ids_in_station: #TODO does that work for lofar? otherwise getter function
+                            self.logger.info(f"channel {channel_id} not in station {station_id}")
+                            continue
+                        else:
                             antenna_position_rel = detector.get_relative_position(station_id, channel_id)
                             antenna_position = det_station_position + antenna_position_rel
-                            res_efield = self.get_interpolated_efield(antenna_position, core, ddmax, cs, efield_interpolator)
+                            res_efield = self.get_interpolated_efield(antenna_position, core)
                             smooth_res_efield = self.apply_hanning(res_efield)
-                            interp_observer = self.get_interp_observer(smooth_res_efield, efield_times)
-                            #TODO add channel_id to sim station
-                            sim_station = coreas.make_sim_station(station_id, corsika, interp_observer, channel_id, interpFlag=True)
-                            station.set_sim_station(sim_station)
-                            evt.set_station(station)            
-                            t_event_structure = time.time()
+                            interp_observer = self.get_4d_observer(smooth_res_efield, efield_times)
+                            interp_efield, interp_times = coreas.observer_to_NuRadio(interp_observer)
+                            coreas.add_sim_channel(sim_station, channel_id, interp_efield, interp_times)
+                    station.set_sim_station(sim_station)
+                    evt.set_station(station)
+                    t_event_structure = time.time()
 
                 self.__t += time.time() - t
                 yield evt

--- a/NuRadioReco/modules/io/coreas/readCoREASDetector.py
+++ b/NuRadioReco/modules/io/coreas/readCoREASDetector.py
@@ -1,0 +1,284 @@
+from NuRadioReco.modules.base.module import register_run
+import h5py
+import NuRadioReco.framework.event
+import NuRadioReco.framework.station
+import NuRadioReco.framework.radio_shower
+from radiotools import coordinatesystems as cstrafo
+from NuRadioReco.framework.parameters import showerParameters as shp
+from NuRadioReco.modules.io.coreas import coreas
+from NuRadioReco.utilities import units
+import numpy as np
+import numpy.random
+import logging
+import time
+import os
+import cr_pulse_interpolator.interpolation_fourier
+import cr_pulse_interpolator.signal_interpolation_fourier
+import matplotlib.pyplot as plt
+
+conversion_fieldstrength_cgs_to_SI = 2.99792458e10 * units.micro * units.volt / units.meter 
+
+debug = True
+
+class readCoREASDetector:
+    """
+    Use this as default when reading CoREAS files and combining them with a detector.
+
+    This model reads the electric fields of a CoREAS file with a star shaped pattern and foldes them with it given detector. 
+    The core position of the star shape pattern is randomly distributed within a user defined area. 
+    If interpolated=True the electric field of the star shaped pattern is interpolated at the detector positions. 
+    If interpolated=False the closest observer position of the star shape pattern to the detector is chosen.
+    """
+
+    def __init__(self):
+            self.__t = 0
+            self.__t_event_structure = 0
+            self.__t_per_event = 0
+            self.__input_files = None
+            self.__n_cores = None
+            self.__current_input_file = None
+            self.__random_generator = None
+            self.__interp_lowfreq = None
+            self.__interp_highfreq = None
+            self.logger = logging.getLogger('NuRadioReco.readCoREAS')
+
+    def begin(self, input_files, xmin, xmax, ymin, ymax, n_cores=10, seed=None,  
+              interp_lowfreq = 30, interp_highfreq = 500, sampling_period = 0.2e-9, log_level=logging.INFO, efield_for_station = False):
+        """
+        begin method
+        initialize readCoREAS module
+        Parameters
+        ----------
+        input_files: input files
+            list of coreas hdf5 files
+        xmin: float
+            minimum x coordinate of the area in which core positions are distributed
+        xmax: float
+            maximum x coordinate of the area in which core positions are distributed
+        ymin: float
+            minimum y coordinate of the area in which core positions are distributed
+        ynax: float
+            maximum y coordinate of the area in which core positions are distributed
+        n_cores: number of cores (integer)
+            the number of random core positions to generate for each input file
+        seed: int (default: None)
+            Seed for the random number generation. If None is passed, no seed is set
+        interp_lowfreq: float (default = 30)
+            lower frequency for the bandpass filter in interpolation
+        interp_highfreq: float (default = 500)
+            higher frequency for the bandpass filter in interpolation
+        sampling_period: float (default 0.2e-9)
+            sampling period of the signal
+        """
+        self.__input_files = input_files
+        self.__n_cores = n_cores
+        self.__current_input_file = 0
+        self.__area = [xmin, xmax, ymin, ymax]
+        self.__interp_lowfreq = interp_lowfreq
+        self.__interp_highfreq = interp_highfreq
+        self.__sampling_period = sampling_period
+        self.__efield_for_station = efield_for_station
+        self.__random_generator = numpy.random.RandomState(seed)
+        self.logger.setLevel(log_level)
+
+    @register_run()
+    def run(self, detector, output_mode=0):
+        """
+        Parameters
+        ----------
+        detector: Detector object
+            Detector description of the detector that shall be simulated
+        output_mode: integer (default 0)
+            
+            * 0: only the event object is returned
+            * 1: the function reuturns the event object, the current inputfilename, 
+                 the distance between the choosen station and the requested core position,
+                 and the area in which the core positions are randomly distributed
+        """
+        while (self.__current_input_file < len(self.__input_files)):
+            t = time.time()
+            t_per_event = time.time()
+            filesize = os.path.getsize(self.__input_files[self.__current_input_file])
+            if(filesize < 18456 * 2):  # based on the observation that a file with such a small filesize is corrupt
+                self.logger.warning("file {} seems to be corrupt, skipping to next file".format(self.__input_files[self.__current_input_file]))
+                self.__current_input_file += 1
+                continue
+            corsika = h5py.File(self.__input_files[self.__current_input_file], "r")
+            self.logger.info(
+                "using coreas simulation {} with E={:2g} theta = {:.0f}".format(
+                    self.__input_files[self.__current_input_file],
+                    corsika['inputs'].attrs["ERANGE"][0] * units.GeV,
+                    corsika['inputs'].attrs["THETAP"][0]
+                )
+            )
+            
+            # get observer positions from coreas file
+            # coreas: x-axis pointing to the magnetic north, the positive y-axis to the west, and the z-axis upwards.
+            # NuRadio: x-axis pointing to the east, the positive y-axis geographical north, and the z-axis upwards.
+            # NuRadio_x = -coreas_y, NuRadio_y = coreas_x, NuRadio_z = coreas_z and then correct for mag north
+            obs_positions = []
+            for i, observer in enumerate(corsika['CoREAS']['observers'].values()):
+                position = observer.attrs['position']
+                obs_positions.append(np.array([-position[1], position[0], 0]) * units.cm)
+                self.logger.debug("({:.0f}, {:.0f})".format(obs_positions[i][0], obs_positions[i][1]))
+                self.logger.debug("({:.0f}, {:.0f})".format(obs_positions[i][0], obs_positions[i][1]))
+            obs_positions = np.array(obs_positions)
+
+            zenith, azimuth, magnetic_field_vector = coreas.get_angles(corsika)
+            # initialize coordinate transformation
+            cs = cstrafo.cstrafo(zenith, azimuth, magnetic_field_vector)
+            if debug:
+                print('obs_positions', obs_positions.shape)
+            # second to last dimension has to be 3 for the transformation
+            obs_positions_geo = cs.transform_from_magnetic_to_geographic(obs_positions.T)
+            # transforms the coreas observer positions into the vxB, vxvxB shower plane
+            obs_positions_vBvvB = cs.transform_to_vxB_vxvxB(obs_positions_geo).T
+
+            dd = (obs_positions_vBvvB[:, 0] ** 2 + obs_positions_vBvvB[:, 1] ** 2) ** 0.5
+            # maximum distance between to observer positions and shower center in shower plane
+            ddmax = dd.max() 
+            self.logger.info("star shape from: {} - {}".format(-dd.max(), dd.max()))
+
+            # convert coreas efield to NuRadio spherical coordinated eR, eTheta, ePhi (on sky)
+            electric_field_on_sky = []
+            for i, observer in enumerate(corsika['CoREAS']['observers'].values()):
+                efield = np.array([observer[()][:,0]*units.second, 
+                                   -observer[()][:,2]*conversion_fieldstrength_cgs_to_SI, 
+                                   observer[()][:,1]*conversion_fieldstrength_cgs_to_SI, 
+                                   observer[()][:,3]*conversion_fieldstrength_cgs_to_SI])
+
+                efield_geo = cs.transform_from_magnetic_to_geographic(efield[1:,:])
+                efield_on_sky = cs.transform_from_ground_to_onsky(efield_geo)
+                # insert time column before efield values
+                electric_field_on_sky.append(np.insert(efield_on_sky.T, 0, efield[0,:], axis = 1))
+
+            # shape: (n_observers, n_samples, (time, eR, eTheta, ePhi))
+            electric_field_on_sky = np.array(electric_field_on_sky) 
+            if debug:
+                print('electric_field_on_sky', electric_field_on_sky.shape)
+
+            # consturct interpolator object for air shower efield in shower plane
+            efield_interpolator = cr_pulse_interpolator.signal_interpolation_fourier.interp2d_signal(obs_positions_vBvvB[:,0], obs_positions_vBvvB[:,1], 
+                            electric_field_on_sky[:,:,1:], lowfreq = self.__interp_lowfreq, highfreq = self.__interp_highfreq,  sampling_period= self.__sampling_period) 
+
+            # generate core positions randomly within a rectangle
+            cores = np.array([self.__random_generator.uniform(self.__area[0], self.__area[1], self.__n_cores),
+                              self.__random_generator.uniform(self.__area[2], self.__area[3], self.__n_cores),
+                              np.zeros(self.__n_cores)]).T
+
+            if debug:
+                fig1, ax = plt.subplots()
+                fig2, ax2 = plt.subplots()
+
+            self.__t_per_event += time.time() - t_per_event
+            self.__t += time.time() - t
+
+            station_ids = detector.get_station_ids()
+
+            for iCore, core in enumerate(cores):
+                t = time.time()
+                evt = NuRadioReco.framework.event.Event(self.__current_input_file, iCore)  # create empty event
+                sim_shower = coreas.make_sim_shower(corsika)
+                sim_shower.set_parameter(shp.core, core)
+                evt.add_sim_shower(sim_shower)
+                rd_shower = NuRadioReco.framework.radio_shower.RadioShower(station_ids=station_ids)
+                evt.add_shower(rd_shower)
+                # basically core is always at (0,0,0) in shower plane
+                core_vBvvB = cs.transform_to_vxB_vxvxB(core, core=core) 
+                for station_id in station_ids:
+                    if debug:
+                        ax.plot(obs_positions[:,0]+core[0], obs_positions[:,1]+core[1], 'x')
+                        ax2.plot(obs_positions_vBvvB[:,0]+core_vBvvB[0], obs_positions_vBvvB[:,1]+core_vBvvB[1], 'x')
+                        ax.plot(core[0], core[1], 'o')
+                        ax2.plot(core_vBvvB[0], core_vBvvB[1], 'o')
+
+                    station = NuRadioReco.framework.station.Station(station_id)
+
+                    det_station_position = detector.get_absolute_position(station_id)
+                    channel_ids = detector.get_channel_ids(station_id)       
+
+                    if self.__efield_for_station:
+                        antenna_position = det_station_position
+                        antenna_position[2] = 0
+
+                        # transform antenna position into shower plane with respect to core position
+                        antenna_pos_vBvvB = cs.transform_to_vxB_vxvxB(antenna_position, core=core)
+                        # calculate distance between core position and antenna positions in shower plane
+                        if debug:
+                            ax.plot(antenna_position[0], antenna_position[1], '+')
+                            ax2.plot(antenna_pos_vBvvB[0], antenna_pos_vBvvB[1], '.')
+
+                        dcore_vBvvB = np.sqrt((core_vBvvB[0] - antenna_pos_vBvvB[0])**2
+                            +(core_vBvvB[1] - antenna_pos_vBvvB[1])**2
+                            +(core_vBvvB[2] - antenna_pos_vBvvB[2])**2)
+
+                        # interpolate electric field at antenna position in shower plane which are inside star pattern
+                        if dcore_vBvvB > ddmax:
+                            res_efield = None
+                        else:
+                            if debug:
+                                print(dcore_vBvvB, 'inside')
+                            efield_interp = efield_interpolator(antenna_pos_vBvvB[0], antenna_pos_vBvvB[1])
+                            res_efield = [efield_interp[:,0], efield_interp[:,1], efield_interp[:,2]]
+                            res_efield = np.array(res_efield)
+                        sim_station = coreas.make_sim_station(station_id, corsika, res_efield, channel_ids, interpFlag=True)
+                    else:
+                        self.logger.debug('interpolate efield at antenna position instead of station')
+                        for channel_id in channel_ids:
+                            antenna_position_rel = detector.get_relative_position(station_id, channel_id)
+                            antenna_position = det_station_position + antenna_position_rel
+                            antenna_pos_vBvvB = cs.transform_to_vxB_vxvxB(antenna_position, core=core)
+                            
+                            if debug:
+                                ax.plot(antenna_position[0], antenna_position[1], '+')
+                                ax2.plot(antenna_pos_vBvvB[0], antenna_pos_vBvvB[1], '.')
+
+                            # calculate distance between core position and antenna positions in shower plane
+                            dcore_vBvvB = np.sqrt((core_vBvvB[0] - antenna_pos_vBvvB[0])**2
+                                +(core_vBvvB[1] - antenna_pos_vBvvB[1])**2
+                                +(core_vBvvB[2] - antenna_pos_vBvvB[2])**2)
+
+                            # interpolate electric field at antenna position in shower plane which are inside star pattern
+                            if dcore_vBvvB > ddmax:
+                                res_efield = None
+                            else:
+                                efield_interp = efield_interpolator(antenna_pos_vBvvB[0], antenna_pos_vBvvB[1])
+                                res_efield = [efield_interp[:,0], efield_interp[:,1], efield_interp[:,2]]
+                                res_efield = np.array(res_efield)
+                            sim_station = coreas.make_sim_station(station_id, corsika, res_efield, channel_id, interpFlag=True)
+       
+                    station.set_sim_station(sim_station)
+                    evt.set_station(station)            
+                    t_event_structure = time.time()
+                if debug:
+                    ax.set_xlabel('east [m]')
+                    ax.set_ylabel('north [m]')
+                    ax.set_aspect('equal')
+                    ax2.set_aspect('equal')
+                    ax2.set_xlabel('v x B [m]')
+                    ax2.set_ylabel('v x v x B [m]')
+                    ax2.set_title(f'{zenith/units.deg:.0f} deg, {azimuth/units.deg:.0f} deg')
+                    plt.tight_layout()
+                    plt.show()
+
+                if(output_mode == 0):
+                    self.__t += time.time() - t
+                    yield evt
+                elif(output_mode == 1):
+                    self.__t += time.time() - t
+                    self.__t_event_structure += time.time() - t_event_structure
+                    yield evt, self.__current_input_file
+                else:
+                    self.logger.debug("output mode > 1 not implemented")
+                    raise NotImplementedError
+
+            self.__current_input_file += 1
+
+    def end(self):
+        from datetime import timedelta
+        self.logger.setLevel(logging.INFO)
+        dt = timedelta(seconds=self.__t)
+        self.logger.info("total time used by this module is {}".format(dt))
+        self.logger.info("\tcreate event structure {}".format(timedelta(seconds=self.__t_event_structure)))
+        self.logger.info("per event {}".format(timedelta(seconds=self.__t_per_event)))
+        return dt

--- a/NuRadioReco/modules/io/coreas/readCoREASDetector.py
+++ b/NuRadioReco/modules/io/coreas/readCoREASDetector.py
@@ -28,19 +28,19 @@ class readCoREASDetector:
     """
 
     def __init__(self):
-            self.__t = 0
-            self.__t_event_structure = 0
-            self.__t_per_event = 0
-            self.__input_files = None
-            self.__n_cores = None
-            self.__current_input_file = None
-            self.__random_generator = None
-            self.__interp_lowfreq = None
-            self.__interp_highfreq = None
-            self.logger = logging.getLogger('NuRadioReco.readCoREASDetector')
+        self.__t = 0
+        self.__t_event_structure = 0
+        self.__t_per_event = 0
+        self.__input_files = None
+        self.__n_cores = None
+        self.__current_input_file = None
+        self.__random_generator = None
+        self.__interp_lowfreq = None
+        self.__interp_highfreq = None
+        self.logger = logging.getLogger('NuRadioReco.readCoREASDetector')
 
     def begin(self, input_files, xmin, xmax, ymin, ymax, n_cores=10, seed=None,
-                interp_lowfreq=30, interp_highfreq=500, sampling_period=0.2e-9, log_level=logging.INFO, efield_for_station=True):
+                interp_lowfreq=30*units.MHz, interp_highfreq=1000*units.MHz, log_level=logging.INFO, efield_for_station=True, debug=False):
             
         """
         begin method
@@ -63,10 +63,8 @@ class readCoREASDetector:
             Seed for the random number generation. If None is passed, no seed is set
         interp_lowfreq: float (default = 30)
             lower frequency for the bandpass filter in interpolation
-        interp_highfreq: float (default = 500)
+        interp_highfreq: float (default = 1000)
             higher frequency for the bandpass filter in interpolation
-        sampling_period: float (default 0.2e-9)
-            sampling period of the signal
         """
         self.__input_files = input_files
         self.__n_cores = n_cores
@@ -74,12 +72,37 @@ class readCoREASDetector:
         self.__area = [xmin, xmax, ymin, ymax]
         self.__interp_lowfreq = interp_lowfreq
         self.__interp_highfreq = interp_highfreq
-        self.__sampling_period = sampling_period
         self.__efield_for_station = efield_for_station
         self.__random_generator = np.random.RandomState(seed)
         self.logger.setLevel(log_level)
-     
+        self.debug = debug
+
+    def get_efield_times(self, efield, sampling_rate):
+        """
+        calculate the time axis of the electric field from the sampling rate
+        """
+        efield_times = np.arange(0, len(efield[:,0])) / sampling_rate
+        return efield_times
+
+    def apply_hanning(self, efields):
+        """
+        Apply a hann window to the electric field in the time domain
+        """
+        if efields is None:
+            return None
+        else:
+            print(f'Smoothen time trace with hann window. Assume efields are {efields.shape[0]} samples and {efields.shape[1]} polarizations')
+            smoothed_trace = np.zeros_like(efields)
+            hann_window = np.hanning(efields.shape[0])
+            for pol in range(efields.shape[1]):
+                smoothed_trace[:,pol] = efields[:,pol] * hann_window
+            return smoothed_trace
+
     def get_interpolated_efield(self, position, core, ddmax, cs, efield_interpolator):
+        """
+        Accesses the interpolated electric field at the position of the detector. Set nu_radio_timing to True to 
+        shift all pulses to the center of the trace and account for the physical time delay of the signal."""
+
         antenna_position = position
         antenna_position[2] = 0
 
@@ -91,26 +114,36 @@ class readCoREASDetector:
 
         # interpolate electric field at antenna position in shower plane which are inside star pattern
         if dcore_vBvvB > ddmax:
-            res_efield = None
+            efield_interp = None
         else:
-            efield_interp = efield_interpolator(antenna_pos_vBvvB[0], antenna_pos_vBvvB[1])
-            res_efield = [efield_interp[:,0], efield_interp[:,1], efield_interp[:,2]]
-            res_efield = np.array(res_efield)
-        return res_efield  
+            efield_interp = efield_interpolator(antenna_pos_vBvvB[0], antenna_pos_vBvvB[1],
+                                                lowfreq=self.__interp_lowfreq/units.MHz,
+                                                highfreq=self.__interp_highfreq/units.MHz,
+                                                filter_up_to_cutoff=False,
+                                                account_for_timing=False,
+                                                nu_radio_timing=True,
+                                                const_time_offset=20.0e-9,
+                                                full_output=False)
+
+        return efield_interp
+
+    def get_interp_observer(self, efield_interp, efield_times):
+        """
+        add the time axis before the efield and transpose the array
+        """
+        interp_observer = np.zeros((len(efield_times), 4))
+        interp_observer[:, 0] = efield_times
+        interp_observer[:, 1:4] = efield_interp
+        interp_observer = interp_observer.T
+        return interp_observer
 
     @register_run()
-    def run(self, detector, output_mode=0):
+    def run(self, detector):
         """
         Parameters
         ----------
         detector: Detector object
             Detector description of the detector that shall be simulated
-        output_mode: integer (default 0)
-            
-            * 0: only the event object is returned
-            * 1: the function reuturns the event object, the current inputfilename, 
-                 the distance between the choosen station and the requested core position,
-                 and the area in which the core positions are randomly distributed
         """
         while (self.__current_input_file < len(self.__input_files)):
             t = time.time()
@@ -125,10 +158,8 @@ class readCoREASDetector:
                 "using coreas simulation {} with E={:2g} theta = {:.0f}".format(
                     self.__input_files[self.__current_input_file],
                     corsika['inputs'].attrs["ERANGE"][0] * units.GeV,
-                    corsika['inputs'].attrs["THETAP"][0]
-                )
-            )
-                                   
+                    corsika['inputs'].attrs["THETAP"][0]))
+
             # coreas: x-axis pointing to the magnetic north, the positive y-axis to the west, and the z-axis upwards.
             # NuRadio: x-axis pointing to the east, the positive y-axis geographical north, and the z-axis upwards.
             # NuRadio_x = -coreas_y, NuRadio_y = coreas_x, NuRadio_z = coreas_z and then correct for mag north
@@ -137,7 +168,7 @@ class readCoREASDetector:
 
             obs_positions = []
             electric_field_on_sky = []
-            for i, observer in enumerate(corsika['CoREAS']['observers'].values()):
+            for j_obs, observer in enumerate(corsika['CoREAS']['observers'].values()):
                 obs_positions.append(np.array([-observer.attrs['position'][1], observer.attrs['position'][0], 0]) * units.cm)
 
                 efield = np.array([observer[()][:,0]*units.second, 
@@ -152,23 +183,48 @@ class readCoREASDetector:
                 electric_field_on_sky.append(np.insert(efield_on_sky.T, 0, efield[0,:], axis = 1))
             
             # shape: (n_observers, n_samples, (time, eR, eTheta, ePhi))
-            electric_field_on_sky = np.array(electric_field_on_sky) 
-            
+            electric_field_on_sky = np.array(electric_field_on_sky)
+            electric_field_r_theta_phi = electric_field_on_sky[:,:,1:]
+            coreas_dt = (corsika['CoREAS'].attrs['TimeResolution'] * units.second)
+            coreas_sampling_rate = 1. / coreas_dt
+
             obs_positions = np.array(obs_positions)
             # second to last dimension has to be 3 for the transformation
             obs_positions_geo = cs.transform_from_magnetic_to_geographic(obs_positions.T)
             # transforms the coreas observer positions into the vxB, vxvxB shower plane
             obs_positions_vBvvB = cs.transform_to_vxB_vxvxB(obs_positions_geo).T
-            
             dd = (obs_positions_vBvvB[:, 0] ** 2 + obs_positions_vBvvB[:, 1] ** 2) ** 0.5
             # maximum distance between to observer positions and shower center in shower plane
             ddmax = dd.max() 
             self.logger.info("star shape from: {} - {}".format(-dd.max(), dd.max()))
 
-            # consturct interpolator object for air shower efield in shower plane
-            efield_interpolator = cr_pulse_interpolator.signal_interpolation_fourier.interp2d_signal(obs_positions_vBvvB[:,0], obs_positions_vBvvB[:,1], 
-                            electric_field_on_sky[:,:,1:], lowfreq = self.__interp_lowfreq, highfreq = self.__interp_highfreq,  sampling_period= self.__sampling_period) 
+            if self.debug:
+                max_efield = []
+                for i in range(len(electric_field_on_sky[:,0,1])):
+                    max_efield.append(np.max(np.abs(electric_field_on_sky[i,:,1:4])))
+                plt.scatter(obs_positions_vBvvB[:,0], obs_positions_vBvvB[:,1], c=max_efield, cmap='viridis', marker='o', edgecolors='k')
+                cbar = plt.colorbar()
+                cbar.set_label('max amplitude')
+                plt.xlabel('v x B [m]')
+                plt.ylabel('v x v x B [m]')
+                plt.show()
+                plt.close()
 
+            # consturct interpolator object for air shower efield in shower plane
+            efield_interpolator = cr_pulse_interpolator.signal_interpolation_fourier.interp2d_signal(
+                obs_positions_vBvvB[:, 0],
+                obs_positions_vBvvB[:, 1],
+                electric_field_r_theta_phi,
+                lowfreq=self.__interp_lowfreq/units.MHz,
+                highfreq=self.__interp_highfreq/units.MHz,
+                sampling_period=coreas_dt/units.s,
+                phase_method="phasor",
+                radial_method='cubic',
+                upsample_factor=5,
+                coherency_cutoff_threshold=0.9,
+                ignore_cutoff_freq_in_timing=False,
+                verbose=False
+            )
             # generate core positions randomly within a rectangle
             cores = np.array([self.__random_generator.uniform(self.__area[0], self.__area[1], self.__n_cores),
                               self.__random_generator.uniform(self.__area[2], self.__area[3], self.__n_cores),
@@ -176,7 +232,7 @@ class readCoREASDetector:
 
             self.__t_per_event += time.time() - t_per_event
             self.__t += time.time() - t
-
+            efield_times = self.get_efield_times(electric_field_r_theta_phi[0,:,:], coreas_sampling_rate)
             station_ids = detector.get_station_ids()
             for iCore, core in enumerate(cores):
                 t = time.time()
@@ -192,32 +248,28 @@ class readCoREASDetector:
                     channel_ids = detector.get_channel_ids(station_id)       
                     if self.__efield_for_station:
                         res_efield = self.get_interpolated_efield(det_station_position, core, ddmax, cs, efield_interpolator)
-                        sim_station = coreas.make_sim_station(station_id, corsika, res_efield, channel_ids, interpFlag=True)
+                        smooth_res_efield = self.apply_hanning(res_efield)
+                        interp_observer = self.get_interp_observer(smooth_res_efield, efield_times)
+                        sim_station = coreas.make_sim_station(station_id, corsika, interp_observer, channel_ids, interpFlag=True)
                         station.set_sim_station(sim_station)
                         evt.set_station(station) 
                         t_event_structure = time.time()
                     else:
-                        self.logger.info('interpolate efield at antenna position instead of station')
+                        self.logger.info('interpolate efield at antenna position instead of station, this is not implemented yet!')
                         for channel_id in channel_ids:
                             antenna_position_rel = detector.get_relative_position(station_id, channel_id)
                             antenna_position = det_station_position + antenna_position_rel
                             res_efield = self.get_interpolated_efield(antenna_position, core, ddmax, cs, efield_interpolator)
-                            sim_station = coreas.make_sim_station(station_id, corsika, res_efield, channel_id, interpFlag=True)
+                            smooth_res_efield = self.apply_hanning(res_efield)
+                            interp_observer = self.get_interp_observer(smooth_res_efield, efield_times)
+                            #TODO add channel_id to sim station
+                            sim_station = coreas.make_sim_station(station_id, corsika, interp_observer, channel_id, interpFlag=True)
                             station.set_sim_station(sim_station)
                             evt.set_station(station)            
                             t_event_structure = time.time()
 
-                if(output_mode == 0):
-                    self.__t += time.time() - t
-                    yield evt
-                elif(output_mode == 1):
-                    self.__t += time.time() - t
-                    self.__t_event_structure += time.time() - t_event_structure
-                    yield evt, self.__current_input_file
-                else:
-                    self.logger.debug("output mode > 1 not implemented")
-                    raise NotImplementedError
-
+                self.__t += time.time() - t
+                yield evt
             self.__current_input_file += 1
 
     def end(self):

--- a/NuRadioReco/modules/io/coreas/readCoREASDetector.py
+++ b/NuRadioReco/modules/io/coreas/readCoREASDetector.py
@@ -180,7 +180,6 @@ class readCoREASDetector:
         self.electric_field_on_sky = np.array(electric_field_on_sky)
         self.electric_field_r_theta_phi = self.electric_field_on_sky[:,:,1:]
         self.max_coreas_efield = np.max(np.abs(self.electric_field_r_theta_phi))
-        print('!!!! max coreas efield', self.max_coreas_efield )
         self.empty_efield = np.zeros_like(self.electric_field_r_theta_phi[0,:,:])
         coreas_dt = (self.__corsika['CoREAS'].attrs['TimeResolution'] * units.second)
 
@@ -189,12 +188,8 @@ class readCoREASDetector:
         self.obs_positions_geo = self.cs.transform_from_magnetic_to_geographic(obs_positions.T)
         # transforms the coreas observer positions into the vxB, vxvxB shower plane
         self.obs_positions_vBvvB = self.cs.transform_to_vxB_vxvxB(self.obs_positions_geo).T
-        print('self.obs_positions_vBvvB', self.obs_positions_vBvvB.shape)
-        print('self.obs_positions_geo', self.obs_positions_geo.shape)
         self.star_radius = np.max(np.linalg.norm(self.obs_positions_vBvvB[:, :-1], axis=-1))
         self.geo_star_radius = np.max(np.linalg.norm(self.obs_positions_geo[:-1, :], axis=0))
-        print('star_radius', self.star_radius)
-        print('geo_star_radius', self.geo_star_radius)
 
         if self.debug:
             max_efield = []
@@ -229,7 +224,7 @@ class readCoREASDetector:
                     verbose=False
                 )
         if self.__interp_fluence:
-            #TODO use 10ns around the maximum for the fluence interpolation, then the sum of the square of the efield
+            #TODO use 10ns around the maximum for the fluence interpolation, then the sum of the square of the efield, get_electric_field_energy_fluence in utilities
             logging.info(f'initilize fluence interpolator')
             self.fluence_interpolator = cr_pulse_interpolator.interpolation_fourier.interp2d_fourier(
                 self.obs_positions_vBvvB[:, 0],
@@ -257,7 +252,7 @@ class readCoREASDetector:
         if dcore_vBvvB > self.star_radius:
             efield_interp = self.empty_efield
             fluence_interp = 0
-            logging.info(f'antenna position with distance {dcore_vBvvB:.2f} to core is outside of star pattern with radius {self.star_radius:.2f}, set efield and fluence to zero')
+            logging.info(f'antenna position with distance {dcore_vBvvB:.2f} to core is outside of star pattern with radius {self.star_radius:.2f} on ground {self.geo_star_radius:.2f}, set efield and fluence to zero')
         else:
             if kind == 'efield':
                 if self.efield_interpolator == -1:

--- a/NuRadioReco/modules/io/coreas/readCoREASDetector.py
+++ b/NuRadioReco/modules/io/coreas/readCoREASDetector.py
@@ -277,7 +277,7 @@ class readCoREASDetector:
             )
             self.__t_per_event += time.time() - t_per_event
             self.__t += time.time() - t
-            efield_times = self.get_efield_times(electric_field_r_theta_phi[0,:,:], coreas_sampling_rate)
+            efield_times = get_efield_times(electric_field_r_theta_phi[0,:,:], coreas_sampling_rate)
 
             if len(self.__core_position_list) > 0:
                 cores = self.__core_position_list
@@ -309,10 +309,10 @@ class readCoREASDetector:
                             antenna_position_rel = detector.get_relative_position(station_id, channel_id)
                             antenna_position = det_station_position + antenna_position_rel
                             res_efield = self.get_interpolated_efield(antenna_position, core)
-                            smooth_res_efield = self.apply_hanning(res_efield)
-                            interp_observer = self.get_4d_observer(smooth_res_efield, efield_times)
-                            interp_efield, interp_times = coreas.observer_to_NuRadio(interp_observer)
-                            coreas.add_sim_channel(sim_station, channel_id, interp_efield, interp_times)
+                            smooth_res_efield = apply_hanning(res_efield)
+                            interp_observer = get_4d_observer(smooth_res_efield, efield_times)
+                            interp_efield, interp_times = coreas.observer_to_nuradio(corsika, interp_observer, interpFlag=True)
+                            coreas.add_sim_channel(sim_station, channel_id, interp_efield, interp_times, corsika)
                     station.set_sim_station(sim_station)
                     evt.set_station(station)
                     t_event_structure = time.time()

--- a/NuRadioReco/modules/io/coreas/readCoREASDetector.py
+++ b/NuRadioReco/modules/io/coreas/readCoREASDetector.py
@@ -15,8 +15,18 @@ from NuRadioReco.framework.parameters import showerParameters as shp
 from NuRadioReco.modules.io.coreas import coreas
 from NuRadioReco.utilities import units
 from collections import defaultdict
+from scipy.signal.windows import hann
 
 conversion_fieldstrength_cgs_to_SI = 2.99792458e10 * units.micro * units.volt / units.meter
+
+def get_random_core_positions(xmin, xmax, ymin, ymax, n_cores, seed=None):
+    random_generator = np.random.RandomState(seed)
+
+    # generate core positions randomly within a rectangle
+    cores = np.array([random_generator.uniform(xmin, xmax, n_cores),
+                    random_generator.uniform(ymin, ymax, n_cores),
+                    np.zeros(n_cores)]).T
+    return cores
 
 def get_efield_times(efield, sampling_rate):
     """
@@ -28,6 +38,31 @@ def get_efield_times(efield, sampling_rate):
     """
     efield_times = np.arange(0, len(efield[:,0])) / sampling_rate
     return efield_times
+
+def half_hann_window(length, half_percent=None, hann_window_length=None):
+    """
+    Produce a half-Hann window. This is the Hann window from SciPY with ones inserted in the middle to make the window
+    `length` long. Note that this is different from a Hamming window.
+    Parameters
+    ----------
+    length : int
+        The desired total length of the window
+    half_percent : float, default=None
+        The percentage of `length` at the beginning **and** end that should correspond to half of the Hann window
+    hann_window_length : int, default=None
+        The length of the half the Hann window. If `half_percent` is set, this value will be overwritten by it.
+    """
+    if half_percent is not None:
+        hann_window_length = int(length * half_percent)
+    elif hann_window_length is None:
+        raise ValueError("Either half_percent or half_window_length should be set!")
+    hann_window = hann(2 * hann_window_length)
+
+    half_hann_widow = np.ones(length, dtype=np.double)
+    half_hann_widow[:hann_window_length] = hann_window[:hann_window_length]
+    half_hann_widow[-hann_window_length:] = hann_window[hann_window_length:]
+
+    return half_hann_widow
 
 def apply_hanning(efields):
     """
@@ -45,28 +80,10 @@ def apply_hanning(efields):
         return None
     else:
         smoothed_trace = np.zeros_like(efields)
-        hann_window = np.hanning(efields.shape[0])
+        half_hann_window = half_hann_window(efields.shape[0], half_percent=0.1)
         for pol in range(efields.shape[1]):
-            smoothed_trace[:,pol] = efields[:,pol] * hann_window
+            smoothed_trace[:,pol] = efields[:,pol] * half_hann_window
         return smoothed_trace
-
-def get_4d_observer(efields, efield_times):
-    """
-    add the time axis before the efield and transpose the array
-
-    Parameters
-    ----------
-    efield in time domain: array (n_samples, n_polarizations)
-
-    Returns
-    ----------
-    4d_efield: array ((time, n_polarizations), n_samples)
-    """
-    observer = np.zeros((efield_times.shape[0], 4))
-    observer[:, 0] = efield_times
-    observer[:, 1:4] = efields
-    observer = observer.T
-    return observer
 
 def select_channels_per_station(det, station_id, requested_channel_ids):
     """
@@ -94,24 +111,20 @@ class readCoREASDetector:
     Use this as default when reading CoREAS files and combining them with a detector.
 
     This model reads the electric fields of a CoREAS file with a star shaped pattern and foldes them with it given detector. 
-    The core position of the star shape pattern is randomly distributed within a user defined area. 
-    If interpolated=True the electric field of the star shaped pattern is interpolated at the detector positions. 
-    If interpolated=False the closest observer position of the star shape pattern to the detector is chosen.
+    The electric field of the star shaped pattern is interpolated at the detector positions. 
     """
 
     def __init__(self):
         self.__t = 0
         self.__t_event_structure = 0
         self.__t_per_event = 0
-        self.__input_files = None
-        self.__n_cores = None
-        self.__current_input_file = None
+        self.__input_file = None
         self.__random_generator = None
         self.__interp_lowfreq = None
         self.__interp_highfreq = None
         self.logger = logging.getLogger('NuRadioReco.readCoREASDetector')
 
-    def begin(self, input_files, xmin=0, xmax=0, ymin=0, ymax=0, n_cores=10, seed=None, core_position_list=[], selected_station_ids=[], selected_channel_ids=[], interp_lowfreq=30*units.MHz, interp_highfreq=1000*units.MHz, log_level=logging.INFO, debug=False):
+    def begin(self, input_file, interp_lowfreq=30*units.MHz, interp_highfreq=1000*units.MHz, log_level=logging.INFO, debug=False):
             
         """
         begin method
@@ -120,42 +133,77 @@ class readCoREASDetector:
         ----------
         input_files: input files
             list of coreas hdf5 files
-        xmin: float
-            minimum x coordinate of the area in which core positions are distributed
-        xmax: float
-            maximum x coordinate of the area in which core positions are distributed
-        ymin: float
-            minimum y coordinate of the area in which core positions are distributed
-        ynax: float
-            maximum y coordinate of the area in which core positions are distributed
-        n_cores: number of cores (integer)
-            the number of random core positions to generate for each input file
-        seed: int (default: None)
-            Seed for the random number generation. If None is passed, no seed is set
         interp_lowfreq: float (default = 30)
             lower frequency for the bandpass filter in interpolation
         interp_highfreq: float (default = 1000)
             higher frequency for the bandpass filter in interpolation
         """
-        self.__input_files = input_files
-        self.__n_cores = n_cores
-        self.__current_input_file = 0
-        self.__area = [xmin, xmax, ymin, ymax]
-        self.__core_position_list = core_position_list
+        self.__input_file = input_file
+        self.__corsika = h5py.File(input_file, "r")
         self.__interp_lowfreq = interp_lowfreq
         self.__interp_highfreq = interp_highfreq
-        self.__selected_station_ids = selected_station_ids
-        self.__selected_channel_ids = selected_channel_ids
-        self.__random_generator = np.random.RandomState(seed)
+        self.__sampling_rate = 1. / (self.__corsika['CoREAS'].attrs['TimeResolution'] * units.second)
         self.logger.setLevel(log_level)
         self.debug = debug
 
-    def get_random_core_positions(self):
-        # generate core positions randomly within a rectangle
-        cores = np.array([self.__random_generator.uniform(self.__area[0], self.__area[1], self.__n_cores),
-                        self.__random_generator.uniform(self.__area[2], self.__area[3], self.__n_cores),
-                        np.zeros(self.__n_cores)]).T
-        return cores
+        self.initialize_efield_interpolator()
+
+    def initialize_efield_interpolator(self):
+        zenith, azimuth, magnetic_field_vector = coreas.get_angles(self.__corsika)
+        self.cs = cstrafo.cstrafo(zenith, azimuth, magnetic_field_vector)
+
+        obs_positions = []
+        electric_field_on_sky = []
+        for j_obs, observer in enumerate(self.__corsika['CoREAS']['observers'].values()):
+            obs_positions.append(np.array([-observer.attrs['position'][1], observer.attrs['position'][0], 0]) * units.cm)
+            efield = np.array([observer[()][:,0]*units.second,
+                                -observer[()][:,2]*conversion_fieldstrength_cgs_to_SI,
+                                observer[()][:,1]*conversion_fieldstrength_cgs_to_SI,
+                                observer[()][:,3]*conversion_fieldstrength_cgs_to_SI])
+            efield_geo = self.cs.transform_from_magnetic_to_geographic(efield[1:,:])
+            # convert coreas efield to NuRadio spherical coordinated eR, eTheta, ePhi (on sky)
+            efield_on_sky = self.cs.transform_from_ground_to_onsky(efield_geo)
+            # insert time column before efield values
+            electric_field_on_sky.append(np.insert(efield_on_sky.T, 0, efield[0,:], axis = 1))
+
+        # shape: (n_observers, n_samples, (time, eR, eTheta, ePhi))
+        electric_field_on_sky = np.array(electric_field_on_sky)
+        electric_field_r_theta_phi = electric_field_on_sky[:,:,1:]
+        coreas_dt = (self.__corsika['CoREAS'].attrs['TimeResolution'] * units.second)
+
+        obs_positions = np.array(obs_positions)
+        # second to last dimension has to be 3 for the transformation
+        obs_positions_geo = self.cs.transform_from_magnetic_to_geographic(obs_positions.T)
+        # transforms the coreas observer positions into the vxB, vxvxB shower plane
+        obs_positions_vBvvB = self.cs.transform_to_vxB_vxvxB(obs_positions_geo).T
+
+        if self.debug:
+            max_efield = []
+            for i in range(len(electric_field_on_sky[:,0,1])):
+                max_efield.append(np.max(np.abs(electric_field_on_sky[i,:,1:4])))
+            plt.scatter(obs_positions_vBvvB[:,0], obs_positions_vBvvB[:,1], c=max_efield, cmap='viridis', marker='o', edgecolors='k')
+            cbar = plt.colorbar()
+            cbar.set_label('max amplitude')
+            plt.xlabel('v x B [m]')
+            plt.ylabel('v x v x B [m]')
+            plt.show()
+            plt.close()
+
+        # consturct interpolator object for air shower efield in shower plane
+        self.efield_interpolator = cr_pulse_interpolator.signal_interpolation_fourier.interp2d_signal(
+            obs_positions_vBvvB[:, 0],
+            obs_positions_vBvvB[:, 1],
+            electric_field_r_theta_phi,
+            lowfreq=self.__interp_lowfreq/units.MHz,
+            highfreq=self.__interp_highfreq/units.MHz,
+            sampling_period=coreas_dt/units.s,
+            phase_method="phasor",
+            radial_method='cubic',
+            upsample_factor=5,
+            coherency_cutoff_threshold=0.9,
+            ignore_cutoff_freq_in_timing=False,
+            verbose=False
+        )
 
     def get_interpolated_efield(self, position, core):
         """
@@ -183,143 +231,70 @@ class readCoREASDetector:
 
         return efield_interp
 
+
     @register_run()
-    def run(self, detector):
+    def run(self, detector, core_position_list=[], selected_station_ids=[], selected_channel_ids=[]):
         """
         Parameters
         ----------
         detector: Detector object
             Detector description of the detector that shall be simulated
         """
-        if len(self.__selected_station_ids) == 0:
-            self.__selected_station_ids = detector.get_station_ids()
-            logging.info(f"using all station ids in detector: {self.__selected_station_ids}")
+        if len(selected_station_ids) == 0:
+            selected_station_ids = detector.get_station_ids()
+            logging.info(f"using all station ids in detector description: {selected_station_ids}")
         else:
-            logging.info(f"using selected station ids: {self.__selected_station_ids}")
+            logging.info(f"using selected station ids: {selected_station_ids}")
 
-        while (self.__current_input_file < len(self.__input_files)):
+        filesize = os.path.getsize(self.__input_file)
+        if(filesize < 18456 * 2):  # based on the observation that a file with such a small filesize is corrupt
+            self.logger.warning("file {} seems to be corrupt".format(self.__input_file))
+        else:
             t = time.time()
             t_per_event = time.time()
-            filesize = os.path.getsize(self.__input_files[self.__current_input_file])
-            if(filesize < 18456 * 2):  # based on the observation that a file with such a small filesize is corrupt
-                self.logger.warning("file {} seems to be corrupt, skipping to next file".format(self.__input_files[self.__current_input_file]))
-                self.__current_input_file += 1
-                continue
-            corsika = h5py.File(self.__input_files[self.__current_input_file], "r")
             self.logger.info(
                 "using coreas simulation {} with E={:2g} theta = {:.0f}".format(
-                    self.__input_files[self.__current_input_file],
-                    corsika['inputs'].attrs["ERANGE"][0] * units.GeV,
-                    corsika['inputs'].attrs["THETAP"][0]))
-
-            # coreas: x-axis pointing to the magnetic north, the positive y-axis to the west, and the z-axis upwards.
-            # NuRadio: x-axis pointing to the east, the positive y-axis geographical north, and the z-axis upwards.
-            # NuRadio_x = -coreas_y, NuRadio_y = coreas_x, NuRadio_z = coreas_z and then correct for mag north
-            zenith, azimuth, magnetic_field_vector = coreas.get_angles(corsika)
-            self.cs = cstrafo.cstrafo(zenith, azimuth, magnetic_field_vector)
-
-            obs_positions = []
-            electric_field_on_sky = []
-            for j_obs, observer in enumerate(corsika['CoREAS']['observers'].values()):
-                obs_positions.append(np.array([-observer.attrs['position'][1], observer.attrs['position'][0], 0]) * units.cm)
-                efield = np.array([observer[()][:,0]*units.second, 
-                                   -observer[()][:,2]*conversion_fieldstrength_cgs_to_SI, 
-                                   observer[()][:,1]*conversion_fieldstrength_cgs_to_SI, 
-                                   observer[()][:,3]*conversion_fieldstrength_cgs_to_SI])
-                efield_geo = self.cs.transform_from_magnetic_to_geographic(efield[1:,:])
-                # convert coreas efield to NuRadio spherical coordinated eR, eTheta, ePhi (on sky)
-                efield_on_sky = self.cs.transform_from_ground_to_onsky(efield_geo)
-                # insert time column before efield values
-                electric_field_on_sky.append(np.insert(efield_on_sky.T, 0, efield[0,:], axis = 1))
+                    self.__input_file,
+                    self.__corsika['inputs'].attrs["ERANGE"][0] * units.GeV,
+                    self.__corsika['inputs'].attrs["THETAP"][0]))
             
-            # shape: (n_observers, n_samples, (time, eR, eTheta, ePhi))
-            electric_field_on_sky = np.array(electric_field_on_sky)
-            electric_field_r_theta_phi = electric_field_on_sky[:,:,1:]
-            coreas_dt = (corsika['CoREAS'].attrs['TimeResolution'] * units.second)
-            coreas_sampling_rate = 1. / coreas_dt
-
-            obs_positions = np.array(obs_positions)
-            # second to last dimension has to be 3 for the transformation
-            obs_positions_geo = self.cs.transform_from_magnetic_to_geographic(obs_positions.T)
-            # transforms the coreas observer positions into the vxB, vxvxB shower plane
-            obs_positions_vBvvB = self.cs.transform_to_vxB_vxvxB(obs_positions_geo).T
-            dd = (obs_positions_vBvvB[:, 0] ** 2 + obs_positions_vBvvB[:, 1] ** 2) ** 0.5
-            # maximum distance between to observer positions and shower center in shower plane
-            self.ddmax = dd.max()
-            self.logger.info("star shape from: {} - {}".format(-dd.max(), dd.max()))
-
-            if self.debug:
-                max_efield = []
-                for i in range(len(electric_field_on_sky[:,0,1])):
-                    max_efield.append(np.max(np.abs(electric_field_on_sky[i,:,1:4])))
-                plt.scatter(obs_positions_vBvvB[:,0], obs_positions_vBvvB[:,1], c=max_efield, cmap='viridis', marker='o', edgecolors='k')
-                cbar = plt.colorbar()
-                cbar.set_label('max amplitude')
-                plt.xlabel('v x B [m]')
-                plt.ylabel('v x v x B [m]')
-                plt.show()
-                plt.close()
-
-            # consturct interpolator object for air shower efield in shower plane
-            self.efield_interpolator = cr_pulse_interpolator.signal_interpolation_fourier.interp2d_signal(
-                obs_positions_vBvvB[:, 0],
-                obs_positions_vBvvB[:, 1],
-                electric_field_r_theta_phi,
-                lowfreq=self.__interp_lowfreq/units.MHz,
-                highfreq=self.__interp_highfreq/units.MHz,
-                sampling_period=coreas_dt/units.s,
-                phase_method="phasor",
-                radial_method='cubic',
-                upsample_factor=5,
-                coherency_cutoff_threshold=0.9,
-                ignore_cutoff_freq_in_timing=False,
-                verbose=False
-            )
             self.__t_per_event += time.time() - t_per_event
             self.__t += time.time() - t
-            efield_times = get_efield_times(electric_field_r_theta_phi[0,:,:], coreas_sampling_rate)
 
-            if len(self.__core_position_list) > 0:
-                cores = self.__core_position_list
-                logging.info(f"using core positions from list: {cores}")
-            else:
-                cores = self.get_random_core_positions()
-                logging.info(f"using random core positions: {cores}")
-
-            for iCore, core in enumerate(cores):
+            for iCore, core in enumerate(core_position_list):
                 t = time.time()
-                evt = NuRadioReco.framework.event.Event(self.__current_input_file, iCore)  # create empty event
-                sim_shower = coreas.make_sim_shower(corsika)
+                evt = NuRadioReco.framework.event.Event(self.__input_file, iCore)  # create empty event
+                sim_shower = coreas.make_sim_shower(self.__corsika)
                 sim_shower.set_parameter(shp.core, core)
                 evt.add_sim_shower(sim_shower)
-                rd_shower = NuRadioReco.framework.radio_shower.RadioShower(station_ids=self.__selected_station_ids)
+                rd_shower = NuRadioReco.framework.radio_shower.RadioShower(station_ids=selected_station_ids)
                 evt.add_shower(rd_shower)
-                for station_id in self.__selected_station_ids:
+                for station_id in selected_station_ids:
                     station = NuRadioReco.framework.station.Station(station_id)
-                    sim_station = coreas.make_empty_sim_station(station_id, corsika)
+                    sim_station = coreas.make_empty_sim_station(station_id, self.__corsika)
                     det_station_position = detector.get_absolute_position(station_id)
                     channel_ids_in_station = detector.get_channel_ids(station_id)
-                    if len(self.__selected_channel_ids) == 0:
-                        self.__selected_channel_ids = channel_ids_in_station
-                    for channel_id in self.__selected_channel_ids:
-                        if channel_id not in channel_ids_in_station: #TODO does that work for lofar? otherwise getter function
-                            self.logger.info(f"channel {channel_id} not in station {station_id}")
-                            continue
-                        else:
-                            antenna_position_rel = detector.get_relative_position(station_id, channel_id)
-                            antenna_position = det_station_position + antenna_position_rel
-                            res_efield = self.get_interpolated_efield(antenna_position, core)
-                            smooth_res_efield = apply_hanning(res_efield)
-                            interp_observer = get_4d_observer(smooth_res_efield, efield_times)
-                            interp_efield, interp_times = coreas.observer_to_nuradio(corsika, interp_observer, interpFlag=True)
-                            coreas.add_sim_channel(sim_station, channel_id, interp_efield, interp_times, corsika)
+
+                    if len(selected_channel_ids) == 0:
+                        selected_channel_ids = channel_ids_in_station
+
+                    channel_ids_dict = select_channels_per_station(detector, station_id, selected_channel_ids)
+                    print(channel_ids_dict)
+                    for ch_g_ids in channel_group_ids:
+                        antenna_position_rel = detector.get_relative_position(station_id, ch_g_ids)
+                        antenna_position = det_station_position + antenna_position_rel
+                        res_efield = self.get_interpolated_efield(antenna_position, core)
+                        smooth_res_efield = apply_hanning(res_efield)
+                        efield_times = get_efield_times(smooth_res_efield, self.__sampling_rate)
+                        channel_ids_for_group_id = channel_ids_dict[ch_g_ids]
+                        coreas.add_electric_field(sim_station, channel_ids_for_group_id, smooth_res_efield, efield_times, self.__corsika)
                     station.set_sim_station(sim_station)
                     evt.set_station(station)
                     t_event_structure = time.time()
 
                 self.__t += time.time() - t
                 yield evt
-            self.__current_input_file += 1
+            self.__input_file += 1
 
     def end(self):
         self.logger.setLevel(logging.INFO)

--- a/NuRadioReco/modules/io/coreas/readCoREASDetector.py
+++ b/NuRadioReco/modules/io/coreas/readCoREASDetector.py
@@ -13,6 +13,7 @@ import NuRadioReco.framework.event
 import NuRadioReco.framework.station
 import NuRadioReco.framework.radio_shower
 from NuRadioReco.framework.parameters import showerParameters as shp
+from NuRadioReco.framework.parameters import stationParameters as stnp
 from NuRadioReco.modules.io.coreas import coreas
 from NuRadioReco.utilities import units
 from collections import defaultdict
@@ -380,6 +381,8 @@ class readCoREASDetector:
                         channel_ids_for_group_id = channel_ids_dict[ch_g_ids]
                         coreas.add_electric_field(sim_station, channel_ids_for_group_id, smooth_res_efield.T, efield_times, self.__corsika, fluence=res_fluence)
                     station.set_sim_station(sim_station)
+                    distance_to_core = np.linalg.norm(det_station_position[:-1] - core[:-1])
+                    station.set_parameter(stnp.distance_to_core, distance_to_core)
                     evt.set_station(station)
                     t_event_structure = time.time()
 

--- a/NuRadioReco/modules/voltageToEfieldConverterPerChannelGroup.py
+++ b/NuRadioReco/modules/voltageToEfieldConverterPerChannelGroup.py
@@ -1,0 +1,101 @@
+from NuRadioReco.modules.base.module import register_run
+import numpy as np
+from NuRadioReco.utilities import trace_utilities
+from NuRadioReco.detector import antennapattern
+from NuRadioReco.framework.parameters import stationParameters as stnp
+from NuRadioReco.framework.parameters import electricFieldParameters as efp
+from NuRadioReco.framework import electric_field as ef
+from NuRadioReco.modules.io.coreas.readCoREASDetector import select_channels_per_station
+from NuRadioReco.modules.voltageToEfieldConverter import get_array_of_channels
+import logging
+
+
+class voltageToEfieldConverterPerChannelGroup:
+    """
+    This module is intended to reconstruct the electric field from dual-polarized antennas, 
+    i.e., two antennas with orthogonal polarizations combined in one mechanical structure. 
+    This is the typical case for air-shower detectors such as Auger and LOFAR. 
+
+    Converts voltage trace to electric field per channel group.
+    """
+
+    def __init__(self):
+        self.logger = logging.getLogger('NuRadioReco.voltageToEfieldConverterPerChannelGroup')
+        self.antenna_provider = None
+        self.__counter = 0
+        self.begin()
+
+    def begin(self, use_MC_direction=False):
+        """
+        Initializes the module
+
+        Parameters
+        ----------
+        use_MC_direction: bool
+            If True, the MC direction is used for the reconstruction. If False, the reconstructed angles are used.
+        """
+        self.antenna_provider = antennapattern.AntennaPatternProvider()
+        self.__use_MC_direction = use_MC_direction
+
+    @register_run()
+    def run(self, evt, station, det):
+        """
+        Performs computation for voltage trace to electric field per channel
+
+        Will provide a deconvoluted (electric field) trace for each channel from the stations input voltage traces
+
+        Parameters
+        ----------
+        evt: event data structure
+            the event data structure
+        station: station data structure
+            the station data structure
+        det: detector object
+            the detector object
+        """
+        if self.__use_MC_direction:
+            if station.get_sim_station() is not None and station.get_sim_station().has_parameter(stnp.zenith):
+                zenith = station.get_sim_station()[stnp.zenith]
+                azimuth = station.get_sim_station()[stnp.azimuth]
+            else:
+                self.logger.error(f"MC direction requested but no simulation present in station {station.get_id()}")
+                raise ValueError("MC direction requested but no simulation present")
+        else:
+            self.logger.debug("Using reconstructed angles as no simulation present")
+            zenith = station[stnp.zenith]
+            azimuth = station[stnp.azimuth]
+
+        use_channels = det.get_channel_ids(station.get_id())
+        frequencies = station.get_channel(use_channels[0]).get_frequencies()  # assuming that all channels have the  same sampling rate and length
+
+        sampling_rate = station.get_channel(use_channels[0]).get_sampling_rate()
+
+        group_ids = select_channels_per_station(det, station.get_id(), station.get_channel_ids())
+        for gid, use_channels in group_ids.items():
+            efield_antenna_factor = trace_utilities.get_efield_antenna_factor(station, frequencies, use_channels, det,
+                                                                            zenith, azimuth, self.antenna_provider)
+            V = np.zeros((len(use_channels), len(frequencies)), dtype=complex)
+            for i_ch, channel_id in enumerate(use_channels):
+                V[i_ch] = station.get_channel(channel_id).get_frequency_spectrum()
+            denom = (efield_antenna_factor[0][0] * efield_antenna_factor[1][1] - efield_antenna_factor[0][1] * efield_antenna_factor[1][0])
+            mask = np.abs(denom) != 0
+            # solving for electric field using just two orthorgonal antennas
+            E1 = np.zeros_like(V[0], dtype=complex)
+            E2 = np.zeros_like(V[0], dtype=complex)
+            E1[mask] = (V[0] * efield_antenna_factor[1][1] - V[1] * efield_antenna_factor[0][1])[mask] / denom[mask]
+            E2[mask] = (V[1] - efield_antenna_factor[1][0] * E1)[mask] / efield_antenna_factor[1][1][mask]
+            denom = (efield_antenna_factor[0][0] * efield_antenna_factor[-1][1] - efield_antenna_factor[0][1] * efield_antenna_factor[-1][0])
+            mask = np.abs(denom) != 0
+            E1[mask] = (V[0] * efield_antenna_factor[-1][1] - V[-1] * efield_antenna_factor[0][1])[mask] / denom[mask]
+            E2[mask] = (V[-1] - efield_antenna_factor[-1][0] * E1)[mask] / efield_antenna_factor[-1][1][mask]
+
+            efield = ef.ElectricField(use_channels)
+            efield.set_frequency_spectrum(np.array([np.zeros_like(E1), E1, E2]), sampling_rate)
+
+            efield.set_trace_start_time(station.get_channel(use_channels[0]).get_trace_start_time())
+            efield[efp.zenith] = zenith
+            efield[efp.azimuth] = azimuth
+            station.add_electric_field(efield)
+
+    def end(self):
+        pass


### PR DESCRIPTION

This is a coreasReader that can be given a detector array and a selection of station_ids and channel_ids for which the electric field from the coreas shower at a certain core position is interpolated. It uses the coreas interpolation code cr-pulse-interpolator (https://github.com/nu-radio/cr-pulse-interpolator). The electric field is interpolated in the shower plane and stored per channel_id. 