### PR TITLE
Cleanup of functions in LOFAR beamforming utilities

### DIFF
--- a/NuRadioReco/modules/LOFAR/beamforming_utilities.py
+++ b/NuRadioReco/modules/LOFAR/beamforming_utilities.py
@@ -1,7 +1,5 @@
 import numpy as np
-import radiotools.helper as hp
 
-from scipy.optimize import fmin_powell
 from scipy import constants
 
 from NuRadioReco.utilities import units
@@ -12,56 +10,104 @@ lightspeed = constants.c * units.m / units.s
 
 def mini_beamformer(fft_data, frequencies, positions, direction):
     """
+    Beamforms the spectra given the arrival direction and antenna positions.
+    This function is a wrapper around the `beamformer()` function, which beamforms the
+    spectra given the timedelay. Here we first calculate the geometric delays in the far
+    field, based on the arrival direction.
+
+    Parameters
+    ----------
+    fft_data : np.ndarray
+        The Fourier transformed time traces of all antennae, shaped as (nr_of_ant, nr_of_freq_samples)
+    frequencies : np.ndarray
+        The values of the frequencies samples, shaped as (nr_of_freq_samples,)
+    positions : np.ndarray
+        The position of antenna, shaped as (nr_of_ant, 3)
+    direction : np.ndarray
+        The arrival direction in the sky, in cartesian coordinates, shape (3,)
+
+    Returns
+    -------
+    beamformed : np.ndarray
+        The beamformed (ie summed) frequency spectrum
+
+    Notes
+    -----
     Adapted from PyCrTools hBeamformBlock
-
-    Beamform the spectra given the arrival direction. Based on the arrival direction,
-    the geometric delays are calculated.
     """
-    n_antennas = len(positions)
+    delays = geometric_delay_far_field(positions, direction)
 
-    output = np.zeros([len(frequencies)], dtype=complex)
-
-    norm = np.sqrt(direction[0] * direction[0] + direction[1] * direction[1] + direction[2] * direction[2])
-
-    for a in np.arange(n_antennas):
-        delay = GeometricDelayFarField(positions[a], direction, norm)
-
-        real = 1.0 * np.cos(2 * np.pi * frequencies * delay)
-        imag = 1.0 * np.sin(2 * np.pi * frequencies * delay)
-
-        de = real + 1j * imag
-        output = output + fft_data[a] * de
-
-    return output
+    return beamformer(fft_data, frequencies, delays)
 
 
-def beamformer(fft_data, frequencies, delay):
+def beamformer(fft_data, frequencies, delays):
     """
-    Beamform the spectra according to the given delays.
+    Beamform the spectra according to the given delays, by phase shifting them according
+    to the time delays and summing up the resulting spectra.
+
+    Parameters
+    ----------
+    fft_data : np.ndarray
+        The Fourier transformed time traces of all antennae, shaped as (nr_of_ant, nr_of_freq_samples)
+    frequencies : np.ndarray
+        The values of the frequencies samples, shaped as (nr_of_freq_samples,)
+    delays : np.ndarray
+        The delay per antenna, shaped as (nr_of_ant,)
+
+    Returns
+    -------
+    beamformed : np.ndarray
+        The beamformed (ie summed) frequency spectrum
     """
-    n_antennas = len(delay)
-    output = np.zeros([len(frequencies)], dtype=complex)
+    real = 1.0 * np.cos(2 * np.pi * frequencies[np.newaxis, :] * delays[:, np.newaxis])
+    imag = 1.0 * np.sin(2 * np.pi * frequencies[np.newaxis, :] * delays[:, np.newaxis])
 
-    for a in np.arange(n_antennas):
-        real = 1.0 * np.cos(2 * np.pi * frequencies * delay[a])
-        imag = 1.0 * np.sin(2 * np.pi * frequencies * delay[a])
+    de = real + 1j * imag
+    output = fft_data * de
 
-        de = real + 1j * imag
-        output = output + fft_data[a] * de
-
-    return output
+    return np.sum(output, axis=0)  # sum all the antennas together to beamform
 
 
-def geometric_delays(ant_pos, sky):
+def geometric_delays_near_field(ant_pos, sky):
     """
-    Calculate the geometric delays of given antenna position, given an arrival direction in the sky.
+    Calculate the geometric delays of given antenna position, given a source location in the sky.
+
+    Parameters
+    ----------
+    ant_pos : array_like
+        Antenna positions
+    sky : array_like
+        Source location in the sky
+
+    Returns
+    -------
+    delays : array_like
+        The geometric delays for all antenna positions.
     """
-    distance = np.sqrt(sky[0] ** 2 + sky[1] ** 2 + sky[2] ** 2)
-    delays = (np.sqrt(
-        (sky[0] - ant_pos[0]) ** 2 + (sky[1] - ant_pos[1]) ** 2 + (sky[2] - ant_pos[2]) ** 2) - distance) / lightspeed
+    delays = np.linalg.norm(ant_pos - sky, axis=1) / lightspeed
+
     return delays
 
 
-def GeometricDelayFarField(position, direction, length):
-    delay = np.sum(np.asarray(direction) * np.asarray(position)) / length / lightspeed
-    return delay
+def geometric_delay_far_field(ant_positions, direction):
+    """
+    Calculate the geometric delays in the far field approximation, by projecting the positions onto
+    the arrival direction vector and dividing by the lightspeed.
+
+    If the `direction` vector points towards the incoming direction (as usually calculated using
+    zenith and azimuth), then positive delays correspond to later times compared to the [0, 0, 0]
+    location.
+
+    Parameters
+    ----------
+    ant_positions : array_like
+        The positions of the antennae, with shape (nr_of_ant, 3)
+    direction : array_like
+        The arrival direction, in cartesian coordinates
+    """
+    direction_normalised = np.asarray(direction) / np.linalg.norm(direction)
+
+    delays = np.dot(ant_positions, direction_normalised)
+    delays /= -1 * lightspeed
+
+    return delays


### PR DESCRIPTION
I removed a bunch of old code in`[beamforming_utilities.py](https://github.com/nu-radio/NuRadioMC/compare/lofar/development...lofar/beamforming_utilities_cleanup?expand=1#diff-77e866206f274f79671989260ae2167b24b68e18b9e7225f6f2929ef4cab0566) and added the docstrings to go with the remaining functions. 

I also simplified and optimised the function that are still there, by using numpy array magic.
