### PR TITLE
Modify the hardware database reader such that multiple entries from the same collection can be handled

### DIFF
--- a/NuRadioReco/detector/RNO_G/db_mongo_read.py
+++ b/NuRadioReco/detector/RNO_G/db_mongo_read.py
@@ -885,15 +885,15 @@ class Database(object):
             supp_info = {k.replace(component + "_", ""): additional_information[k] for k in additional_information
                          if re.search(component, k)}
 
-            if re.search("golden", component, re.IGNORECASE):
-                collection_component = component.replace("_1", "").replace("_2", "")
-                # load the s21 parameter measurement
-                component_data = self.get_component_data(
-                    collection_component, component_id, supp_info, primary_time=self.__database_time, verbose=verbose)
+            if re.search("_\d+", component, re.IGNORECASE):
+                collection_suffix = re.findall("(_\d+)", component, re.IGNORECASE)[0]
+                collection_component = component.replace(collection_suffix, "")
             else:
-                # load the s21 parameter measurement
-                component_data = self.get_component_data(
-                    component, component_id, supp_info, primary_time=self.__database_time, verbose=verbose)
+                collection_component = component
+
+            # load the s21 parameter measurement
+            component_data = self.get_component_data(
+                collection_component, component_id, supp_info, primary_time=self.__database_time, verbose=verbose)
 
             # add the component name, the weight of the s21 measurement and the actual s21 measurement (component_data) to a combined dictionary
             components_data[component] = {'name': component_id}


### PR DESCRIPTION
The keys in the response chain are the names of the database collections, to tell the code where to look in the database for the measurement. This leads to problems when multiple measurements from the same collection need to be in the response chain. In this PR, the db_reader is modified such that it can handle multiple objects from the same collection. It was achieved by adding '_1', '_2', ... to the keys to differentiate between the elements from the same collection.