### PR TITLE
Fix deprecation window import from scipy.signal

### DIFF
--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -1467,7 +1467,7 @@ class AntennaPatternAnalytic(AntennaPatternBase):
 
             index = np.argmax(freq > self._cutoff_freq)
             Gain = np.ones_like(freq)
-            from scipy.signal import hann
+            from scipy.signal.windows import hann
             gain_filter = hann(2 * index)
             Gain[:index] = gain_filter[:index]
 


### PR DESCRIPTION
Importing windows from `scipy.signal` was deprecated in scipy 1.13 in favour of importing from `scipy.signal.windows`. See https://docs.scipy.org/doc/scipy-1.13.0/release/1.11.0-notes.html#deprecated-features

This is the only occurrence I found in NuRadioMC, and should fix the tests on Python >= 3.9
