### PR TITLE
Hotfix and cosmic ray energy reconstruction parameterization for summit

### DIFF
--- a/NuRadioReco/modules/cosmicRayEnergyReconstructor.py
+++ b/NuRadioReco/modules/cosmicRayEnergyReconstructor.py
@@ -39,8 +39,8 @@ class cosmicRayEnergyReconstructor:
                 'falloff': np.array([(-.1445, -.09820), (.5936, -1.1763)])
             },
             'summit': {
-                'scale': np.array([[ 610.25, -551.65,  281.34], [ 570.2 , -590.02,  411.01]]),
-                'falloff': np.array([[ 0.4058, -0.2285], [-1.2992,  2.0967]])
+                'scale': np.array([[ 404.5 , -131.56,   11.7 ], [ 428.97,  -92.11,    5.94]]),
+                'falloff': np.array([[-0.3391,  0.1738], [ 0.9543, -1.6967]])
             }
         }
         self.__elevations = {  # TODO: This should be changed once we have implemented a proper coordinate system
@@ -133,14 +133,15 @@ class cosmicRayEnergyReconstructor:
         energy_fluence = NuRadioReco.utilities.trace_utilities.get_electric_field_energy_fluence(efield_trace_vxB_vxvxB, electric_field.get_times())
         energy_fluence = np.abs(energy_fluence[0]) + np.abs(energy_fluence[1])
         xmax_distance = self.__atmosphere.get_distance_xmax_geometric(zenith, 750., elevation)  # parametrization is for Xmax of 750g/cm^2
+        xmax_distance = np.abs(xmax_distance) #np.max([xmax_distance, 200*units.m]) # for some zeniths and altitudes the parameterization can become negative
 
         # find out if we are inside or outside of the Cherenkov ring
         second_order_spectrum_parameter = electric_field.get_parameter(efp.cr_spectrum_quadratic_term)
         if second_order_spectrum_parameter <= spectrum_slope * .1:
-            scale_parameter = parametrization_for_site['scale'][0][0] * zenith ** 2 + parametrization_for_site['scale'][0][1] * zenith + parametrization_for_site['scale'][0][0]
+            scale_parameter = parametrization_for_site['scale'][0][0] * zenith ** 2 + parametrization_for_site['scale'][0][1] * zenith + parametrization_for_site['scale'][0][2]
             falloff_parameter = parametrization_for_site['falloff'][0][0] * zenith + parametrization_for_site['falloff'][0][1]
         else:
-            scale_parameter = parametrization_for_site['scale'][1][0] * zenith ** 2 + parametrization_for_site['scale'][1][1] * zenith + parametrization_for_site['scale'][1][0]
+            scale_parameter = parametrization_for_site['scale'][1][0] * zenith ** 2 + parametrization_for_site['scale'][1][1] * zenith + parametrization_for_site['scale'][1][2]
             falloff_parameter = parametrization_for_site['falloff'][1][0] * zenith + parametrization_for_site['falloff'][1][1]
         rec_energy = 1.e18 * np.sqrt(energy_fluence) * (xmax_distance / units.km) / (scale_parameter * np.exp(falloff_parameter * np.abs(spectrum_slope) ** 0.8))
         station.set_parameter(stnp.cr_energy_em, rec_energy)

--- a/NuRadioReco/modules/cosmicRayEnergyReconstructor.py
+++ b/NuRadioReco/modules/cosmicRayEnergyReconstructor.py
@@ -39,8 +39,8 @@ class cosmicRayEnergyReconstructor:
                 'falloff': np.array([(-.1445, -.09820), (.5936, -1.1763)])
             },
             'summit': {
-                'scale': np.array([[ 281.34, -551.65,  610.25],[ 411.01, -590.02,  570.2 ]]),
-                'falloff': np.array([[-0.2285,  0.4058], [ 2.0967, -1.2992]])
+                'scale': np.array([[ 610.25, -551.65,  281.34], [ 570.2 , -590.02,  411.01]]),
+                'falloff': np.array([[ 0.4058, -0.2285], [-1.2992,  2.0967]])
             }
         }
         self.__elevations = {  # TODO: This should be changed once we have implemented a proper coordinate system

--- a/NuRadioReco/modules/cosmicRayEnergyReconstructor.py
+++ b/NuRadioReco/modules/cosmicRayEnergyReconstructor.py
@@ -36,12 +36,17 @@ class cosmicRayEnergyReconstructor:
             'auger': {
                 'scale': np.array([(229.96, -123.75, 110.51), (214.46, -111.01, 119.18)]),
                 'falloff': np.array([(-.1445, -.09820), (.5936, -1.1763)])
+            },
+            'summit': {
+                'scale': np.array([[ 281.34, -551.65,  610.25],[ 411.01, -590.02,  570.2 ]]),
+                'falloff': np.array([[-0.2285,  0.4058], [ 2.0967, -1.2992]])
             }
         }
         self.__elevations = {  # TODO: This should be changed once we have implemented a proper coordinate system
             'mooresbay': 30.,
             'southpole': 2800.,
-            'auger': 1560.
+            'auger': 1560.,
+            'summit': 3216.
         }
         self.__site = None
         self.__parametrization_for_site = None

--- a/NuRadioReco/modules/cosmicRayEnergyReconstructor.py
+++ b/NuRadioReco/modules/cosmicRayEnergyReconstructor.py
@@ -1,3 +1,16 @@
+"""
+Module to reconstruct the energy of an air shower from its radio signal
+
+To reconstruct the air-shower energy, the radio signals should be bandpass filtered
+between 80 to 300 MHz with a 10th order Butterworth filter, and both the cosmic ray
+direction and the unfolded electric field should be present. The latter can be obtained
+(after the signal direction has been reconstructed) by running the
+`NuRadioReco.modules.voltageToAnalyticEfieldConverter` module.
+
+For more details on this algorithm, see https://dx.doi.org/10.1088/1475-7516/2019/10/075
+
+"""
+
 import numpy as np
 from NuRadioReco.modules.base.module import register_run
 from NuRadioReco.framework.parameters import stationParameters as stnp

--- a/NuRadioReco/modules/cosmicRayEnergyReconstructor.py
+++ b/NuRadioReco/modules/cosmicRayEnergyReconstructor.py
@@ -133,7 +133,14 @@ class cosmicRayEnergyReconstructor:
         energy_fluence = NuRadioReco.utilities.trace_utilities.get_electric_field_energy_fluence(efield_trace_vxB_vxvxB, electric_field.get_times())
         energy_fluence = np.abs(energy_fluence[0]) + np.abs(energy_fluence[1])
         xmax_distance = self.__atmosphere.get_distance_xmax_geometric(zenith, 750., elevation)  # parametrization is for Xmax of 750g/cm^2
-        xmax_distance = np.abs(xmax_distance) #np.max([xmax_distance, 200*units.m]) # for some zeniths and altitudes the parameterization can become negative
+        if np.any(xmax_distance) < 0:
+            self.logger.warning(
+                f"Estimated distance to Xmax is negative for zenith {zenith/units.deg:.0f} and elevation {elevation}. "
+                "This means Xmax may be below the detector elevation. The absolute value "
+                "of the distance will be used instead, but note that the resulting energy estimates may be inaccurate"
+            )
+
+            xmax_distance = np.abs(xmax_distance) # for some zeniths and altitudes the parameterization can become negative
 
         # find out if we are inside or outside of the Cherenkov ring
         second_order_spectrum_parameter = electric_field.get_parameter(efp.cr_spectrum_quadratic_term)


### PR DESCRIPTION
This PR adds the parameterization for Summit station for the cosmic ray energy to the cosmicRayEnergyReconstructor module. This parameterization was determined in a similar way as described in [the original paper](https://arxiv.org/abs/1905.11185) by @christophwelling; I used the cosmic ray simulations by @cg-laser (see [MSc thesis](https://bib-pubdb1.desy.de/record/456326/files/Pyras_Msc.pdf?version=1) by @lpyras for more details) and fit the parameterization to noiseless cosmic ray signals using a 4-LPDA layout. The fit was performed directly over all zeniths and energies, weighted by the simulation weights and using an $E^-2$ flux, and minimizing $\Delta \log E$.

In addition, I noticed a bug in the code - the third parameter of the `scale_parameterization` was never used, instead the first parameter was used twice. I fixed this, but I am actually not sure if the parameterizations are otherwise correct; also in the original paper, I'm worried the order of the parameters might occasionally be swapped, because e.g. numpy uses the convention `p[0] + p[1] x + p[2] x**2 + ...` (i.e. constant term first) rather than putting the highest-order term first. It would maybe be good if @christophwelling could double check this : )