### PR TITLE
use fixed noise and pulse windows for SNR calculation

### DIFF
--- a/NuRadioReco/modules/LOFAR/stationPulseFinder.py
+++ b/NuRadioReco/modules/LOFAR/stationPulseFinder.py
@@ -275,7 +275,7 @@ class stationPulseFinder:
             station_even_list = []
             station_odd_list = []
             for channel in station.iter_channels():
-                if channel.get_id() == int(channel.get_group_id()[1:]):
+                if channel.get_id() == channel.get_group_id():
                     station_even_list.append(channel.get_id())
                 else:
                     station_odd_list.append(channel.get_id())

--- a/NuRadioReco/modules/LOFAR/stationPulseFinder.py
+++ b/NuRadioReco/modules/LOFAR/stationPulseFinder.py
@@ -125,10 +125,8 @@ class stationPulseFinder:
 
         for i, channel_ids in enumerate(channel_ids_per_pol):
             all_spectra = np.array([station.get_channel(channel).get_frequency_spectrum() for channel in channel_ids])
-            all_real_traces = np.array([station.get_channel(channel).get_trace() for channel in channel_ids])#debug
             beamed_fft = mini_beamformer(all_spectra, frequencies, channel_positions, self.direction_cartesian)
             beamed_timeseries = fft.freq2time(beamed_fft, sampling_rate, n=station.get_channel(channel_ids[0]).get_trace().shape[0])
-            optimal_amp = np.sum( [np.max(np.abs(trace)) for trace in all_real_traces] )
 
             analytic_signal = hilbert(beamed_timeseries)
             amplitude_envelope = np.abs(analytic_signal)
@@ -140,35 +138,6 @@ class stationPulseFinder:
             )
 
             values_per_pol.append([np.max(amplitude_envelope), signal_window_start, signal_window_end])
-            #debug:
-            fig = plt.figure(figsize=(14, 9), dpi=150)
-            ax1 = plt.subplot(311)
-            for trace in all_real_traces:
-                ax1.plot(trace, linewidth=1)
-            ax1.axvline(signal_window_start, color='k')
-            ax1.axvline(signal_window_end, color='k')
-            ax1.set_ylabel('raw traces')
-            # ax1.set(xlim=[0, len(all_real_traces[0])])
-            ax2 = plt.subplot(312)
-            ax2.plot(amplitude_envelope, linewidth=1)
-            ax2.axvline(signal_window_start, color='k')
-            ax2.axvline(signal_window_end, color='k')
-            ax2.set_ylabel('beamformed amplitude envelope')
-            # ax2.set(xlim=[0, len(amplitude_envelope)])
-            ax3 = plt.subplot(313)
-            ax3.plot(beamed_timeseries, linewidth=1)
-            ax3.axvline(signal_window_start, color='k')
-            ax3.axvline(signal_window_end, color='k')
-            ax3.set_ylabel('beamformed timeseries')
-            # ax3.set(xlim=[0, len(beamed_timeseries)])
-            for ax in [ax1, ax2, ax3]:
-                # ax.set(xlim=[signal_window_start-100, signal_window_end+100])
-                ax.set(xlim=[33000, 34000])
-
-            plt.xlabel('samples')
-            plt.suptitle(f'Station {station.get_id()}, polarization {i}, optimal amplitude: {optimal_amp}, beamformed amplitude: {np.max(np.abs(beamed_timeseries))}\n{all_real_traces.shape}')
-            plt.show()
-
 
         values_per_pol = np.asarray(values_per_pol)
         dominant = np.argmax(values_per_pol[:, 0])

--- a/NuRadioReco/modules/LOFAR/stationPulseFinder.py
+++ b/NuRadioReco/modules/LOFAR/stationPulseFinder.py
@@ -262,7 +262,7 @@ class stationPulseFinder:
             The detector related to the event.
         """
         zenith = event.get_hybrid_information().get_hybrid_shower("LORA").get_parameter(showerParameters.zenith)
-        azimuth = np.mod( event.get_hybrid_information().get_hybrid_shower("LORA").get_parameter(showerParameters.azimuth), 2* np.pi )
+        azimuth = event.get_hybrid_information().get_hybrid_shower("LORA").get_parameter(showerParameters.azimuth)
 
         self.direction_cartesian = hp.spherical_to_cartesian(
             zenith, azimuth
@@ -276,8 +276,7 @@ class stationPulseFinder:
             station_even_list = []
             station_odd_list = []
             for channel in station.iter_channels():
-                # if channel.get_id() == channel.get_group_id(): #tested it, does not work
-                if channel.get_id() == int(channel.get_group_id()[1:]): #this works
+                if channel.get_id() == channel.get_group_id(): 
                     station_even_list.append(channel.get_id())
                 else:
                     station_odd_list.append(channel.get_id())

--- a/NuRadioReco/modules/LOFAR/stationPulseFinder.py
+++ b/NuRadioReco/modules/LOFAR/stationPulseFinder.py
@@ -166,7 +166,7 @@ class stationPulseFinder:
         if signal_window is None:
             signal_window = [0, -1]
         if noise_window is None:
-            noise_window = [0, -1]
+            noise_window = [10000, 20000]
 
         frequencies = station.get_channel(channel_ids_per_pol[0][0]).get_frequencies()
         sampling_rate = station.get_channel(channel_ids_per_pol[0][0]).get_sampling_rate()
@@ -204,7 +204,7 @@ class stationPulseFinder:
         if signal_window is None:
             signal_window = [0, -1]
         if noise_window is None:
-            noise_window = [0, -1]
+            noise_window = [10000, 20000]
 
         good_channels = []
         for channel in station.iter_channels():
@@ -275,7 +275,7 @@ class stationPulseFinder:
             station_even_list = []
             station_odd_list = []
             for channel in station.iter_channels():
-                if channel.get_id() == channel.get_group_id():
+                if channel.get_id() == int(channel.get_group_id()[1:]):
                     station_even_list.append(channel.get_id())
                 else:
                     station_odd_list.append(channel.get_id())
@@ -299,11 +299,21 @@ class stationPulseFinder:
             station.set_parameter(stationParameters.cr_dominant_polarisation,
                                   detector.get_antenna_orientation(station_id, ant_same_orientation[dominant_pol][0]))
 
-            # Check if the station has a strong enough signal
-            signal_window = [int(pulse_window_start), int(pulse_window_end)]
-            noise_window = [0, int(pulse_window_start - self.__noise_away_from_pulse)]
+            # # Check if the station has a strong enough signal
+            # signal_window = [int(pulse_window_start), int(pulse_window_end)]
+            # noise_window = [0, int(pulse_window_start - self.__noise_away_from_pulse)]
 
-            self._check_station_triggered(station, position_array, ant_same_orientation, signal_window, noise_window)
+            # there was a bug with the windows for the SNR calculation, where strong signals had low SNR and vice versa. 
+            # Since the pulse should be somewhere around the middle of the trace, we use a fixed noise window (without the tapered edges of the trace). 
+            # For the signal window, the whole trace is used since we need the maximum. 
+            # Narrowing this down may increase performance and may be worth looking into in the future.
+            self._check_station_triggered(
+                station, 
+                position_array, 
+                ant_same_orientation, 
+                signal_window=[0, -1], 
+                noise_window=[int(1e4), int(2e4)]
+                )
 
     def end(self):
         pass


### PR DESCRIPTION
There was a bug in the calculation of the trace SNR, where strong pulses would be assigned a low SNR and vice versa. This is suspected to originate from the pulse and noise windows used for the calculation of the SNR. 

This fix uses fixed windows for the noise, so that the tapered edges of the LOFAR traces are excluded from the noise RMS calculation, preventing the noise RMS to blow up eventually. It is furthermore assumed that the pulse is located somewhat close to the middle of the trace and the noise window is chosen accordingly so that the pulse is not included in the noise RMS calculation. The pulse window for now is the full trace, since only the maximum of the hilbert envelope is used for the pulse calculation. 
