### PR TITLE
Jit ray tracing

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -129,12 +129,6 @@ jobs:
          export PYTHONPATH=$PWD:$PYTHONPATH
          export GSLDIR=$(gsl-config --prefix)
          NuRadioMC/test/SignalProp/run_signal_test.sh
-    - name: "Test ray tracing modules"
-      if: always()
-      run: |
-         export PYTHONPATH=$PWD:$PYTHONPATH
-         export GSLDIR=$(gsl-config --prefix)
-         python NuRadioMC/SignalProp/examples/ray_tracing_modules.py
     - name: "Test Birefringence"
       if: always()
       run: |

--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -432,7 +432,6 @@ class ray_tracing_2D(ray_tracing_base):
             self._use_optimized_calculation = overwrite_speedup
         self.use_cpp = use_cpp
         if compile_numba:
-            self.use_cpp = False
             if numba_available:
                 global get_reflection_point,obj_delta_y_square,get_delta_y
                 global get_y_turn, get_y_with_z_mirror,get_turning_point
@@ -451,6 +450,7 @@ class ray_tracing_2D(ray_tracing_base):
                     get_C0_from_log = jit(get_C0_from_log, nopython=True, cache=True)
                     get_z_unmirrored = jit(get_z_unmirrored, nopython=True, cache=True)
                     n = jit(n, nopython=True, cache=True)
+                    self.use_cpp = False
                 except:
                     compile_numba = False
 

--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -57,7 +57,7 @@ try:
     from numba import jit, njit
     numba_available = True
     print("Numba version of raytracer is available")
-except:
+except ImportError:
     print("Numba is not available")
     numba_available = False
 
@@ -193,19 +193,6 @@ def get_y_with_z_mirror(z, C_0, n_ice, b, delta_n, z_0, C_1=0.0):
     else:
         gamma = get_gamma(2 * z_turn - z, delta_n, z_0)
         return 2 * y_turn - get_y(gamma, C_0, C_1, n_ice, b, z_0)
-## Used in case of an array being passed as z 
-#    else:
-#        mask = z < z_turn
-#        res = np.zeros_like(z)
-#        zs = np.zeros_like(z)
-#        gamma = get_gamma(z[mask], delta_n, z_0)
-#        zs[mask] = z[mask]
-#        res[mask] = get_y(gamma, C_0, C_1, n_ice, b, z_0)
-#        gamma = get_gamma(2 * z_turn - z[~mask], delta_n, z_0)
-#        res[~mask] = 2 * y_turn - get_y(gamma, C_0, C_1, n_ice, b, z_0)
-#        zs[~mask] = 2 * z_turn - z[~mask]
-
-#        return np.array([res, zs])
 
 def get_y_turn( C_0, x1, n_ice, b, delta_n, z_0):
     """
@@ -452,6 +439,7 @@ class ray_tracing_2D(ray_tracing_base):
                     n = jit(n, nopython=True, cache=True)
                     self.use_cpp = False
                 except:
+                    self.__logger.warning("Error in compiling methods using jit - proceeding without numba")
                     compile_numba = False
 
 

--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -423,25 +423,19 @@ class ray_tracing_2D(ray_tracing_base):
                 global get_reflection_point,obj_delta_y_square,get_delta_y
                 global get_y_turn, get_y_with_z_mirror,get_turning_point
                 global get_gamma, get_y, get_C0_from_log
-                global  get_z_unmirrored, get_y_diff, n
-                try :
-                
-                    get_reflection_point = jit(get_reflection_point, nopython=True, cache=True)
-                    obj_delta_y_square = jit(obj_delta_y_square, nopython=True, cache=True)
-                    get_delta_y = jit(get_delta_y, nopython=True, cache=True)
-                    get_y_turn = jit(get_y_turn, nopython=True, cache=True)
-                    get_y_with_z_mirror = jit(get_y_with_z_mirror, nopython=True, cache=True)
-                    get_turning_point = jit(get_turning_point, nopython=True, cache=True)
-                    get_gamma = jit(get_gamma, nopython=True, cache=True)
-                    get_y = jit(get_y, nopython=True, cache=True)
-                    get_C0_from_log = jit(get_C0_from_log, nopython=True, cache=True)
-                    get_z_unmirrored = jit(get_z_unmirrored, nopython=True, cache=True)
-                    n = jit(n, nopython=True, cache=True)
-                    self.use_cpp = False
-                except:
-                    self.__logger.warning("Error in compiling methods using jit - proceeding without numba")
-                    compile_numba = False
-
+                global  get_z_unmirrored, get_y_diff, n                
+                get_reflection_point = jit(get_reflection_point, nopython=True, cache=True)
+                obj_delta_y_square = jit(obj_delta_y_square, nopython=True, cache=True)
+                get_delta_y = jit(get_delta_y, nopython=True, cache=True)
+                get_y_turn = jit(get_y_turn, nopython=True, cache=True)
+                get_y_with_z_mirror = jit(get_y_with_z_mirror, nopython=True, cache=True)
+                get_turning_point = jit(get_turning_point, nopython=True, cache=True)
+                get_gamma = jit(get_gamma, nopython=True, cache=True)
+                get_y = jit(get_y, nopython=True, cache=True)
+                get_C0_from_log = jit(get_C0_from_log, nopython=True, cache=True)
+                get_z_unmirrored = jit(get_z_unmirrored, nopython=True, cache=True)
+                n = jit(n, nopython=True, cache=True)
+                self.use_cpp = False
 
     def get_C_1(self, x1, C_0):
         """

--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -438,7 +438,7 @@ class ray_tracing_2D(ray_tracing_base):
                     n = jit(n, nopython=True, cache=True)
                     self.use_cpp = False
                 except: 
-                     self.__logger.warning("Error in compiling methods using jit - proceeding without numba")
+                    self.__logger.warning("Error in compiling methods using jit - proceeding without numba")
                     compile_numba = False
 
     def get_C_1(self, x1, C_0):

--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -423,19 +423,23 @@ class ray_tracing_2D(ray_tracing_base):
                 global get_reflection_point,obj_delta_y_square,get_delta_y
                 global get_y_turn, get_y_with_z_mirror,get_turning_point
                 global get_gamma, get_y, get_C0_from_log
-                global  get_z_unmirrored, get_y_diff, n                
-                get_reflection_point = jit(get_reflection_point, nopython=True, cache=True)
-                obj_delta_y_square = jit(obj_delta_y_square, nopython=True, cache=True)
-                get_delta_y = jit(get_delta_y, nopython=True, cache=True)
-                get_y_turn = jit(get_y_turn, nopython=True, cache=True)
-                get_y_with_z_mirror = jit(get_y_with_z_mirror, nopython=True, cache=True)
-                get_turning_point = jit(get_turning_point, nopython=True, cache=True)
-                get_gamma = jit(get_gamma, nopython=True, cache=True)
-                get_y = jit(get_y, nopython=True, cache=True)
-                get_C0_from_log = jit(get_C0_from_log, nopython=True, cache=True)
-                get_z_unmirrored = jit(get_z_unmirrored, nopython=True, cache=True)
-                n = jit(n, nopython=True, cache=True)
-                self.use_cpp = False
+                global  get_z_unmirrored, get_y_diff, n
+                try:
+                    get_reflection_point = jit(get_reflection_point, nopython=True, cache=True)
+                    obj_delta_y_square = jit(obj_delta_y_square, nopython=True, cache=True)
+                    get_delta_y = jit(get_delta_y, nopython=True, cache=True)
+                    get_y_turn = jit(get_y_turn, nopython=True, cache=True)
+                    get_y_with_z_mirror = jit(get_y_with_z_mirror, nopython=True, cache=True)
+                    get_turning_point = jit(get_turning_point, nopython=True, cache=True)
+                    get_gamma = jit(get_gamma, nopython=True, cache=True)
+                    get_y = jit(get_y, nopython=True, cache=True)
+                    get_C0_from_log = jit(get_C0_from_log, nopython=True, cache=True)
+                    get_z_unmirrored = jit(get_z_unmirrored, nopython=True, cache=True)
+                    n = jit(n, nopython=True, cache=True)
+                    self.use_cpp = False
+                except: 
+                     self.__logger.warning("Error in compiling methods using jit - proceeding without numba")
+                    compile_numba = False
 
     def get_C_1(self, x1, C_0):
         """

--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -51,6 +51,15 @@ except:
         print("check NuRadioMC/NuRadioMC/SignalProp/CPPAnalyticRayTracing for manual compilation")
         cpp_available = False
 
+numba_available = False
+
+try:
+    from numba import jit, njit
+    numba_available = True
+    print("Numba version of raytracer is available")
+except:
+    print("Numba is not available")
+    numba_available = False
 
 """
 analytic ray tracing solution
@@ -98,6 +107,219 @@ def get_z_deep(ice_params):
     return res
 
 
+def get_C0_from_log(logC0, n_ice):
+    """
+    transforms the fit parameter C_0 so that the likelihood looks better
+    """
+    return np.exp(logC0) + 1. / n_ice
+
+def get_y(gamma, C_0, C_1, n_ice, b, z_0):
+    """
+    analytic form of the ray tracing part given an exponential index of refraction profile
+
+    Parameters
+    ----------
+    gamma: (float or array)
+        gamma is a function of the depth z
+    C_0: (float)
+        first parameter
+    C_1: (float)
+        second parameter
+    """
+    c = n_ice ** 2 - C_0 ** -2
+    # we take the absolute number here but we only evaluate the equation for
+    # positive outcome. This is to prevent rounding errors making the root
+    # negative
+    root = np.abs(gamma ** 2 - gamma * b + c)
+    logargument = gamma / (2 * c ** 0.5 * (root) ** 0.5 - b * gamma + 2 * c)
+    result = z_0 * (n_ice ** 2 * C_0 ** 2 - 1) ** -0.5 * np.log(logargument) + C_1
+    return result
+
+def get_gamma(z, delta_n, z_0):
+    """
+    transforms z coordinate into gamma
+    """
+    return delta_n * (np.exp(z / z_0))
+
+def get_turning_point(c, b, z_0, delta_n):
+    """
+    calculate the turning point, i.e. the maximum of the ray tracing path;
+    parameter is c = self.medium.n_ice ** 2 - C_0 ** -2
+
+    This is either the point of reflection off the ice surface
+    or the point where the saddle point of the ray (transition from upward to downward going)
+
+    Technically, the turning point is set to z=0 if the saddle point is above the surface.
+
+    Parameters
+    ----------
+    c: float
+        related to C_0 parameter via c = self.medium.n_ice ** 2 - C_0 ** -2
+
+    Returns
+    -------
+    typle (gamma, z coordinate of turning point)
+    """
+    gamma2 = np.array([b * 0.5 - (0.25 * b ** 2 - c) ** 0.5])  # first solution discarded
+    z2 = np.log(gamma2 / delta_n) * z_0
+    if(z2 > 0):
+        z2 = np.array([0], dtype=np.float64)  # a reflection is just a turning point at z = 0, i.e. cases 2) and 3) are the same
+        gamma2 = get_gamma(z2, delta_n, z_0)
+
+    return gamma2  , z2
+
+def get_y_with_z_mirror(z, C_0, n_ice, b, delta_n, z_0, C_1=0.0):
+    """
+    analytic form of the ray tracing part given an exponential index of refraction profile
+
+    this function automatically mirrors z values that are above the turning point,
+    so that this function is defined for all z
+
+    Parameters
+    ----------
+    z: (float or array)
+        depth z
+    C_0: (float)
+        first parameter
+    C_1: (float)
+        second parameter
+    """
+    c = n_ice ** 2 - C_0 ** -2
+    gamma_turn, z_turn = get_turning_point(c, b, z_0, delta_n)
+    y_turn = get_y(gamma_turn, C_0, C_1, n_ice, b, z_0)
+    if(not hasattr(z, '__len__')):
+        if(z < z_turn):
+            gamma = get_gamma(np.array([1])*z, delta_n, z_0)
+            return get_y(gamma, C_0, C_1, n_ice, b, z_0)
+        else:
+            gamma = get_gamma(2 * z_turn - z, delta_n, z_0)
+            return 2 * y_turn - get_y(gamma, C_0, C_1, n_ice, b, z_0)
+    else:
+        mask = z < z_turn
+        res = np.zeros_like(z)
+        zs = np.zeros_like(z)
+        gamma = get_gamma(z[mask], delta_n, z_0)
+        zs[mask] = z[mask]
+        res[mask] = get_y(gamma, C_0, C_1, n_ice, b, z_0)
+        gamma = get_gamma(2 * z_turn - z[~mask], delta_n, z_0)
+        res[~mask] = 2 * y_turn - get_y(gamma, C_0, C_1, n_ice, b, z_0)
+        zs[~mask] = 2 * z_turn - z[~mask]
+
+        return np.array([res, zs])
+
+def get_y_turn( C_0, x1, n_ice, b, delta_n, z_0):
+    """
+    calculates the y-coordinate of the turning point. This is either the point of reflection off the ice surface
+    or the point where the saddle point of the ray (transition from upward to downward going)
+
+    Parameters
+    ----------
+    C_0: float
+        C_0 parameter of function
+    x1: typle
+        (y, z) start position of ray
+    """
+    c = n_ice ** 2 - C_0 ** -2
+    gamma_turn, z_turn = get_turning_point(c, b, z_0, delta_n)
+    C_1 = x1[0] - get_y_with_z_mirror(x1[1], C_0, n_ice, b, delta_n, z_0)[0]
+    y_turn = get_y(gamma_turn[0], C_0, C_1, n_ice, b, z_0) 
+    return y_turn
+
+def get_delta_y(C_0, x1, x2, n_ice, b, delta_n, z_0, C0range=None, reflection=0, reflection_case=2):
+    """
+    calculates the difference in the y position between the analytic ray tracing path
+    specified by C_0 at the position x2
+    """
+    C_0_first = C_0
+
+    if C0range is None:
+        C0range = [1. / n_ice, np.inf]
+    else:
+        C0range = [float(C0range[0]), float(C0range[1])]
+    Corange_array = np.array(C0range ,  dtype=np.float64)
+    if((C_0_first < Corange_array[0]) or(C_0_first > Corange_array[1])):
+        return -np.inf
+    c = n_ice ** 2 - C_0 ** -2
+    # we consider two cases here,
+    # 1) the rays start rising -> the default case
+    # 2) the rays start decreasing -> we need to find the position left of the start point that
+    #    that has rising rays that go through the point x1
+    if(reflection > 0 and reflection_case == 2):
+        y_turn = get_y_turn(C_0_first, x1, n_ice, b, delta_n, z_0)
+        dy = y_turn - x1[0]
+        x1[0] = x1[0] - 2 * dy[0]
+
+    for i in range(reflection):
+        # we take account reflections at the bottom layer into account via
+        # 1) calculating the point where the reflection happens
+        # 2) starting a ray tracing from this new point
+
+        # determine y translation first
+        C_1 = x1[0] - get_y_with_z_mirror(x1[1], C_0_first, n_ice, b, delta_n, z_0)[0]
+        if(hasattr(C_1, '__len__')):
+            C_1 = C_1[0]
+
+        x1 = get_reflection_point(C_0, C_1, n_ice, reflection, b, z_0, delta_n)
+
+    # determine y translation first
+    C_1 = x1[0] - get_y_with_z_mirror(x1[1], C_0_first, n_ice, b, delta_n, z_0)[0]
+    if(hasattr(C_1, '__len__')):
+        C_1 = C_1[0]
+
+    # for a given c_0, 3 cases are possible to reach the y position of x2
+    # 1) direct ray, i.e., before the turning point
+    # 2) refracted ray, i.e. after the turning point but not touching the surface
+    # 3) reflected ray, i.e. after the ray reaches the surface
+    gamma_turn, z_turn = get_turning_point(c, b, z_0, delta_n)
+    y_turn = get_y(gamma_turn, C_0_first, C_1, n_ice, b, z_0)
+    if(z_turn < x2[1]):  # turning points is deeper that x2 positions, can't reach target
+        # the minimizer has problems finding the minimum if inf is returned here. Therefore, we return the distance
+        # between the turning point and the target point + 10 x the distance between the z position of the turning points
+        # and the target position. This results in a objective function that has the solutions as the only minima and
+        # is smooth in C_0
+        diff = ((z_turn - x2[1]) ** 2 + (y_turn - x2[0]) ** 2) ** 0.5 + 10 * np.abs(z_turn - x2[1])
+        return -diff[0]
+#             return -np.inf
+    if(y_turn > x2[0]):  # we always propagate from left to right
+        # direct ray
+        y2_fit = get_y(get_gamma(x2[1], delta_n, z_0), C_0_first, C_1, n_ice, b, z_0)  # calculate y position at get_path position
+        diff = (x2[0] - y2_fit)
+        #if(hasattr(diff, '__len__')):
+        #    diff = diff[0]
+        if(hasattr(x2[0], '__len__')):
+            x2[0] = x2[0][0]
+
+        return diff
+    else:
+        # now it's a bit more complicated. we need to transform the coordinates to
+        # be on the mirrored part of the function
+        z_mirrored = x2[1]
+        gamma = get_gamma(z_mirrored, delta_n, z_0)
+        y2_raw = get_y(gamma, C_0_first, C_1, n_ice, b, z_0)
+        y2_fit = 2 * y_turn - y2_raw
+        diff = (x2[0] - y2_fit)
+
+        return -1 * diff[0]
+
+def obj_delta_y_square( logC_0, x1, x2, n_ice, b, delta_n, z_0, reflection=0, reflection_case=2):
+    """
+    objective function to find solution for C0
+    """
+    C_0 = get_C0_from_log(logC_0[0], n_ice)
+    return get_delta_y(C_0, x1, x2, n_ice, b, delta_n, z_0, None, reflection=reflection, reflection_case=reflection_case) ** 2
+
+def get_reflection_point(C_0, C_1, n_ice, reflection, b, z_0, delta_n):
+    """
+    calculates the point where the signal gets reflected off the bottom of the ice shelf
+
+    Returns tuple (y,z)
+    """
+    c = n_ice ** 2 - C_0 ** -2
+    _gamma_turn, z_turn = get_turning_point(c, b, z_0, delta_n)
+    x2 = np.array([0, reflection],dtype = np.float64)
+    x2[0]  = get_y_with_z_mirror(-x2[1] + 2 * z_turn, C_0, n_ice, b, delta_n, z_0, C_1)[0]
+    return x2
+
 class ray_tracing_2D(ray_tracing_base):
 
     def __init__(self, medium, attenuation_model="SP1",
@@ -105,7 +327,8 @@ class ray_tracing_2D(ray_tracing_base):
                  n_frequencies_integration=25,
                  use_optimized_start_values=False,
                  overwrite_speedup=None,
-                 use_cpp=cpp_available):
+                 use_cpp=cpp_available,
+                 compile_numba=False):
         """
         initialize 2D analytic ray tracing class
 
@@ -153,6 +376,25 @@ class ray_tracing_2D(ray_tracing_base):
         if overwrite_speedup is not None:
             self._use_optimized_calculation = overwrite_speedup
         self.use_cpp = use_cpp
+        if compile_numba:
+            self.use_cpp = False
+            if numba_available:
+                global get_reflection_point,obj_delta_y_square,get_delta_y
+                global get_y_turn, get_y_with_z_mirror,get_turning_point
+                global get_gamma, get_y, get_C0_from_log
+                try :
+                
+                    get_reflection_point = jit(get_reflection_point, nopython=True, cache=True)
+                    obj_delta_y_square = jit(obj_delta_y_square, nopython=True, cache=True)
+                    get_delta_y = jit(get_delta_y, nopython=True, cache=True)
+                    get_y_turn = jit(get_y_turn, nopython=True, cache=True)
+                    get_y_with_z_mirror = jit(get_y_with_z_mirror, nopython=True, cache=True)
+                    get_turning_point = jit(get_turning_point, nopython=True, cache=True)
+                    get_gamma = jit(get_gamma, nopython=True, cache=True)
+                    get_y = jit(get_y, nopython=True, cache=True)
+                    get_C0_from_log = jit(get_C0_from_log, nopython=True, cache=True)
+                except:
+                    compile_numba = False
 
     def n(self, z):
         """
@@ -168,96 +410,14 @@ class ray_tracing_2D(ray_tracing_base):
     #         res[z > 0] = 1.
         return res
 
-    def get_gamma(self, z):
-        """
-        transforms z coordinate into gamma
-        """
-        return self.medium.delta_n * np.exp(z / self.medium.z_0)
-
-    def get_turning_point(self, c):
-        """
-        calculate the turning point, i.e. the maximum of the ray tracing path;
-        parameter is c = self.medium.n_ice ** 2 - C_0 ** -2
-
-        This is either the point of reflection off the ice surface
-        or the point where the saddle point of the ray (transition from upward to downward going)
-
-        Technically, the turning point is set to z=0 if the saddle point is above the surface.
-
-        Parameters
-        ----------
-        c: float
-            related to C_0 parameter via c = self.medium.n_ice ** 2 - C_0 ** -2
-
-        Returns
-        -------
-        typle (gamma, z coordinate of turning point)
-        """
-        gamma2 = self.__b * 0.5 - (0.25 * self.__b ** 2 - c) ** 0.5  # first solution discarded
-        z2 = np.log(gamma2 / self.medium.delta_n) * self.medium.z_0
-
-        if(z2 > 0):
-            z2 = 0  # a reflection is just a turning point at z = 0, i.e. cases 2) and 3) are the same
-            gamma2 = self.get_gamma(z2)
-
-        return gamma2, z2
-
-    def get_y_turn(self, C_0, x1):
-        """
-        calculates the y-coordinate of the turning point. This is either the point of reflection off the ice surface
-        or the point where the saddle point of the ray (transition from upward to downward going)
-
-        Parameters
-        ----------
-        C_0: float
-            C_0 parameter of function
-        x1: typle
-            (y, z) start position of ray
-        """
-        c = self.medium.n_ice ** 2 - C_0 ** -2
-        gamma_turn, z_turn = self.get_turning_point(c)
-        C_1 = x1[0] - self.get_y_with_z_mirror(x1[1], C_0)
-        y_turn = self.get_y(gamma_turn, C_0, C_1)
-        return y_turn
-
     def get_C_1(self, x1, C_0):
         """
         calculates constant C_1 for a given C_0 and start point x1
         """
-        return x1[0] - self.get_y_with_z_mirror(x1[1], C_0)
+        return x1[0] - get_y_with_z_mirror(x1[1], C_0, self.medium.n_ice, self.__b, self.medium.delta_n, self.medium.z_0)[0]
 
     def get_c(self, C_0):
         return self.medium.n_ice ** 2 - C_0 ** -2
-
-    def get_C0_from_log(self, logC0):
-        """
-        transforms the fit parameter C_0 so that the likelihood looks better
-        """
-        return np.exp(logC0) + 1. / self.medium.n_ice
-
-    def get_y(self, gamma, C_0, C_1):
-        """
-        analytic form of the ray tracing part given an exponential index of refraction profile
-
-        Parameters
-        ----------
-        gamma: (float or array)
-            gamma is a function of the depth z
-        C_0: (float)
-            first parameter
-        C_1: (float)
-            second parameter
-        """
-        c = self.medium.n_ice ** 2 - C_0 ** -2
-        # we take the absolute number here but we only evaluate the equation for
-        # positive outcome. This is to prevent rounding errors making the root
-        # negative
-        root = np.abs(gamma ** 2 - gamma * self.__b + c)
-        logargument = gamma / (2 * c ** 0.5 * (root) ** 0.5 - self.__b * gamma + 2 * c)
-        if(np.sum(logargument <= 0)):
-            self.__logger.debug('log = {}'.format(logargument))
-        result = self.medium.z_0 * (self.medium.n_ice ** 2 * C_0 ** 2 - 1) ** -0.5 * np.log(logargument) + C_1
-        return result
 
     def get_y_diff(self, z_raw, C_0, in_air=False):
         """
@@ -290,55 +450,16 @@ class ray_tracing_2D(ray_tracing_base):
             res *= -1
         return res
 
-    def get_y_with_z_mirror(self, z, C_0, C_1=0):
-        """
-        analytic form of the ray tracing part given an exponential index of refraction profile
-
-        this function automatically mirrors z values that are above the turning point,
-        so that this function is defined for all z
-
-        Parameters
-        ----------
-        z: (float or array)
-            depth z
-        C_0: (float)
-            first parameter
-        C_1: (float)
-            second parameter
-        """
-        c = self.medium.n_ice ** 2 - C_0 ** -2
-        gamma_turn, z_turn = self.get_turning_point(c)
-        y_turn = self.get_y(gamma_turn, C_0, C_1)
-        if(not hasattr(z, '__len__')):
-            if(z < z_turn):
-                gamma = self.get_gamma(z)
-                return self.get_y(gamma, C_0, C_1)
-            else:
-                gamma = self.get_gamma(2 * z_turn - z)
-                return 2 * y_turn - self.get_y(gamma, C_0, C_1)
-        else:
-            mask = z < z_turn
-            res = np.zeros_like(z)
-            zs = np.zeros_like(z)
-            gamma = self.get_gamma(z[mask])
-            zs[mask] = z[mask]
-            res[mask] = self.get_y(gamma, C_0, C_1)
-            gamma = self.get_gamma(2 * z_turn - z[~mask])
-            res[~mask] = 2 * y_turn - self.get_y(gamma, C_0, C_1)
-            zs[~mask] = 2 * z_turn - z[~mask]
-
-            self.__logger.debug('turning points for C_0 = {:.2f}, b= {:.2f}, gamma = {:.4f}, z = {:.1f}, y_turn = {:.0f}'.format(
-                C_0, self.__b, gamma_turn, z_turn, y_turn))
-            return res, zs
-
     def get_z_mirrored(self, x1, x2, C_0):
         """
         calculates the mirrored x2 position so that y(z) can be used as a continuous function
         """
         c = self.medium.n_ice ** 2 - C_0 ** -2
-        C_1 = x1[0] - self.get_y_with_z_mirror(x1[1], C_0)
-        gamma_turn, z_turn = self.get_turning_point(c)
-        y_turn = self.get_y(gamma_turn, C_0, C_1)
+        C_1 = x1[0] - get_y_with_z_mirror(x1[1], C_0, self.medium.n_ice, self.__b, self.medium.delta_n, self.medium.z_0)[0]
+        gamma_turn, z_turn = get_turning_point(c, self.__b, self.medium.z_0, self.medium.delta_n)
+        gamma_turn = gamma_turn[0]
+        z_turn = z_turn[0]
+        y_turn = get_y(gamma_turn, C_0, C_1, self.medium.n_ice, self.__b, self.medium.z_0)
         zstart = x1[1]
         zstop = x2[1]
         if(y_turn < x2[0]):
@@ -351,7 +472,9 @@ class ray_tracing_2D(ray_tracing_base):
         calculates the unmirrored z position
         """
         c = self.medium.n_ice ** 2 - C_0 ** -2
-        gamma_turn, z_turn = self.get_turning_point(c)
+        gamma_turn, z_turn = get_turning_point(c, self.__b, self.medium.z_0, self.medium.delta_n)
+        gamma_turn = gamma_turn[0]
+        z_turn = z_turn[0]
         z_unmirrored = z
         if(z > z_turn):
             z_unmirrored = 2 * z_turn - z
@@ -383,14 +506,15 @@ class ray_tracing_2D(ray_tracing_base):
             if(x2[1] > 0):
                 # we need to integrat only until the ray touches the surface
                 z_turn = 0
-                y_turn = self.get_y(self.get_gamma(z_turn), C_0, self.get_C_1(x1, C_0))
+                y_turn = get_y(get_gamma(z_turn, self.medium.delta_n, self.medium.z_0), C_0, self.get_C_1(x1, C_0), self.medium.n_ice, self.__b, self.medium.z_0)
                 d_air = ((x2[0] - y_turn) ** 2 + (x2[1]) ** 2) ** 0.5
                 tmp += d_air
                 z_int = z_turn
                 self.__logger.info(f"adding additional propagation path through air of {d_air/units.m:.1f}m")
             else:
                 x2_mirrored = self.get_z_mirrored(x1, x2, C_0)
-                gamma_turn, z_turn = self.get_turning_point(self.medium.n_ice ** 2 - C_0 ** -2)
+                gamma_turn, z_turn = get_turning_point(self.medium.n_ice ** 2 - C_0 ** -2,self.__b, self.medium.z_0, self.medium.delta_n)
+                z_turn = z_turn[0]
                 if(x1[1] < z_turn and z_turn < x2_mirrored[1]):
                     points = [z_turn]
                 z_int = x2_mirrored[1]
@@ -478,7 +602,7 @@ class ray_tracing_2D(ray_tracing_base):
             # first treat special case of ice to air propagation
             if(x2[1] > 0):
                 z_turn = 0
-                y_turn = self.get_y(self.get_gamma(z_turn), C_0, self.get_C_1(x1, C_0))
+                y_turn = get_y(get_gamma(z_turn, self.medium.delta_n, self.medium.z_0), C_0, self.get_C_1(x1, C_0), self.medium.n_ice, self.__b, self.medium.z_0)
                 d_air = ((x2[0] - y_turn) ** 2 + (x2[1]) ** 2) ** 0.5
                 try:
                     ttmp = get_path_direct(x1[1], z_turn)
@@ -495,7 +619,8 @@ class ray_tracing_2D(ray_tracing_base):
                     if(solution_type == 3):
                         z_turn = 0
                     else:
-                        gamma_turn, z_turn = self.get_turning_point(self.medium.n_ice ** 2 - C_0 ** -2)
+                        gamma_turn, z_turn = get_turning_point(self.medium.n_ice ** 2 - C_0 ** -2,self.__b, self.medium.z_0, self.medium.delta_n)
+                        z_turn = z_turn[0]
         #             print('solution type {:d}, zturn = {:.1f}'.format(solution_type, z_turn))
                     try:
                         tmp += get_path_direct(x1[1], z_turn) + get_path_direct(x2[1], z_turn)
@@ -525,13 +650,14 @@ class ray_tracing_2D(ray_tracing_base):
             if(x2[1] > 0):
                 # we need to integrat only until the ray touches the surface
                 z_turn = 0
-                y_turn = self.get_y(self.get_gamma(z_turn), C_0, self.get_C_1(x1, C_0))
+                y_turn = get_y(get_gamma(z_turn, self.medium.delta_n, self.medium.z_0), C_0, self.get_C_1(x1, C_0), self.medium.n_ice, self.__b, self.medium.z_0)
                 T_air = ((x2[0] - y_turn) ** 2 + (x2[1]) ** 2) ** 0.5 / speed_of_light
                 tmp += T_air
                 z_int = z_turn
                 self.__logger.info(f"adding additional propagation path through air of {T_air/units.ns:.1f}ns")
             else:
-                gamma_turn, z_turn = self.get_turning_point(self.medium.n_ice ** 2 - C_0 ** -2)
+                gamma_turn, z_turn = get_turning_point(self.medium.n_ice ** 2 - C_0 ** -2,self.__b, self.medium.z_0, self.medium.delta_n)
+                z_turn = z_turn[0]
                 if(x1[1] < z_turn and z_turn < x2_mirrored[1]):
                     points = [z_turn]
                 z_int = x2_mirrored[1]
@@ -624,7 +750,7 @@ class ray_tracing_2D(ray_tracing_base):
             # first treat special case of ice to air propagation
             if(x2[1] > 0):
                 z_turn = 0
-                y_turn = self.get_y(self.get_gamma(z_turn), C_0, self.get_C_1(x1, C_0))
+                y_turn = get_y(get_gamma(z_turn, self.medium.delta_n, self.medium.z_0), C_0, self.get_C_1(x1, C_0), self.medium.n_ice, self.__b, self.medium.z_0)
                 t_air = ((x2[0] - y_turn) ** 2 + (x2[1]) ** 2) ** 0.5 / speed_of_light
                 try:
                     ttmp = get_ToF_direct(x1[1], z_turn)
@@ -644,7 +770,8 @@ class ray_tracing_2D(ray_tracing_base):
                     if(solution_type == 3):
                         z_turn = 0
                     else:
-                        gamma_turn, z_turn = self.get_turning_point(self.medium.n_ice ** 2 - C_0 ** -2)
+                        gamma_turn, z_turn = get_turning_point(self.medium.n_ice ** 2 - C_0 ** -2,self.__b, self.medium.z_0, self.medium.delta_n)
+                        z_turn = z_turn[0]
         #             print('solution type {:d}, zturn = {:.1f}'.format(solution_type, z_turn))
                     try:
                         ttmp = get_ToF_direct(x1[1], z_turn) + get_ToF_direct(x2[1], z_turn)
@@ -694,7 +821,7 @@ class ray_tracing_2D(ray_tracing_base):
             # calculate attenuation until the ray reaches the surface
             if x2[1] > 0:
                 z_turn = 0
-                y_turn = self.get_y(self.get_gamma(z_turn), C_0, self.get_C_1(x1, C_0))
+                y_turn = get_y(get_gamma(z_turn, self.medium.delta_n, self.medium.z_0), C_0, self.get_C_1(x1, C_0), self.medium.n_ice, self.__b, self.medium.z_0)
                 x2 = [y_turn, z_turn]
 
             if self.use_cpp:
@@ -726,7 +853,8 @@ class ray_tracing_2D(ray_tracing_base):
                 # and interpolate linearly between them
                 mask = frequency > 0
                 freqs = self.__get_frequencies_for_attenuation(frequency, max_detector_freq)
-                gamma_turn, z_turn = self.get_turning_point(self.medium.n_ice ** 2 - C_0 ** -2)
+                gamma_turn, z_turn = get_turning_point(self.medium.n_ice ** 2 - C_0 ** -2,self.__b, self.medium.z_0, self.medium.delta_n)
+                z_turn = z_turn[0]
                 self.__logger.info(f"_use_optimized_calculation {self._use_optimized_calculation}")
 
                 if self._use_optimized_calculation:
@@ -856,7 +984,7 @@ class ray_tracing_2D(ray_tracing_base):
         if(reflection_case == 2):
             # the code only allows upward going rays, thus we find a point left from x1 that has an upward going ray
             # that will produce a downward going ray through x1
-            y_turn = self.get_y_turn(C_0, x1)
+            y_turn = get_y_turn(C_0, x1, self.medium.n_ice, self.__b, self.medium.delta_n, self.medium.z_0)
             dy = y_turn - x1[0]
             self.__logger.debug("relaction case 2: shifting x1 {} to {}".format(x1, x1[0] - 2 * dy))
             x1[0] = x1[0] - 2 * dy
@@ -864,7 +992,7 @@ class ray_tracing_2D(ray_tracing_base):
         for i in range(reflection + 1):
             self.__logger.debug("calculation path for reflection = {}".format(i + 1))
             C_1 = self.get_C_1(x1, C_0)
-            x2 = self.get_reflection_point(C_0, C_1)
+            x2 = get_reflection_point(C_0, C_1, self.medium.n_ice, reflection, self.__b, self.medium.z_0, self.medium.delta_n)
             stop_loop = False
             if(x2[0] > x22[0]):
                 stop_loop = True
@@ -945,8 +1073,9 @@ class ray_tracing_2D(ray_tracing_base):
         c = self.medium.n_ice ** 2 - C_0 ** -2
         for segment in self.get_path_segments(x1, x2, C_0, reflection, reflection_case):
             x11, x1, x22, x2, C_0, C_1 = segment
-            gamma_turn, z_turn = self.get_turning_point(c)
-            y_turn = self.get_y_turn(C_0, x1)
+            gamma_turn, z_turn = get_turning_point(c,self.__b, self.medium.z_0, self.medium.delta_n)
+            z_turn = z_turn[0]
+            y_turn = get_y_turn(C_0, x1, self.medium.n_ice, self.__b, self.medium.delta_n, self.medium.z_0)
             if((z_turn >= 0) and (y_turn > x11[0]) and (y_turn < x22[0])):  # for the first track segment we need to check if turning point is right of start point (otherwise we have a downward going ray that does not have a turning point), and for the last track segment we need to check that the turning point is left of the stop position.
                 r = self.get_angle(np.array([y_turn, 0]), x1, C_0)
                 self.__logger.debug(
@@ -981,18 +1110,20 @@ class ray_tracing_2D(ray_tracing_base):
             the z coordinates of the ray tracing path
         """
         c = self.medium.n_ice ** 2 - C_0 ** -2
-        C_1 = x1[0] - self.get_y_with_z_mirror(x1[1], C_0)
-        gamma_turn, z_turn = self.get_turning_point(c)
-        y_turn = self.get_y(gamma_turn, C_0, C_1)
+        C_1 = x1[0] - get_y_with_z_mirror(x1[1], C_0, self.medium.n_ice, self.__b, self.medium.delta_n, self.medium.z_0)[0]
+        gamma_turn, z_turn = get_turning_point(c, self.__b, self.medium.z_0, self.medium.delta_n)
+        gamma_turn = gamma_turn[0]
+        z_turn = z_turn[0]
+        y_turn = get_y(gamma_turn, C_0, C_1, self.medium.n_ice, self.__b, self.medium.z_0)
         zstart = x1[1]
         zstop = self.get_z_mirrored(x1, x2, C_0)[1]
         z = np.linspace(zstart, zstop, n_points)
         mask = z < z_turn
         res = np.zeros_like(z)
         zs = np.zeros_like(z)
-        gamma = self.get_gamma(z[mask])
+        gamma = get_gamma(z[mask], self.medium.delta_n, self.medium.z_0)
         zs[mask] = z[mask]
-        res[mask] = self.get_y(gamma, C_0, C_1)
+        res[mask] = get_y(gamma, C_0, C_1, self.medium.n_ice, self.__b, self.medium.z_0)
         if x2[1] > 0:  # treat ice to air case
             zenith_reflection = self.get_reflection_angle(x1, x2, C_0)
             n_1 = self.medium.get_index_of_refraction([y_turn, 0, z_turn])
@@ -1000,8 +1131,8 @@ class ray_tracing_2D(ray_tracing_base):
             zs[~mask] = z[~mask]
             res[~mask] = zs[~mask] * np.tan(zenith_air) + y_turn
         else:
-            gamma = self.get_gamma(2 * z_turn - z[~mask])
-            res[~mask] = 2 * y_turn - self.get_y(gamma, C_0, C_1)
+            gamma = get_gamma(2 * z_turn - z[~mask], self.medium.delta_n, self.medium.z_0)
+            res[~mask] = 2 * y_turn - get_y(gamma, C_0, C_1, self.medium.n_ice, self.__b, self.medium.z_0)
             zs[~mask] = 2 * z_turn - z[~mask]
 
         self.__logger.debug('turning points for C_0 = {:.2f}, b= {:.2f}, gamma = {:.4f}, z = {:.1f}, y_turn = {:.0f}'.format(
@@ -1046,7 +1177,7 @@ class ray_tracing_2D(ray_tracing_base):
         if(reflection and reflection_case == 2):
             # the code only allows upward going rays, thus we find a point left from x1 that has an upward going ray
             # that will produce a downward going ray through x1
-            y_turn = self.get_y_turn(C_0, x1)
+            y_turn = get_y_turn(C_0, x1, self.medium.n_ice, self.__b, self.medium.delta_n, self.medium.z_0)
             dy = y_turn - x1[0]
             self.__logger.debug("relaction case 2: shifting x1 {} to {}".format(x1, x1[0] - 2 * dy))
             x1[0] = x1[0] - 2 * dy
@@ -1057,8 +1188,8 @@ class ray_tracing_2D(ray_tracing_base):
         x22 = copy.copy(x2)
         for i in range(reflection + 1):
             self.__logger.debug("calculation path for reflection = {}".format(i))
-            C_1 = x1[0] - self.get_y_with_z_mirror(x1[1], C_0)
-            x2 = self.get_reflection_point(C_0, C_1)
+            C_1 = x1[0] - get_y_with_z_mirror(x1[1], C_0,self.medium.n_ice, self.__b, self.medium.delta_n, self.medium.z_0)[0]
+            x2 = get_reflection_point(C_0, C_1,  self.medium.n_ice, reflection, self.__b, self.medium.z_0, self.medium.delta_n)
             if(x2[0] > x22[0]):
                 x2 = x22
             yyy, zzz = self.get_path(x1, x2, C_0, n_points)
@@ -1072,140 +1203,13 @@ class ray_tracing_2D(ray_tracing_base):
         mask = yy > x11[0]
         return yy[mask], zz[mask]
 
-    def get_reflection_point(self, C_0, C_1):
-        """
-        calculates the point where the signal gets reflected off the bottom of the ice shelf
-
-        Returns tuple (y,z)
-        """
-        c = self.medium.n_ice ** 2 - C_0 ** -2
-        gamma_turn, z_turn = self.get_turning_point(c)
-        x2 = [0, self.medium.reflection]
-        x2[0] = self.get_y_with_z_mirror(-x2[1] + 2 * z_turn, C_0, C_1)
-        return x2
-
-    def obj_delta_y_square(self, logC_0, x1, x2, reflection=0, reflection_case=2):
-        """
-        objective function to find solution for C0
-        """
-        C_0 = self.get_C0_from_log(logC_0)
-        return self.get_delta_y(C_0, copy.copy(x1), x2, reflection=reflection, reflection_case=reflection_case) ** 2
-
     def obj_delta_y(self, logC_0, x1, x2, reflection=0, reflection_case=2):
         """
         function to find solution for C0, returns distance in y between function and x2 position
         result is signed! (important to use a root finder)
         """
-        C_0 = self.get_C0_from_log(logC_0)
-        return self.get_delta_y(C_0, copy.copy(x1), x2, reflection=reflection, reflection_case=reflection_case)
-
-    def get_delta_y(self, C_0, x1, x2, C0range=None, reflection=0, reflection_case=2):
-        """
-        calculates the difference in the y position between the analytic ray tracing path
-        specified by C_0 at the position x2
-        """
-        if(C0range is None):
-            C0range = [1. / self.medium.n_ice, np.inf]
-        if(hasattr(C_0, '__len__')):
-            C_0 = C_0[0]
-        if((C_0 < C0range[0]) or(C_0 > C0range[1])):
-            self.__logger.debug('C0 = {:.4f} out of range {:.0f} - {:.2f}'.format(C_0, C0range[0], C0range[1]))
-            return -np.inf
-        c = self.medium.n_ice ** 2 - C_0 ** -2
-
-        # we consider two cases here,
-        # 1) the rays start rising -> the default case
-        # 2) the rays start decreasing -> we need to find the position left of the start point that
-        #    that has rising rays that go through the point x1
-        if(reflection > 0 and reflection_case == 2):
-            y_turn = self.get_y_turn(C_0, x1)
-            dy = y_turn - x1[0]
-            self.__logger.debug("reflection case 2: shifting x1 {} to {}".format(x1, x1[0] - 2 * dy))
-            x1[0] = x1[0] - 2 * dy
-
-        for i in range(reflection):
-            # we take account reflections at the bottom layer into account via
-            # 1) calculating the point where the reflection happens
-            # 2) starting a ray tracing from this new point
-
-            # determine y translation first
-            C_1 = x1[0] - self.get_y_with_z_mirror(x1[1], C_0)
-            if(hasattr(C_1, '__len__')):
-                C_1 = C_1[0]
-
-            self.__logger.debug("C_0 = {:.4f}, C_1 = {:.1f}".format(C_0, C_1))
-            x1 = self.get_reflection_point(C_0, C_1)
-
-        # determine y translation first
-        C_1 = x1[0] - self.get_y_with_z_mirror(x1[1], C_0)
-        if(hasattr(C_1, '__len__')):
-            C_1 = C_1[0]
-
-        self.__logger.debug("C_0 = {:.4f}, C_1 = {:.1f}".format(C_0, C_1))
-
-        # for a given c_0, 3 cases are possible to reach the y position of x2
-        # 1) direct ray, i.e., before the turning point
-        # 2) refracted ray, i.e. after the turning point but not touching the surface
-        # 3) reflected ray, i.e. after the ray reaches the surface
-        gamma_turn, z_turn = self.get_turning_point(c)
-        y_turn = self.get_y(gamma_turn, C_0, C_1)
-        if(z_turn < min(x2[1], 0)):  # turning points is deeper that x2 positions, can't reach target
-            # the minimizer has problems finding the minimum if inf is returned here. Therefore, we return the distance
-            # between the turning point and the target point + 10 x the distance between the z position of the turning points
-            # and the target position. This results in a objective function that has the solutions as the only minima and
-            # is smooth in C_0
-            
-            diff = ((z_turn - x2[1]) ** 2 + (y_turn - x2[0]) ** 2) ** 0.5 + 10 * np.abs(z_turn - x2[1])
-            self.__logger.debug(
-                "turning points (zturn = {:.4g} is deeper than x2 positon z2 = {:.0f}, setting distance to target position to {:.1f}".format(z_turn, x2[1], -diff))
-            return -diff
-#             return -np.inf
-        self.__logger.debug('turning points is z = {:.1f}, y =  {:.1f}'.format(z_turn, y_turn))
-        
-        if(x2[1] > 0):  # first treat the ice to air case
-            # Do nothing if ray is refracted. If ray is reflected, don't mirror but do straight line upwards
-            if(z_turn == 0):
-                zenith_reflection = self.get_reflection_angle(x1, x2, C_0, reflection, reflection_case)
-                if(zenith_reflection == None):
-                    diff = x2[1]
-                    self.__logger.debug(f"not refracting into air")
-                    return diff
-                n_1 = self.medium.get_index_of_refraction([y_turn, 0, z_turn])
-                zenith_air = NuRadioReco.utilities.geometryUtilities.get_fresnel_angle(zenith_reflection, n_1=n_1, n_2=1)
-                if(zenith_air is None):
-                    diff = x2[1]
-                    self.__logger.debug(f"not refracting into air")
-                    return diff
-                z = (x2[0] - y_turn) / np.tan(zenith_air)
-                diff = x2[1] - z
-                self.__logger.debug(f"touching surface at {zenith_reflection/units.deg:.1f}deg -> {zenith_air/units.deg:.1f}deg -> x2 = {x2} diff {diff:.2f}")
-                return diff
-        if(y_turn > x2[0]):  # we always propagate from left to right
-            # direct ray
-            y2_fit = self.get_y(self.get_gamma(x2[1]), C_0, C_1)  # calculate y position at get_path position
-            diff = (x2[0] - y2_fit)
-            if(hasattr(diff, '__len__')):
-                diff = diff[0]
-            if(hasattr(x2[0], '__len__')):
-                x2[0] = x2[0][0]
-
-            self.__logger.debug(
-                'we have a direct ray, y({:.1f}) = {:.1f} -> {:.1f} away from {:.1f}, turning point = y={:.1f}, z={:.2f}, x0 = {:.1f} {:.1f}'.format(x2[1], y2_fit, diff, x2[0], y_turn, z_turn, x1[0], x1[1]))
-            return diff
-        else:
-            # now it's a bit more complicated. we need to transform the coordinates to
-            # be on the mirrored part of the function
-            z_mirrored = x2[1]
-            gamma = self.get_gamma(z_mirrored)
-            self.__logger.debug("get_y( {}, {}, {})".format(gamma, C_0, C_1))
-            y2_raw = self.get_y(gamma, C_0, C_1)
-            y2_fit = 2 * y_turn - y2_raw
-            diff = (x2[0] - y2_fit)
-
-            self.__logger.debug('we have a reflected/refracted ray, y({:.1f}) = {:.1f} ({:.1f}) -> {:.1f} away from {:.1f} (gamma = {:.5g})'.format(
-                z_mirrored, y2_fit, y2_raw, diff, x2[0], gamma))
-
-            return -1 * diff
+        C_0 = get_C0_from_log(logC_0,self.medium.n_ice)
+        return get_delta_y(C_0, np.array(x1), np.array(x2),self.medium.n_ice, self.__b, self.medium.delta_n, self.medium.z_0, None, reflection, reflection_case)
 
     def determine_solution_type(self, x1, x2, C_0):
         """ returns the type of the solution
@@ -1229,9 +1233,11 @@ class ray_tracing_2D(ray_tracing_base):
 
         """
         c = self.medium.n_ice ** 2 - C_0 ** -2
-        C_1 = x1[0] - self.get_y_with_z_mirror(x1[1], C_0)
-        gamma_turn, z_turn = self.get_turning_point(c)
-        y_turn = self.get_y(gamma_turn, C_0, C_1)
+        C_1 = x1[0] - get_y_with_z_mirror(x1[1], C_0, self.medium.n_ice, self.__b, self.medium.delta_n, self.medium.z_0)[0]
+        gamma_turn, z_turn = get_turning_point(c, self.__b, self.medium.z_0, self.medium.delta_n)
+        gamma_turn = gamma_turn[0]
+        z_turn = z_turn[0]
+        y_turn = get_y(gamma_turn, C_0, C_1, self.medium.n_ice, self.__b, self.medium.z_0)
         if(x2[0] < y_turn):
             return solution_types_revert['direct']
         else:
@@ -1294,7 +1300,7 @@ class ray_tracing_2D(ray_tracing_base):
                     return results
                 result = optimize.brentq(self.obj_delta_y, logC0_start, logC0_stop, args=(x1, x2, reflection, reflection_case))
 
-                C_0 = self.get_C0_from_log(result)
+                C_0 = get_C0_from_log(result, self.medium.n_ice)
                 C0s.append(C_0)
                 solution_type = self.determine_solution_type(x1, x2, C_0)
                 self.__logger.info("found {} solution C0 = {:.2f} (internal logC = {:.2f})".format(solution_types[solution_type], C_0, result))
@@ -1321,17 +1327,16 @@ class ray_tracing_2D(ray_tracing_base):
                     'starting optimization with x0 = {:.2f} -> C0 = {:.3f}'.format(logC_0_start, C_0_start))
             else:
                 logC_0_start = -1
-
-            result = optimize.root(self.obj_delta_y_square, x0=logC_0_start, args=(x1, x2, reflection, reflection_case), tol=tol)
-
+            obj_delta_y_sqr = obj_delta_y_square
+            result = optimize.root(obj_delta_y_sqr, x0=logC_0_start, args=(np.array(x1), np.array(x2),self.medium.n_ice,self.__b, self.medium.delta_n, self.medium.z_0, reflection, reflection_case), tol=tol)
             if(plot):
                 import matplotlib.pyplot as plt
                 fig, ax = plt.subplots(1, 1)
             if(result.fun < 1e-7):
                 if(plot):
-                    self.plot_result(x1, x2, self.get_C0_from_log(result.x[0]), ax)
+                    self.plot_result(x1, x2, get_C0_from_log(result.x[0], self.medium.n_ice), ax)
                 if(np.round(result.x[0], 3) not in np.round(C0s, 3)):
-                    C_0 = self.get_C0_from_log(result.x[0])
+                    C_0 = get_C0_from_log(result.x[0], self.medium.n_ice)
                     C0s.append(C_0)
                     solution_type = self.determine_solution_type(x1, x2, C_0)
                     self.__logger.info("found {} solution C0 = {:.2f}".format(solution_types[solution_type], C_0))
@@ -1351,9 +1356,9 @@ class ray_tracing_2D(ray_tracing_base):
                 self.__logger.info("solution with logC0 > {:.3f} exists".format(result.x[0]))
                 result2 = optimize.brentq(self.obj_delta_y, logC0_start, logC0_stop, args=(x1, x2, reflection, reflection_case))
                 if(plot):
-                    self.plot_result(x1, x2, self.get_C0_from_log(result2), ax)
+                    self.plot_result(x1, x2, get_C0_from_log(result2, self.medium.n_ice), ax)
                 if(np.round(result2, 3) not in np.round(C0s, 3)):
-                    C_0 = self.get_C0_from_log(result2)
+                    C_0 = get_C0_from_log(result2, self.medium.n_ice)
                     C0s.append(C_0)
                     solution_type = self.determine_solution_type(x1, x2, C_0)
                     self.__logger.info("found {} solution C0 = {:.2f}".format(solution_types[solution_type], C_0))
@@ -1375,9 +1380,9 @@ class ray_tracing_2D(ray_tracing_base):
                 result3 = optimize.brentq(self.obj_delta_y, logC0_start, logC0_stop, args=(x1, x2, reflection, reflection_case))
 
                 if(plot):
-                    self.plot_result(x1, x2, self.get_C0_from_log(result3), ax)
+                    self.plot_result(x1, x2, get_C0_from_log(result3, self.medium.n_ice), ax)
                 if(np.round(result3, 3) not in np.round(C0s, 3)):
-                    C_0 = self.get_C0_from_log(result3)
+                    C_0 = get_C0_from_log(result3, self.medium.n_ice)
                     C0s.append(C_0)
                     solution_type = self.determine_solution_type(x1, x2, C_0)
                     self.__logger.info("found {} solution C0 = {:.2f}".format(solution_types[solution_type], C_0))
@@ -1402,7 +1407,9 @@ class ray_tracing_2D(ray_tracing_base):
         C_1 = self.get_C_1(x1, C_0)
 
         zs = np.linspace(x1[1], x1[1] + np.abs(x1[1]) + np.abs(x2[1]), 1000)
-        yy, zz = self.get_y_with_z_mirror(zs, C_0, C_1)
+        yz = get_y_with_z_mirror(zs, C_0, self.medium.n_ice, self.__b, self.medium.delta_n, self.medium.z_0, C_1)
+        yy = yz[0] 
+        zz = yz[1]        
         ax.plot(yy, zz, '-', label='C0 = {:.3f}'.format(C_0))
         ax.plot(x1[0], x1[1], 'ko')
         ax.plot(x2[0], x2[1], 'd')
@@ -1437,7 +1444,7 @@ class ray_tracing_2D(ray_tracing_base):
             angle corresponding to C_0, minus offset angoff
         '''
 
-        C_0 = self.get_C0_from_log(logC_0)
+        C_0 = get_C0_from_log(logC_0, self.medium.n_ice)
 
         dydz = self.get_y_diff(z_pos, C_0, in_air=in_air)
 #        dydz = self.get_dydz_analytic(C_0, z_pos)
@@ -1475,7 +1482,7 @@ class ray_tracing_2D(ray_tracing_base):
         # want to return the complete instance of the result class; result value result.x[0] is logC_0,
         # but we want C_0, so replace it in the result class. This may not be good practice but it seems to be
         # more user-friendly than to return the value logC_0
-        result.x[0] = copy.copy(self.get_C0_from_log(result.x[0]))
+        result.x[0] = copy.copy(get_C0_from_log(result.x[0], self.medium.n_ice))
 
         return result
 
@@ -1568,7 +1575,7 @@ class ray_tracing_2D(ray_tracing_base):
         # z_crit = 0 and hence gamma_crit = delta_n by definition
         gcrit = self.medium.delta_n
         # the y-value where the ray hits z=0
-        ycrit = self.get_y(gcrit, C0crit, self.get_C_1(x1, C0crit))
+        ycrit = get_y(gcrit, C0crit, self.get_C_1(x1, C0crit), self.medium.n_ice, self.__b, self.medium.z_0)
 
         if plot:
             import matplotlib.pyplot as plt
@@ -1590,9 +1597,9 @@ class ray_tracing_2D(ray_tracing_base):
             # theoretically this is not quite unterstood
             C0check = self.get_C_0_from_angle(np.pi / 2., 0)
             C0check = C0check.x[0]
-            gcheck = self.get_gamma(x2[1])
+            gcheck = get_gamma(x2[1], self.medium.delta_n, self.medium.z_0)
             # print('C0check, gcheck',C0check,gcheck)
-            ycheck = -self.get_y(gcheck, C0check, self.get_C_1([ycrit, 0], C0check)) + 2 * ycrit
+            ycheck = -get_y(gcheck, C0check, self.get_C_1([ycrit, 0], C0check), self.medium.n_ice, self.__b, self.medium.z_0) + 2 * ycrit
             # print('ycheck, x2[1]',ycheck,x2[1])
             if x2[0] < ycheck:
                 refraction = True
@@ -1677,7 +1684,7 @@ class ray_tracing_2D(ray_tracing_base):
             nxsin = 1.
 
         zsurf = 0
-        gamma = self.get_gamma(zsurf)
+        gamma = get_gamma(zsurf, self.medium.delta_n, self.medium.z_0)
 
         # print('nxsin = ',nxsin)
         # find emission angle for starting point x1 to hit the surface at the specified angle
@@ -1697,7 +1704,7 @@ class ray_tracing_2D(ray_tracing_base):
 
             # x-coordinate where ray reaches surface; is always bigger than the x-position of the emitter
             # (i.e. ray travels "to the right")
-            xsurf = self.get_y(gamma, C0_emit, self.get_C_1(x, C0_emit))
+            xsurf = get_y(gamma, C0_emit, self.get_C_1(x, C0_emit), self.medium.n_ice, self.__b, self.medium.z_0)
             sice += xsurf - x[0]
             self.__logger.info(' air pulse starting at x={}, z={} reaches surface at x={}'.format(x[0], x[1], xsurf))
             ttosurf = self.get_travel_time_analytic(x, [xsurf, zsurf], C0_emit)
@@ -1707,7 +1714,7 @@ class ray_tracing_2D(ray_tracing_base):
             if draw:
                 import matplotlib.pyplot as plt
                 z = np.linspace(x[1], zsurf, 1000, endpoint=True)
-                y = self.get_y(self.get_gamma(z), C0_emit, C_1=self.get_C_1(x, C0_emit))
+                y = get_y(get_gamma(z, self.medium.delta_n, self.medium.z_0), C0_emit, self.medium.n_ice, self.__b, self.medium.z_0, C_1=self.get_C_1(x, C0_emit))
                 if x == x1:
                     ysurf = [y[-1]]
                 else:
@@ -1789,7 +1796,7 @@ class ray_tracing(ray_tracing_base):
     def __init__(self, medium, attenuation_model="SP1", log_level=logging.NOTSET,
                  n_frequencies_integration=100, n_reflections=0, config=None,
                  detector=None, ray_tracing_2D_kwards={},
-                 use_cpp=cpp_available):
+                 use_cpp=cpp_available, compile_numba=False):
         """
         class initilization
 
@@ -1867,7 +1874,7 @@ class ray_tracing(ray_tracing_base):
 
         self._r2d = ray_tracing_2D(self._medium, self._attenuation_model, log_level=log_level,
                                     n_frequencies_integration=self._n_frequencies_integration,
-                                    **ray_tracing_2D_kwards, use_cpp=use_cpp)
+                                    **ray_tracing_2D_kwards, use_cpp=use_cpp, compile_numba=compile_numba)
 
         self._swap = None
         self._dPhi = None

--- a/NuRadioMC/SignalProp/examples/ray_tracing_modules.py
+++ b/NuRadioMC/SignalProp/examples/ray_tracing_modules.py
@@ -10,7 +10,7 @@ solution_types = propagation.solution_types
 try:
     import radiopropa
 except:
-     solution_types.remove("radiopropa")
+     solution_types.pop("radiopropa")
 ray_tracing_modules = propagation.available_modules
 plot_line_styles = ["-", "--", ":", "-."]
 

--- a/NuRadioMC/SignalProp/examples/ray_tracing_modules.py
+++ b/NuRadioMC/SignalProp/examples/ray_tracing_modules.py
@@ -7,6 +7,10 @@ import logging
 
 logger = logging.getLogger('NuRadioMC.SignalProp.ray_tracing_modules')
 solution_types = propagation.solution_types
+try:
+    import radiopropa
+except:
+     solution_types.remove("radiopropa")
 ray_tracing_modules = propagation.available_modules
 plot_line_styles = ["-", "--", ":", "-."]
 

--- a/NuRadioMC/SignalProp/examples/ray_tracing_modules.py
+++ b/NuRadioMC/SignalProp/examples/ray_tracing_modules.py
@@ -23,12 +23,7 @@ attenuation_model = 'GL1'
 fig, axs = plt.subplots(1, 2, figsize=(12,6))
 for i_module, ray_tracing_module in enumerate(ray_tracing_modules):
     print('Testing ray tracing module: \'{}\''.format(ray_tracing_module))
-    try:
-        prop = propagation.get_propagation_module(ray_tracing_module)
-    except ImportError as e:
-        logger.warning("Failed to load {}".format(ray_tracing_module))
-        logger.exception(e)
-
+    prop = propagation.get_propagation_module(ray_tracing_module)
     # This function creates a ray tracing instance refracted index, attenuation model, 
     # number of frequencies # used for integrating the attenuation and interpolate afterwards, 
     # and the number of allowed reflections.

--- a/NuRadioMC/SignalProp/examples/ray_tracing_modules.py
+++ b/NuRadioMC/SignalProp/examples/ray_tracing_modules.py
@@ -7,11 +7,11 @@ import logging
 
 logger = logging.getLogger('NuRadioMC.SignalProp.ray_tracing_modules')
 solution_types = propagation.solution_types
+ray_tracing_modules = propagation.available_modules.copy()
 try:
     import radiopropa
 except:
-     solution_types.pop("radiopropa")
-ray_tracing_modules = propagation.available_modules
+    ray_tracing_modules.remove("radiopropa")
 plot_line_styles = ["-", "--", ":", "-."]
 
 ### This example shows the ray tracing results for the different 

--- a/NuRadioMC/SignalProp/propagation.py
+++ b/NuRadioMC/SignalProp/propagation.py
@@ -5,9 +5,14 @@ solution_types = {1: 'direct',
                       3: 'reflected'}
 solution_types_revert = {v:k for k, v in solution_types.items()}
 
-available_modules = ['analytic',
-                     'radiopropa',
-                     'direct_ray']
+try:
+    import radiopropa
+    available_modules = ['analytic',
+                        'radiopropa',
+                        'direct_ray']
+except:
+    available_modules = ['analytic',
+                        'direct_ray']
 
 reflection_case = {1: 'upwards launch vector',
                    2: 'downward launch vector'}

--- a/NuRadioMC/SignalProp/propagation.py
+++ b/NuRadioMC/SignalProp/propagation.py
@@ -4,15 +4,10 @@ solution_types = {1: 'direct',
                       2: 'refracted',
                       3: 'reflected'}
 solution_types_revert = {v:k for k, v in solution_types.items()}
+available_modules = ['analytic',
+                    'radiopropa',
+                    'direct_ray']
 
-try:
-    import radiopropa
-    available_modules = ['analytic',
-                        'radiopropa',
-                        'direct_ray']
-except:
-    available_modules = ['analytic',
-                        'direct_ray']
 
 reflection_case = {1: 'upwards launch vector',
                    2: 'downward launch vector'}

--- a/NuRadioMC/test/SignalProp/T01test_python_vs_cpp.py
+++ b/NuRadioMC/test/SignalProp/T01test_python_vs_cpp.py
@@ -9,6 +9,14 @@ from numpy import testing
 logger = logging.getLogger('NuRadioMC.test_raytracing')
 logger.setLevel(logging.INFO)
 
+try:
+    from numba import jit, njit
+    numba_available = True
+    print("Numba version of raytracer is available")
+except:
+    print("Numba is not available")
+    numba_available = False
+
 ice = medium.southpole_simple()
 
 np.random.seed(0)  # set seed to have reproducible results
@@ -61,6 +69,26 @@ for iX, x in enumerate(points):
             results_A_python[iX, iS] = r.get_attenuation(iS, ff)
 t_python = time.time() - t_start
 print("Python time = {:.1f} seconds = {:.2f}ms/event".format(t_python, 1000. * t_python / n_events))
+
+
+
+if numba_available:
+    results_C0s_numba = np.zeros((n_events, 2))
+    results_A_numba = np.zeros((n_events, 2, n_freqs))
+    t_start = time.time()
+    for iX, x in enumerate(points):
+        r = ray.ray_tracing(ice, use_cpp=False,compile_numba = True)
+        r.set_start_and_end_point(x, x_receiver)
+        r.find_solutions()
+        if(r.has_solution()):
+            for iS in range(r.get_number_of_solutions()):
+                results_C0s_numba[iX, iS] = r.get_results()[iS]['C0']
+                results_A_numba[iX, iS] = r.get_attenuation(iS, ff)
+    t_numba = time.time() - t_start
+    print("Numba time = {:.1f} seconds = {:.2f}ms/event".format(t_numba, 1000. * t_numba / n_events))
+
+    testing.assert_allclose(results_C0s_numba, results_C0s_python, atol=1e-08, rtol=1e-05)
+    testing.assert_allclose(results_A_numba, results_A_python, rtol=1e-2, atol=1e-3)
 
 testing.assert_allclose(results_C0s_cpp, results_C0s_python, atol=1e-08, rtol=1e-05)
 testing.assert_allclose(results_A_cpp, results_A_python, rtol=1e-2, atol=1e-3)

--- a/NuRadioMC/test/SignalProp/T01test_python_vs_cpp.py
+++ b/NuRadioMC/test/SignalProp/T01test_python_vs_cpp.py
@@ -9,14 +9,6 @@ from numpy import testing
 logger = logging.getLogger('NuRadioMC.test_raytracing')
 logger.setLevel(logging.INFO)
 
-try:
-    from numba import jit, njit
-    numba_available = True
-    print("Numba version of raytracer is available")
-except:
-    print("Numba is not available")
-    numba_available = False
-
 ice = medium.southpole_simple()
 
 np.random.seed(0)  # set seed to have reproducible results
@@ -72,6 +64,11 @@ print("Python time = {:.1f} seconds = {:.2f}ms/event".format(t_python, 1000. * t
 
 
 # Numba testing
+try:
+    from numba import jit
+except:
+    raise NotImplementedError("Numba is not implemented")
+
 results_C0s_numba = np.zeros((n_events, 2))
 results_A_numba = np.zeros((n_events, 2, n_freqs))
 t_start = time.time()

--- a/NuRadioMC/test/SignalProp/T01test_python_vs_cpp.py
+++ b/NuRadioMC/test/SignalProp/T01test_python_vs_cpp.py
@@ -71,24 +71,23 @@ t_python = time.time() - t_start
 print("Python time = {:.1f} seconds = {:.2f}ms/event".format(t_python, 1000. * t_python / n_events))
 
 
+# Numba testing
+results_C0s_numba = np.zeros((n_events, 2))
+results_A_numba = np.zeros((n_events, 2, n_freqs))
+t_start = time.time()
+for iX, x in enumerate(points):
+    r = ray.ray_tracing(ice, use_cpp=False,compile_numba = True)
+    r.set_start_and_end_point(x, x_receiver)
+    r.find_solutions()
+    if(r.has_solution()):
+        for iS in range(r.get_number_of_solutions()):
+            results_C0s_numba[iX, iS] = r.get_results()[iS]['C0']
+            results_A_numba[iX, iS] = r.get_attenuation(iS, ff)
+t_numba = time.time() - t_start
+print("Numba time = {:.1f} seconds = {:.2f}ms/event".format(t_numba, 1000. * t_numba / n_events))
 
-if numba_available:
-    results_C0s_numba = np.zeros((n_events, 2))
-    results_A_numba = np.zeros((n_events, 2, n_freqs))
-    t_start = time.time()
-    for iX, x in enumerate(points):
-        r = ray.ray_tracing(ice, use_cpp=False,compile_numba = True)
-        r.set_start_and_end_point(x, x_receiver)
-        r.find_solutions()
-        if(r.has_solution()):
-            for iS in range(r.get_number_of_solutions()):
-                results_C0s_numba[iX, iS] = r.get_results()[iS]['C0']
-                results_A_numba[iX, iS] = r.get_attenuation(iS, ff)
-    t_numba = time.time() - t_start
-    print("Numba time = {:.1f} seconds = {:.2f}ms/event".format(t_numba, 1000. * t_numba / n_events))
-
-    testing.assert_allclose(results_C0s_numba, results_C0s_python, atol=1e-08, rtol=1e-05)
-    testing.assert_allclose(results_A_numba, results_A_python, rtol=1e-2, atol=1e-3)
+testing.assert_allclose(results_C0s_numba, results_C0s_python, atol=1e-08, rtol=1e-05)
+testing.assert_allclose(results_A_numba, results_A_python, rtol=1e-2, atol=1e-3)
 
 testing.assert_allclose(results_C0s_cpp, results_C0s_python, atol=1e-08, rtol=1e-05)
 testing.assert_allclose(results_A_cpp, results_A_python, rtol=1e-2, atol=1e-3)

--- a/NuRadioMC/test/SignalProp/run_signal_test.sh
+++ b/NuRadioMC/test/SignalProp/run_signal_test.sh
@@ -9,3 +9,4 @@ python3 T06unit_test_C0_mooresbay.py
 cd ../../SignalProp/examples
 python3 example_3d.py
 python3 A01IceCubePulserToARA.py
+python3 ray_tracing_modules.py

--- a/changelog.txt
+++ b/changelog.txt
@@ -51,7 +51,6 @@ can then iterate over a channel group, which yields all channels for a given gro
 loaded again when reading in the Detector from a nur file
 - Added LOFAR coordinates to Detector site coordinates
 - Added up to date in-ice VPol response (RNOG_vpol_v2_5inch_center_n1.75.pkl) sha-1 hash
-- Implemented mattak dataset iterator in readRNOGDataMattak.run()
 - Fixed bug in phased-array noise generation script where the sign of the time delays was being ignored
 for the phasing_mode == "slice"
 - Improved logging: created NuRadioLogger class which is now used by default, the NRR and NRMC loggers

--- a/changelog.txt
+++ b/changelog.txt
@@ -56,6 +56,7 @@ loaded again when reading in the Detector from a nur file
 for the phasing_mode == "slice"
 - Improved logging: created NuRadioLogger class which is now used by default, the NRR and NRMC loggers
 are created automatically when importing the packages, and a new STATUS logging level was added.
+- Implemented mattak dataset iterator in readRNOGDataMattak.run()
 - Updating the ray_tracing_2D class in order to be able to use Numba optimization
 
 bugfixes:

--- a/changelog.txt
+++ b/changelog.txt
@@ -56,6 +56,7 @@ loaded again when reading in the Detector from a nur file
 for the phasing_mode == "slice"
 - Improved logging: created NuRadioLogger class which is now used by default, the NRR and NRMC loggers
 are created automatically when importing the packages, and a new STATUS logging level was added.
+- Updating the ray_tracing_2D class in order to be able to use Numba optimization
 
 bugfixes:
 - Fixed bug in get_travel_time in directRayTracing propagation module

--- a/changelog.txt
+++ b/changelog.txt
@@ -51,11 +51,11 @@ can then iterate over a channel group, which yields all channels for a given gro
 loaded again when reading in the Detector from a nur file
 - Added LOFAR coordinates to Detector site coordinates
 - Added up to date in-ice VPol response (RNOG_vpol_v2_5inch_center_n1.75.pkl) sha-1 hash
+- Implemented mattak dataset iterator in readRNOGDataMattak.run()
 - Fixed bug in phased-array noise generation script where the sign of the time delays was being ignored
 for the phasing_mode == "slice"
 - Improved logging: created NuRadioLogger class which is now used by default, the NRR and NRMC loggers
 are created automatically when importing the packages, and a new STATUS logging level was added.
-- Implemented mattak dataset iterator in readRNOGDataMattak.run()
 - Updating the ray_tracing_2D class in order to be able to use Numba optimization
 
 bugfixes:


### PR DESCRIPTION
Issue being addressed:
Second attempt of https://github.com/nu-radio/NuRadioMC/pull/619

_All commits will be squashed before merging_

The python 2D ray-tracing code is currently out-performed in terms of computation time by a C++ wrapper.
This C++ wrapper however fails to find certain solutions where the python version does.

This PR redefines and modifies methods from the `ray_tracing_2D` class that are used in the root-finding process so they can be compiled using [Numba](https://numba.pydata.org) and used if Numba is available in the user's environment. If Numba is not installed, the C++ or Python versions can still be used instead.
The methods compiled through Numba have been altered so they do not have the versatility of handling both scalars and arrays in order to satisfy Numba's requirements of unified types - only scalars are being handled to simplify the process.

Some of the unit tests have been updated in order to take into account the Numba option.

Computation times are being tested for root finding and path finding processes.
...


![mean_values_plot_all_new](https://github.com/nu-radio/NuRadioMC/assets/100688791/cddc33f0-9920-48ac-a160-add54c0649a5)
![mean_values_plot_cpp_numba_new](https://github.com/nu-radio/NuRadioMC/assets/100688791/ef0c625e-f57d-462c-b597-f70954035535)

![mean_values_paths_all](https://github.com/nu-radio/NuRadioMC/assets/100688791/291f7cb5-1670-4e7c-ae5b-e87d4df063bb)


The attenuation calculation could not be optimised using Numba for two reasons:

- The use of scipy integration methods
- These integration methods involve methods from another class whose optimisation would require an additional workload which might get out of the scope of this PR (see [this line](https://github.com/nu-radio/NuRadioMC/blob/develop/NuRadioMC/SignalProp/analyticraytracing.py#L719) using a method from [attenuation class](https://github.com/nu-radio/NuRadioMC/blob/develop/NuRadioMC/utilities/attenuation.py).
This results in similar runtimes for attenuation calculations between the Python and Numba version.

- [ ] Is there a possible alternative to the use of `global` keyword?
- [ ] How should the case where both cpp and numba are asked to be used?
- [ ] Should more tests be adapted?
