### PR TITLE
Save detector keywords in NUR file

### DIFF
--- a/NuRadioReco/detector/detector.py
+++ b/NuRadioReco/detector/detector.py
@@ -99,7 +99,7 @@ def Detector(*args, **kwargs):
         if len(args) >= 4:
             assume_inf = args[3]
         else:
-            assume_inf = kwargs.pop("assume_inf", True)
+            assume_inf = kwargs.pop("assume_inf", None)
 
         if len(args) >= 5:
             antenna_by_depth = args[4]
@@ -110,7 +110,8 @@ def Detector(*args, **kwargs):
         if source == "sql":
             return detector_base.DetectorBase(
                 json_filename=None, source=source, dictionary=dictionary,
-                assume_inf=assume_inf, antenna_by_depth=if_not_None(antenna_by_depth, True))
+                assume_inf=if_not_None(assume_inf, True),
+                antenna_by_depth=if_not_None(antenna_by_depth, True))
 
         elif source == "rnog_mongo":
             return rnog_detector.Detector(*args, **kwargs)
@@ -165,7 +166,8 @@ def Detector(*args, **kwargs):
 
             return generic_detector.GenericDetector(
                 json_filename=filename, source=source, dictionary=dictionary,
-                assume_inf=assume_inf, antenna_by_depth=if_not_None(antenna_by_depth, False), **kwargs)
+                assume_inf=if_not_None(assume_inf, True),
+                antenna_by_depth=if_not_None(antenna_by_depth, False), **kwargs)
         else:
             # Keys might be present (but should be None). Keys are deprecated, keep them for backwards compatibility
             for key in ["default_station", "default_channel", "default_device"]:
@@ -173,4 +175,5 @@ def Detector(*args, **kwargs):
 
             return detector_base.DetectorBase(
                 json_filename=filename, source=source, dictionary=dictionary,
-                assume_inf=assume_inf, antenna_by_depth=if_not_None(antenna_by_depth, True), **kwargs)
+                assume_inf=if_not_None(assume_inf, True),
+                antenna_by_depth=if_not_None(antenna_by_depth, True), **kwargs)

--- a/NuRadioReco/detector/detector_base.py
+++ b/NuRadioReco/detector/detector_base.py
@@ -208,6 +208,38 @@ class DetectorBase(object):
             logger.info("the correct antenna model will be determined automatically based on the depth of the antenna")
         self._antenna_by_depth = antenna_by_depth
 
+    @property
+    def assume_inf(self):
+        """
+        Getter function for the `assume_inf` attribute
+        """
+        return self.__assume_inf
+
+    @assume_inf.setter
+    def assume_inf(self, value):
+        """
+        Setter function for the `assume_inf` attribute. Checks whether new value is boolean before assigning
+        the value to the attribute.
+        """
+        if isinstance(value, bool):
+            self.__assume_inf = value
+
+    @property
+    def antenna_by_depth(self):
+        """
+        Getter function for the `antenna_by_depth` attribute
+        """
+        return self._antenna_by_depth
+
+    @antenna_by_depth.setter
+    def antenna_by_depth(self, value):
+        """
+        Setter function for the `antenna_by_depth` attribute. Checks whether new value is boolean before assigning
+        the value to the attribute.
+        """
+        if isinstance(value, bool):
+            self.__assume_inf = value
+
     def __query_channel(self, station_id, channel_id):
         Channel = Query()
         if self.__current_time is None:

--- a/NuRadioReco/detector/detector_base.py
+++ b/NuRadioReco/detector/detector_base.py
@@ -223,6 +223,8 @@ class DetectorBase(object):
         """
         if isinstance(value, bool):
             self.__assume_inf = value
+        else:
+            raise ValueError(f"Value for assume_inf should be boolean, not {type(value)}")
 
     @property
     def antenna_by_depth(self):
@@ -239,6 +241,8 @@ class DetectorBase(object):
         """
         if isinstance(value, bool):
             self.__assume_inf = value
+        else:
+            raise ValueError(f"Value for antenna_by_depth should be boolean, not {type(value)}")
 
     def __query_channel(self, station_id, channel_id):
         Channel = Query()

--- a/NuRadioReco/detector/generic_detector.py
+++ b/NuRadioReco/detector/generic_detector.py
@@ -75,7 +75,7 @@ class GenericDetector(NuRadioReco.detector.detector_base.DetectorBase):
         assume_inf : Bool
             Default to True, if true forces antenna models to have infinite boundary conditions, otherwise the antenna
             madel will be determined by the station geometry.
-        antenna_by_depth: bool (default True)
+        antenna_by_depth: bool (default False)
             if True the antenna model is determined automatically depending on the depth of the antenna.
             This is done by appending e.g. '_InfFirn' to the antenna model name.
             if False, the antenna model as specified in the database is used.

--- a/NuRadioReco/modules/io/NuRadioRecoio.py
+++ b/NuRadioReco/modules/io/NuRadioRecoio.py
@@ -358,14 +358,9 @@ class NuRadioRecoio(object):
 
             detector_dict = self._detector_dicts[self._current_file_id]
 
-            # Extract keywords from detector dict
-            assume_inf = None
-            antenna_by_depth = None
-            if 'detector_parameters' in detector_dict:
-                if 'assume_inf' in detector_dict['detector_parameters']:
-                    assume_inf = detector_dict['detector_parameters']['assume_inf']
-                if 'antenna_by_depth' in detector_dict['detector_parameters']:
-                    antenna_by_depth = detector_dict['detector_parameters']['antenna_by_depth']
+            # Extract keywords from detector dict (if not present in nur file, "detector_parameters" is empty dict)
+            assume_inf = detector_dict['detector_parameters'].get('assume_inf', None)
+            antenna_by_depth = detector_dict['detector_parameters'].get('antenna_by_depth', None)
 
             if 'generic_detector' in detector_dict:
                 if detector_dict['generic_detector']:

--- a/NuRadioReco/modules/io/NuRadioRecoio.py
+++ b/NuRadioReco/modules/io/NuRadioRecoio.py
@@ -357,6 +357,16 @@ class NuRadioRecoio(object):
                     return None
 
             detector_dict = self._detector_dicts[self._current_file_id]
+
+            # Extract keywords from detector dict
+            assume_inf = None
+            antenna_by_depth = None
+            if 'detector_parameters' in detector_dict:
+                if 'assume_inf' in detector_dict['detector_parameters']:
+                    assume_inf = detector_dict['detector_parameters']['assume_inf']
+                if 'antenna_by_depth' in detector_dict['detector_parameters']:
+                    antenna_by_depth = detector_dict['detector_parameters']['antenna_by_depth']
+
             if 'generic_detector' in detector_dict:
                 if detector_dict['generic_detector']:
 
@@ -368,6 +378,7 @@ class NuRadioRecoio(object):
                         source='dictionary', dictionary=detector_dict,
                         default_station=detector_dict.get('default_station', None),
                         default_channel=detector_dict.get('default_channel', None),
+                        assume_inf=assume_inf, antenna_by_depth=antenna_by_depth,
                         create_new=True)
 
                     if self._current_file_id in self._event_specific_detector_changes.keys():
@@ -384,7 +395,9 @@ class NuRadioRecoio(object):
             # Detector is a normal detector
             self.__detectors[self._current_file_id] = NuRadioReco.detector.detector.Detector(
                 source='dictionary', dictionary=self._detector_dicts[self._current_file_id],
-                create_new=True)
+                assume_inf=assume_inf, antenna_by_depth=antenna_by_depth,
+                create_new=True
+            )
 
         # Detector object for current file already exists. If it is a generic detector,
         # we update it to the run number and ID of the last event that was requested

--- a/NuRadioReco/modules/io/eventWriter.py
+++ b/NuRadioReco/modules/io/eventWriter.py
@@ -186,6 +186,10 @@ class eventWriter:
         is_generic_detector = isinstance(det, generic_detector.GenericDetector)
         det_dict = {
             "generic_detector": is_generic_detector,
+            "detector_parameters": {
+                "assume_inf": det.assume_inf,
+                "antenna_by_depth": det.antenna_by_depth
+            },
             "channels": {},
             "stations": {}
         }

--- a/NuRadioReco/modules/io/event_parser_factory.py
+++ b/NuRadioReco/modules/io/event_parser_factory.py
@@ -98,10 +98,16 @@ def scan_files_function(version_major, version_minor):
                 is_generic_detector = False
             else:
                 is_generic_detector = detector_dict['generic_detector']
+
+            if 'detector_parameters' not in detector_dict.keys():
+                detector_parameters = {}
+            else:
+                detector_parameters = detector_dict['detector_parameters']
             
             if iF not in self._detector_dicts.keys():
                 self._detector_dicts[iF] = {
                     'generic_detector': is_generic_detector,
+                    'detector_parameters': detector_parameters,
                     'channels': {},
                     'stations': {}
                 }

--- a/NuRadioReco/modules/io/event_parser_factory.py
+++ b/NuRadioReco/modules/io/event_parser_factory.py
@@ -94,15 +94,9 @@ def scan_files_function(version_major, version_minor):
             self.logger.debug("Read detector ...")
 
             detector_dict = pickle.loads(self._get_file(iF).read(bytes_to_read))
-            if 'generic_detector' not in detector_dict.keys():
-                is_generic_detector = False
-            else:
-                is_generic_detector = detector_dict['generic_detector']
 
-            if 'detector_parameters' not in detector_dict.keys():
-                detector_parameters = {}
-            else:
-                detector_parameters = detector_dict['detector_parameters']
+            is_generic_detector = detector_dict.get('generic_detector', False)
+            detector_parameters = detector_dict.get('detector_parameters', {})
             
             if iF not in self._detector_dicts.keys():
                 self._detector_dicts[iF] = {

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,8 @@ can then iterate over a channel group, which yields all channels for a given gro
 - Added LOFAR modules for reading data, removing RFI, beamforming and fitting the arrival direction
 - Added functionality to remove Channel from Station
 - Added LOFAR antenna pattern and function to parse TXT simulation file
+- The assume_inf and antenna_by_depth Detector keywords are now saved in the nur file, and will be
+loaded again when reading in the Detector from a nur file
 
 bugfixes:
 


### PR DESCRIPTION
Issue being addressed: #663 

The Detector parameters `assume_inf` and `antenna_by_depth` were not saved in the .nur file when writing out the Detector object. This means that these values are reset to their defaults when the Detector is being read in from the .nur file, which can cause issues with for example antenna model naming.

In this PR, I have made `assume_inf` and `antenna_by_depth` properties of the DetectorBase class, with getters and setters to easily access them (though I am not sure that a setter is really necessary - we can also remove it to protect these attributes from being overwritten).  These attributes are then added to the `det_dict` in the eventWriter, and are also read in by the event_parse_factory.py code. The NuradioRecoio class then check if these values are present, and sets them to `None` if they are not. I have changed the Detector factory function of @fschlueter to use `None` as the default for `assume_inf` (this was already done for `antenna_by_depth`) and change this to the default value of `True` when calling the appropriate Detector class using the `if_not_None()` function.
