### PR TITLE
Skip TBB files from remote stations on read-in

### DIFF
--- a/NuRadioReco/modules/io/LOFAR/readLOFARData.py
+++ b/NuRadioReco/modules/io/LOFAR/readLOFARData.py
@@ -522,7 +522,11 @@ class readLOFARData:
         # TODO: save paths of files per event in some kind of database
 
         for tbb_filename in all_tbb_files:
-            station_name = re.findall(r"CS\d\d\d", tbb_filename)[0]
+            station_name = re.findall(r"CS\d\d\d", tbb_filename)
+            station_name = next(iter(station_name), None)  # Get the first entry, if the list is not empty -> defaults to None
+            if station_name is None:
+                logger.status(f'TBB file {tbb_filename} is for remote station, skipping...')
+                continue
             if (self.__restricted_station_set is not None) and (station_name not in self.__restricted_station_set):
                 continue  # only process stations in the given set
             self.logger.info(f'Found file {tbb_filename} for station {station_name}...')


### PR DESCRIPTION
*Issue being addressed*

When globbing over all TBB files in the directory, it is possible for a bunch of remote station files to be included in the `all_tbb_files` list. When doing the pattern matching
```python
re.findall(r"CS\d\d\d", tbb_filename)
```
on those files, the result is an empty list. When then calling the first element, the reader crashes.

*Proposed solution*

I changed the code to either take the first element of the resulting list, or default to None in case the list is empty. If the `station_name` is `None`, the file is assumed to be from a remote station and skipped. Is this desired behavior? Should we explicitly check that the pattern "RS\d\d\d" does appear in the file name and do something else with it?
