### PR TITLE
LOFAR reader hotfixes

### DIFF
--- a/NuRadioReco/modules/LOFAR/stationGalacticCalibrator.py
+++ b/NuRadioReco/modules/LOFAR/stationGalacticCalibrator.py
@@ -96,7 +96,7 @@ class stationGalacticCalibrator:
             ),
         )
 
-        # Get fitted Fourier coefficients for relative calibration and store them based on polarisation group ID
+        # Get fitted Fourier coefficients for relative calibration and store them based on polarisation
         rel_calibration_file = np.genfromtxt(
             os.path.join(
                 data_dir, "galactic_calibration",

--- a/NuRadioReco/modules/LOFAR/stationPulseFinder.py
+++ b/NuRadioReco/modules/LOFAR/stationPulseFinder.py
@@ -275,7 +275,7 @@ class stationPulseFinder:
             station_even_list = []
             station_odd_list = []
             for channel in station.iter_channels():
-                if channel.get_id() == int(channel.get_group_id()[1:]):
+                if channel.get_id() == channel.get_group_id():
                     station_even_list.append(channel.get_id())
                 else:
                     station_odd_list.append(channel.get_id())

--- a/NuRadioReco/modules/LOFAR/stationRFIFilter.py
+++ b/NuRadioReco/modules/LOFAR/stationRFIFilter.py
@@ -181,9 +181,8 @@ def FindRFI_LOFAR(
             except IndexError:
                 logger.warning('Could not read data for antenna %s block %d' % (antenna_ids[ant_i], block_i))
                 # proceed with zeros in the block
-            # oneAnt_data[:] = tbb_file.get_data(
-            #    rfi_cleaning_trace_length * block, rfi_cleaning_trace_length, antenna_index=ant_i
-            # )
+                blocks_good[ant_i, block_i] = False
+                continue
             if (
                     num_double_zeros(oneAnt_data) < num_dbl_z
             ):  # this antenna on this block is good

--- a/NuRadioReco/modules/LOFAR/stationRFIFilter.py
+++ b/NuRadioReco/modules/LOFAR/stationRFIFilter.py
@@ -178,7 +178,7 @@ def FindRFI_LOFAR(
                 oneAnt_data[:] = tbb_file.get_data(
                     rfi_cleaning_trace_length * block, rfi_cleaning_trace_length, antenna_ID=antenna_ids[ant_i]
                 )
-            except:  # TODO: more specific exception
+            except IndexError:
                 logger.warning('Could not read data for antenna %s block %d' % (antenna_ids[ant_i], block_i))
                 # proceed with zeros in the block
             # oneAnt_data[:] = tbb_file.get_data(

--- a/NuRadioReco/modules/LOFAR/stationRFIFilter.py
+++ b/NuRadioReco/modules/LOFAR/stationRFIFilter.py
@@ -92,7 +92,7 @@ def FindRFI_LOFAR(
         Size of total block of trace to be evaluated for finding dirty rfi channels.
     rfi_cleaning_trace_length : int
         Size of one chunk of trace to be evaluated at a time for calculating spectrum from.
-    flagged_antenna_ids : list or set, default=[]
+    flagged_antenna_ids : list[str] or set[str], default=[]
         List of antennas which are already flagged. These will not be considered for the RFI detection process.
     num_dbl_z : int, default=100
         The number of double zeros allowed in a block, if there are too many, then there could be data loss.
@@ -497,7 +497,7 @@ class stationRFIFilter:
 
             flagged_tbb_channel_ids = set()
             for ind in flagged_channel_ids:
-                flagged_tbb_channel_ids.add(int(nrrID_to_tbbID(ind)))
+                flagged_tbb_channel_ids.add(nrrID_to_tbbID(ind))  # in rawTBBio, antenna IDs are str
 
             packet = FindRFI_LOFAR(station_files,
                                    self.metadata_dir,

--- a/NuRadioReco/modules/io/LOFAR/rawTBBio.py
+++ b/NuRadioReco/modules/io/LOFAR/rawTBBio.py
@@ -426,6 +426,12 @@ class TBBData_Dal1:
         initial_point = self.sample_offsets[antenna_index] + start_index
         final_point = initial_point + num_points
 
+        if final_point > len(self.file[self.stationKey][antenna_ID]):
+            raise IndexError(
+                "Data point", final_point,
+                "is off end of file with length", len(self.file[self.stationKey][antenna_ID]),
+            )
+
         return self.file[self.stationKey][antenna_ID][initial_point:final_point]
 
 
@@ -697,19 +703,19 @@ class MultiFile_Dal1:
         odd_delays = all_antenna_calibrations[1::2]
         odd_offset = odd_delays - even_delays
         median_odd_offset = np.median(odd_offset)
-        if verbose:
-            print("median offset is:", median_odd_offset)
+        logger.info("median offset is:", median_odd_offset)
+
         below_tolerance = np.abs(odd_offset - median_odd_offset) < tolerance
-        if verbose:
-            print(
-                np.sum(below_tolerance),
-                "antennas below tolerance.",
-                len(below_tolerance) - np.sum(below_tolerance),
-                "above.",
-            )
+        logger.info(
+            np.sum(below_tolerance),
+            "antennas below tolerance.",
+            len(below_tolerance) - np.sum(below_tolerance),
+            "above.",
+        )
+
         ave_best_offset = np.average(odd_offset[below_tolerance])
-        if verbose:
-            print("average of below-tolerance offset is:", ave_best_offset)
+        logger.info("average of below-tolerance offset is:", ave_best_offset)
+
         self.set_odd_polarization_delay(-ave_best_offset)
 
         above_tolerance = np.zeros(len(all_antenna_calibrations), dtype=bool)
@@ -960,11 +966,9 @@ class MultiFile_Dal1:
         antenna_ID = self.dipoleNames[antenna_index]
 
         if final_point > len(TBB_file.file[TBB_file.stationKey][antenna_ID]):
-            print(
-                "WARNING! data point",
-                final_point,
-                "is off end of file",
-                len(TBB_file.file[TBB_file.stationKey][antenna_ID]),
+            raise IndexError(
+                "Data point", final_point,
+                "is off end of file with length", len(TBB_file.file[TBB_file.stationKey][antenna_ID]),
             )
 
         return TBB_file.file[TBB_file.stationKey][antenna_ID][initial_point:final_point]

--- a/NuRadioReco/modules/io/LOFAR/readLOFARData.py
+++ b/NuRadioReco/modules/io/LOFAR/readLOFARData.py
@@ -659,17 +659,22 @@ class readLOFARData:
 
             # Check both channels from the flagged group IDs are removed from station
             # This is needed because when a trace read in fails, the counterpart is not automatically removed
+            self.logger.debug(f"Flagged channel group IDs: {flagged_nrr_channel_group_ids}")
+            channels_to_remove = []  # cannot remove channel in loop, so store them and delete after
             for channel_group_id in flagged_nrr_channel_group_ids:
                 try:
                     for channel in station.iter_channel_group(channel_group_id):
                         self.logger.status(f"Removing channel {channel.get_id()} with group ID {channel_group_id} "
                                            f"from station {station_name}")
-                        station.remove_channel(channel)
-                        flagged_nrr_channel_ids.add(channel.get_id())
+                        channels_to_remove.append(channel)
                 except ValueError:
                     # The channel_group_id not longer present in the station
                     self.logger.debug(f"Both channels of group ID {channel_group_id} were already removed "
                                       f"from station {station_name}")
+
+            for channel in channels_to_remove:
+                station.remove_channel(channel)
+                flagged_nrr_channel_ids.add(channel.get_id())
 
             # store set of flagged nrr channel ids as station parameter
             station.set_parameter(stationParameters.flagged_channels, flagged_nrr_channel_ids)

--- a/NuRadioReco/modules/io/LOFAR/readLOFARData.py
+++ b/NuRadioReco/modules/io/LOFAR/readLOFARData.py
@@ -557,7 +557,11 @@ class readLOFARData:
         # TODO: save paths of files per event in some kind of database
 
         for tbb_filename in all_tbb_files:
-            station_name = re.findall(r"CS\d\d\d", tbb_filename)[0]
+            station_name = re.findall(r"CS\d\d\d", tbb_filename)
+            station_name = next(iter(station_name), None)  # Get the first entry, if the list is not empty -> defaults to None
+            if station_name is None:
+                logger.status(f'TBB file {tbb_filename} is for remote station, skipping...')
+                continue
             if (self.__restricted_station_set is not None) and (station_name not in self.__restricted_station_set):
                 continue  # only process stations in the given set
             self.logger.info(f'Found file {tbb_filename} for station {station_name}...')

--- a/NuRadioReco/modules/io/LOFAR/readLOFARData.py
+++ b/NuRadioReco/modules/io/LOFAR/readLOFARData.py
@@ -638,31 +638,16 @@ class readLOFARData:
             # empty set to add the NRR flagged channel IDs to
             flagged_nrr_channel_ids: set[int] = set()
             flagged_nrr_channel_group_ids: set[int] = set()  # keep track of channel group IDs to remove
-            channel_set_ids: set[int] = set()
 
-            channel_ids = detector.get_channel_ids(station_id)
-            if antenna_set == "LBA_OUTER":
-                # for LBA_OUTER, the antennas have a "0" as fourth element in 9 element string
-                for c in channel_ids:
-                    c_str = str(c).zfill(9)
-                    if c_str[3] == "0":
-                        channel_set_ids.add(c)
+            # Get the list of all dipole names which are present in the TTB file
+            # This avoids issues when a TBB file would not contain all channels
+            channel_tbb_ids: list[str] = station_dict['metadata'][6]
 
-            elif antenna_set == "LBA_INNER":
-                # for LBA_OUTER, the antennas have a "9" as fourth element in 9 element string
-                for c in channel_ids:
-                    c_str = str(c).zfill(9)
-                    if c_str[3] == "9":
-                        channel_set_ids.add(c)
-            else:
-                # other modes are currently not supported
-                # TODO: add them
-                self.logger.warning(f"Station {station_id} has unknown antenna set: {antenna_set}")
-                continue
+            self.logger.debug(f"These channels are present in the TBB file: {channel_tbb_ids}")
 
-            for channel_id in channel_set_ids:
-                # convert channel ID to TBB ID to be able to access trace
-                TBB_channel_id = nrrID_to_tbbID(channel_id)
+            for TBB_channel_id in channel_tbb_ids:
+                # convert TBB ID to NRR equivalent based on antenna set to be able to access trace
+                channel_id = int(tbbID_to_nrrID(TBB_channel_id, antenna_set))
 
                 if TBB_channel_id in flagged_channel_ids:
                     self.logger.status(f"Channel {channel_id} was flagged at read-in, "

--- a/NuRadioReco/modules/io/LOFAR/readLOFARData.py
+++ b/NuRadioReco/modules/io/LOFAR/readLOFARData.py
@@ -473,6 +473,36 @@ class readLOFARData:
         """
         return self.__stations.copy()
 
+    def get_station_calibration_delays(self, station_id):
+        """
+        Make a dictionary of channel ids and their corresponding calibration delays,
+        to avoid misapplying the delays to the wrong channel. Also converts the list
+        of channel IDs pulled from the TBB metadata to their NRR channel ID counterpart.
+
+        Parameters
+        ----------
+        station_id : int
+            The station ID for which to get the calibration delays
+
+        Returns
+        -------
+        station_calibration_delays : dict
+            Dictionary containing the NRR channel IDs as keys and the calibration delays as values
+        """
+        station_name = f"CS{station_id:03}"
+        station_calibration_delays = dict(
+            zip(
+                map(
+                    int,
+                    [tbbID_to_nrrID(channel_id, self.__stations[station_name]['metadata'][1])
+                     for channel_id in self.__stations[station_name]['metadata'][-2]]
+                ),
+                self.__stations[station_name]['metadata'][-1]
+            )
+        )
+
+        return station_calibration_delays
+
     def begin(self, event_id, logger_level=logging.WARNING):
         """
         Prepare the reader to ingest the event with ID `event_id`. This resets the internal representation of the

--- a/NuRadioReco/modules/io/LOFAR/readLOFARData.py
+++ b/NuRadioReco/modules/io/LOFAR/readLOFARData.py
@@ -606,17 +606,17 @@ class readLOFARData:
             flagged_nrr_channel_group_ids: set[int] = set()  # keep track of channel group IDs to remove
             channel_set_ids: set[int] = set()
 
-            channels = detector.get_channel_ids(station_id)
+            channel_ids = detector.get_channel_ids(station_id)
             if antenna_set == "LBA_OUTER":
                 # for LBA_OUTER, the antennas have a "0" as fourth element in 9 element string
-                for c in channels:
+                for c in channel_ids:
                     c_str = str(c).zfill(9)
                     if c_str[3] == "0":
                         channel_set_ids.add(c)
 
             elif antenna_set == "LBA_INNER":
                 # for LBA_OUTER, the antennas have a "9" as fourth element in 9 element string
-                for c in channels:
+                for c in channel_ids:
                     c_str = str(c).zfill(9)
                     if c_str[3] == "9":
                         channel_set_ids.add(c)
@@ -647,9 +647,11 @@ class readLOFARData:
                     self.logger.warning("Could not read data for channel id %s" % channel_id)
                     continue
 
-                # The channel_group_id should be interpreted as an antenna index
-                # dipoles '001000000' and '001000001' -> 'a1000000'
-                channel_group = 'a' + str(detector.get_channel_group_id(station_id, channel_id))
+                # The channel_group_id should be interpreted as an antenna index (e.g. like 'a1000000' which
+                # was used in PyCRTools). The group ID is pulled from the Detector description.
+                # Example: dipoles '001000000' (NRR ID 1000000) and '001000001' (NRR ID 1000001)
+                # both get group ID 1000000
+                channel_group: int = detector.get_channel_group_id(station_id, channel_id)
 
                 channel = NuRadioReco.framework.channel.Channel(channel_id, channel_group_id=channel_group)
                 channel.set_trace(this_trace, station_dict['metadata'][4] * units.Hz)

--- a/NuRadioReco/modules/io/LOFAR/readLOFARData.py
+++ b/NuRadioReco/modules/io/LOFAR/readLOFARData.py
@@ -564,13 +564,16 @@ class readLOFARData:
                 continue
             if (self.__restricted_station_set is not None) and (station_name not in self.__restricted_station_set):
                 continue  # only process stations in the given set
-            self.logger.info(f'Found file {tbb_filename} for station {station_name}...')
+
             self.__stations[station_name]['files'].append(tbb_filename)
 
-            # Save the metadata only once (in case there are multiple files for a station)
-            # TODO: make metadata a dictionary
-            if 'metadata' not in self.__stations[station_name]:
-                self.__stations[station_name]['metadata'] = get_metadata([tbb_filename], self.meta_dir)
+        # Save the metadata after all files for a station have been found
+        # TODO: make metadata a dictionary
+        for station_name in self.__stations:
+            station_files = self.__stations[station_name]['files']
+            if len(station_files) > 0:
+                self.logger.info(f'Found files {station_files} for station {station_name}...')
+                self.__stations[station_name]['metadata'] = get_metadata(station_files, self.meta_dir)
 
     @register_run()
     def run(self, detector, trace_length=65536):


### PR DESCRIPTION
This PR contains a bunch of small hotfixes for the LOFAR branch:

- The TBB reader now raises an IndexError when the endpoint is off the end of a file
- TBB files from remote stations are now skipped when globbing over the directory (solves crashes involving events with only remote TBB files)
- The channel group IDs are now int instead of str (for consistency with Detector description)
- After reading in the channels, we now check whether both channels from the flagged group IDs are removed from the station
- The calibration delays can now be retrieved from the readLOFARData object as a dict, ensuring the calibration delays are associated to the correct channel ID