### PR TITLE
Fix for rnog_detector singleton

### DIFF
--- a/NuRadioReco/detector/RNO_G/rnog_detector.py
+++ b/NuRadioReco/detector/RNO_G/rnog_detector.py
@@ -61,7 +61,7 @@ def _check_detector_time(method):
 class Detector():
     def __init__(self, database_connection='RNOG_test_public', log_level=logging.INFO, over_write_handset_values={},
                  database_time=None, always_query_entire_description=True, detector_file=None,
-                 select_stations=None):
+                 select_stations=None, create_new=False):
         """
 
         Parameters
@@ -78,7 +78,7 @@ class Detector():
             Overwrite the default values for the manually set parameter which are not (yet) implemented in the database.
             (Default: {}, the acutally default values for the parameters in question are defined below)
 
-        database_time : `datetime.datetime` or ``astropy.time.Time``
+        database_time : `datetime.datetime` or `astropy.time.Time`
             Set database time which is used to select the primary measurement. By default (= None) the database time
             is set to now (time the code is running) to select the measurement which is now primary.
 
@@ -92,6 +92,10 @@ class Detector():
             Select a station or list of stations using their station ids for which the describtion is provided.
             This is useful for example in simulations when one wants to simulate only one station. The default None
             means to descibe all commissioned stations.
+
+        create_new : bool (Default: False)
+            If False, and a database already exists, the existing database will be used rather than initializing a
+            new connection. Set to True to create a new database connection.
         """
 
         self.logger = logging.getLogger("NuRadioReco.RNOGdetector")
@@ -113,7 +117,7 @@ class Detector():
         if detector_file is None:
             self._det_imported_from_file = False
 
-            self.__db = Database(database_connection=database_connection)
+            self.__db = Database(database_connection=database_connection, create_new=create_new)
             if database_time is not None:
                 self.__db.set_database_time(database_time)
 

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -216,7 +216,8 @@ epub_exclude_files = ['search.html']
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'scipy': ('https://docs.scipy.org/doc/scipy', None),
-    'numpy': ("https://numpy.org/doc/stable", None)
+    'numpy': ("https://numpy.org/doc/stable", None),
+    'astropy': ("https://docs.astropy.org/en/stable", None)
 }
 default_role = 'autolink' #TODO: probably switch to py:obj?
 


### PR DESCRIPTION
The rnog_detector uses a singleton `Database`, meaning that re-initializing it (e.g. to create another database connection) does not work, as there was no way to pass the argument `create_new` to the Database. This is added by this PR.