### PR TITLE
Add LOFAR site longitude and latitude to Detector

### DIFF
--- a/NuRadioReco/detector/detector_base.py
+++ b/NuRadioReco/detector/detector_base.py
@@ -606,7 +606,8 @@ class DetectorBase(object):
             'auger': (-35.10, -69.55),
             'mooresbay': (-78.74, 165.09),
             'southpole': (-90., 0.),
-            'summit': (72.57, -38.46)
+            'summit': (72.57, -38.46),
+            'lofar': (52.92, 6.87)
         }
         site = self.get_site(station_id)
         if site in sites.keys():

--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ can then iterate over a channel group, which yields all channels for a given gro
 - Added LOFAR antenna pattern and function to parse TXT simulation file
 - The assume_inf and antenna_by_depth Detector keywords are now saved in the nur file, and will be
 loaded again when reading in the Detector from a nur file
+- Added LOFAR coordinates to Detector site coordinates
 
 bugfixes:
 - Fixed bug in get_travel_time in directRayTracing propagation module


### PR DESCRIPTION
Add the coordinates of LOFAR to the `get_site_coordinates()` function of the Detector
