### PR TITLE
exclude readARAData from documentation because of missing .so files

### DIFF
--- a/documentation/make_docs.py
+++ b/documentation/make_docs.py
@@ -84,6 +84,7 @@ if __name__ == "__main__":
     exclude_modules.append('../**/eventbrowser') 
     exclude_modules.append('../**/setup.py')
     exclude_modules.append('../**/CPPAnalyticRayTracing') # C code also doesn't work right now
+    exclude_modules.append('../**/araroot') # this doesn't work because we don't have the .so files to read ARA data
 
     # create the automatic code documentation with apidoc
     for module in ['NuRadioReco', 'NuRadioMC']:


### PR DESCRIPTION
Excludes the `.araroot` module from the online documentation, because sphinx tries to import all modules it documents, and this raises an error for the araroot module due to missing `.so` files.

Annoyingly, sphinx _would_ be able to document this module perfectly if we wrapped the .so-loading in a try/except block, but that would get rid of the error when trying to import the module without the .so files, which I think is behaviour we want to keep.