### PR TITLE
Potentially fixing bug in triggerTimeAdjuster affecting the trace_start_time

### DIFF
--- a/NuRadioReco/modules/triggerTimeAdjuster.py
+++ b/NuRadioReco/modules/triggerTimeAdjuster.py
@@ -30,12 +30,12 @@ class triggerTimeAdjuster:
             If a name is given, corresponding trigger module must be run beforehand.
             If the trigger does not exist or did not trigger, this module will do nothing
         pre_trigger_time: float or dict
-            Amount of time that should be stored in the channel trace before the trigger. 
-            If the channel trace is long enough, it will be cut accordingly. 
+            Amount of time that should be stored in the channel trace before the trigger.
+            If the channel trace is long enough, it will be cut accordingly.
             Otherwise, it will be rolled.
 
             If given as a float, the same ``pre_trigger_time`` will be used for all channels.
-            If a dict, the keys should be ``channel_id``, and the values the ``pre_trigger_time`` 
+            If a dict, the keys should be ``channel_id``, and the values the ``pre_trigger_time``
             to use for each channel. Alternatively, the keys should be the ``trigger_name``,
             and the values either a float or a dictionary with (``channel_id``, ``pre_trigger_time``)
             pairs.
@@ -50,17 +50,17 @@ class triggerTimeAdjuster:
         Run the trigger time adjuster.
 
         This module can be used either to 'cut' the simulated traces into
-        the appropriate readout windows, or to adjust the trace start times 
+        the appropriate readout windows, or to adjust the trace start times
         of simulated / real data to account for the different trigger readout
         delays.
 
         Parameters
         ----------
-        event: NuRadioReco.framework.event.Event
+        event: `NuRadioReco.framework.event.Event`
 
-        station: NuRadioReco.framework.base_station.Station
+        station: `NuRadioReco.framework.base_station.Station`
 
-        detector: NuRadioReco.detector.detector.Detector
+        detector: `NuRadioReco.detector.detector.Detector`
 
         mode: 'sim_to_data' (default) | 'data_to_sim'
             If 'sim_to_data', cuts the (arbitrary-length) simulated traces
@@ -70,7 +70,7 @@ class triggerTimeAdjuster:
 
             If the ``trigger_name`` was specified in the ``begin`` function,
             only this trigger is considered.
-        
+
         """
         if mode == 'sim_to_data':
             trigger = None
@@ -79,15 +79,18 @@ class triggerTimeAdjuster:
             else:
                 min_trigger_time = None
                 for trig in station.get_triggers().values():
-                    if(trig.has_triggered()):
+                    if trig.has_triggered():
                         if min_trigger_time is None or trig.get_trigger_time() < min_trigger_time:
                             min_trigger_time = trig.get_trigger_time()
                             trigger = trig
-                if(min_trigger_time is not None):
+
+                if min_trigger_time is not None:
                     logger.info(f"minimum trigger time is {min_trigger_time/units.ns:.2f}ns")
+
             if trigger is None:
                 logger.info('No trigger found! Channel timings will not be changed.')
                 return
+
             if trigger.has_triggered():
                 trigger_time = trigger.get_trigger_time()
                 store_pre_trigger_time = {} # we also want to save the used pre_trigger_time
@@ -97,68 +100,74 @@ class triggerTimeAdjuster:
                     trace = channel.get_trace()
                     trace_length = len(trace)
                     detector_sampling_rate = detector.get_sampling_frequency(station.get_id(), channel.get_id())
+                    sampling_rate = channel.get_sampling_rate()
+                    self.__check_sampling_rates(detector_sampling_rate, sampling_rate)
+
+                    # this should ensure that 1) the number of samples is even and
+                    # 2) resampling to the detector sampling rate results in the correct number of samples
+                    # (note that 2) can only be guaranteed if the detector sampling rate is lower than the
+                    # current sampling rate)
                     number_of_samples = int(
-                        2 * np.ceil( # this should ensure that 1) the number of samples is even and 2) resampling to the detector sampling rate results in the correct number of samples (note that 2) can only be guaranteed if the detector sampling rate is lower than the current sampling rate)
+                        2 * np.ceil(
                             detector.get_number_of_samples(station.get_id(), channel.get_id()) / 2
-                            * channel.get_sampling_rate() / detector_sampling_rate
+                            * sampling_rate / detector_sampling_rate
                         ))
+
                     if number_of_samples > trace.shape[0]:
                         logger.error("Input has fewer samples than desired output. Channels has only {} samples but {} samples are requested.".format(
                             trace.shape[0], number_of_samples))
                         raise AttributeError
                     else:
-                        sampling_rate = channel.get_sampling_rate()
-                        self.__check_sampling_rates(detector_sampling_rate, sampling_rate)
                         trigger_time_sample = int(np.round(trigger_time_channel * sampling_rate))
-                        # logger.debug(f"channel {channel.get_id()}: trace_start_time = {channel.get_trace_start_time():.1f}ns, trigger time channel {trigger_time_channel/units.ns:.1f}ns,  trigger time sample = {trigger_time_sample}")
-                        pre_trigger_time = self.__pre_trigger_time
+
                         channel_id = channel.get_id()
                         trigger_name = trigger.get_name()
-                        while isinstance(pre_trigger_time, dict):
-                            if trigger_name in pre_trigger_time.keys(): # keys are different triggers
-                                pre_trigger_time = pre_trigger_time[trigger_name]
-                            elif channel_id in pre_trigger_time: # keys are channel_ids
-                                pre_trigger_time = pre_trigger_time[channel_id]
-                            else:
+
+                        if isinstance(self.__pre_trigger_time, dict):
+                            if trigger_name not in self.__pre_trigger_time or channel_id not in self.__pre_trigger_time[trigger_name]:
                                 logger.error(
                                     'pre_trigger_time was specified as a dictionary, '
-                                    f'but neither the trigger_name {trigger_name} '
-                                    f'nor the channel id {channel_id} are present as keys'
-                                    )
+                                    f'but the trigger_name {trigger_name} or channel id {channel_id} '
+                                    'are not present as keys')
                                 raise KeyError
+
+                            pre_trigger_time = self.__pre_trigger_time[trigger_name][channel_id]
+                        else:
+                            pre_trigger_time = self.__pre_trigger_time
+
                         samples_before_trigger = int(pre_trigger_time * sampling_rate)
-                        rel_station_time_samples = 0
                         cut_samples_beginning = 0
-                        if(samples_before_trigger < trigger_time_sample):
+                        if samples_before_trigger < trigger_time_sample:
                             cut_samples_beginning = trigger_time_sample - samples_before_trigger
                             roll_by = 0
-                            if(cut_samples_beginning + number_of_samples > trace_length):
-                                logger.info("trigger time is sample {} but total trace length is only {} samples (requested trace length is {} with an offest of {} before trigger). To achieve desired configuration, trace will be rolled".format(
-                                    trigger_time_sample, trace_length, number_of_samples, samples_before_trigger))
+                            if cut_samples_beginning + number_of_samples > trace_length:
+                                logger.info(f"trigger time is sample {trigger_time_sample} but total "
+                                             f"trace length is only {trace_length} samples "
+                                             f"(requested trace length is {number_of_samples} with an offest of "
+                                             f"{samples_before_trigger} before trigger). "
+                                              "To achieve desired configuration, trace will be rolled")
+
                                 roll_by = cut_samples_beginning + number_of_samples - trace_length  # roll_by is positive
                                 trace = np.roll(trace, -1 * roll_by)
                                 cut_samples_beginning -= roll_by
-                            rel_station_time_samples = cut_samples_beginning + roll_by
-                        elif(samples_before_trigger > trigger_time_sample):
-                            roll_by = -trigger_time_sample + samples_before_trigger
+
+                        elif samples_before_trigger > trigger_time_sample:
+                            roll_by = samples_before_trigger - trigger_time_sample
                             logger.info(
                                 "trigger time is before 'trigger offset window', the trace needs to be rolled by {} samples first".format(roll_by))
+
                             trace = np.roll(trace, roll_by)
-                            trigger_time_sample -= roll_by
-                            rel_station_time_samples = -roll_by
 
                         # shift trace to be in the correct location for cutting
-                        # logger.debug(f"cutting trace to {cut_samples_beginning}-{number_of_samples + cut_samples_beginning} samples")
+                        logger.debug(f"cutting trace to {cut_samples_beginning}-{number_of_samples + cut_samples_beginning} samples")
                         trace = trace[cut_samples_beginning:(number_of_samples + cut_samples_beginning)]
                         channel.set_trace(trace, channel.get_sampling_rate())
-                        channel.set_trace_start_time(trigger_time)
+                        channel.set_trace_start_time(trigger_time - pre_trigger_time)
                         store_pre_trigger_time[channel_id] = pre_trigger_time
-                        # channel.set_trace_start_time(channel.get_trace_start_time() + rel_station_time_samples / channel.get_sampling_rate())
-                        # logger.debug(f"setting trace start time to {channel.get_trace_start_time() + rel_station_time_samples / channel.get_sampling_rate():.0f} = {channel.get_trace_start_time():.0f} + {rel_station_time_samples / channel.get_sampling_rate():.0f}")
-                
+
                 # store the used pre_trigger_times
                 trigger.set_pre_trigger_times(store_pre_trigger_time)
-            
+
             else:
                 logger.debug('Trigger {} has not triggered. Channel timings will not be changed.'.format(self.__trigger_name))
         elif mode == 'data_to_sim':
@@ -177,7 +186,7 @@ class triggerTimeAdjuster:
             for pre_trigger_time in pre_trigger_times:
                 if pre_trigger_time is not None:
                     for channel in station.iter_channels():
-                        channel.set_trace_start_time(channel.get_trace_start_time()-pre_trigger_time[channel.get_id()])
+                        channel.set_trace_start_time(channel.get_trace_start_time() - pre_trigger_time[channel.get_id()])
         else:
             raise ValueError(f"Argument '{mode}' for mode is not valid. Options are 'sim_to_data' or 'data_to_sim'.")
 


### PR DESCRIPTION
Also slightly refactoring the module

I have not tested it yet but just by looking at it, it feels odd to set the `trace_start_time` to the trigger time when the purpose of the module is to place the trigger somewhere within the trace.  
