### PR TITLE
Remove first if condition, the argparser will throw an error anyway. …

### DIFF
--- a/NuRadioMC/utilities/merge_hdf5.py
+++ b/NuRadioMC/utilities/merge_hdf5.py
@@ -242,20 +242,13 @@ if __name__ == "__main__":
         logger.setLevel(log_val)
 
     if len(args.files) == 1:
-        filenames = glob.glob("{}/*/*.hdf5.part????".format(args.files[0]))
-        filenames = np.append(filenames, glob.glob("{}/*/*.hdf5.part??????".format(args.files[0])))
-        filenames = sorted(filenames)
-        filenames2 = []
-        for i, filename in enumerate(filenames):
-            filename, ext = os.path.splitext(filename)
-            if(ext != '.hdf5'):
-                if(filename not in filenames2):
-                    d = os.path.split(filename)
-                    a, b = os.path.split(d[0])
-                    filenames2.append(filename)
-
+        root_directory = args.files[0]
+        if not os.path.isdir(root_directory):
+            sys.exit(f"{root_directory} is not a directory.")
+        
+        filenames = np.unique(glob.glob(f"{root_directory}/*/*.hdf5.part*"))
         input_args = []
-        for filename in sorted(filenames2):
+        for filename in sorted(filenames):
             if(os.path.splitext(filename)[1] == '.hdf5'):
                 d = os.path.split(filename)
                 a, b = os.path.split(d[0])
@@ -263,13 +256,12 @@ if __name__ == "__main__":
                 if(os.path.exists(output_filename)):
                     logger.error('file {} already exists, skipping'.format(output_filename))
                 else:
-                    #                 try:
-                    input_files = np.array(sorted(glob.glob(filename + '.part????')))
-                    input_files = np.append(input_files, np.array(sorted(glob.glob(filename + '.part??????'))))
+                    input_files = np.array(sorted(glob.glob(filename + '.part*')))
                     mask = np.array([os.path.getsize(x) > 1000 for x in input_files], dtype=bool)
                     if(np.sum(~mask)):
                         logger.warning("{:d} files were deselected because their filesize was to small".format(np.sum(~mask)))
                     input_args.append({'filenames': input_files[mask], 'output_filename': output_filename})
+        
         if(args.cores == 1):
             for i in range(len(input_args)):
                 merge2(input_args[i]['filenames'], input_args[i]['output_filename'])

--- a/NuRadioMC/utilities/merge_hdf5.py
+++ b/NuRadioMC/utilities/merge_hdf5.py
@@ -220,14 +220,16 @@ def merge2(filenames, output_filename):
 
 if __name__ == "__main__":
     """
-    merges multiple hdf5 output files into one single files.
-    The merger module automatically keeps track of the total number
-    of simulated events (which are needed to correctly calculate the effective volume).
+    Merges multiple hdf5 files into one single file. Keeps automatically track of the total number
+    of simulated events across all input files (which is necessary to correctly calculate the effective volume).
 
-    The script expects that the folder structure is
+    If a single path is passed as argument the script interprets it as root directory and expects the following folder structure:
     ../output/energy/*.hdf5.part????
+    The output file path is automatically determined.
 
-    Optional log level setting to either set DEBUG, INFO, or WARNING to the readout. Example: add --loglevel DEBUG when calling script to set loglevel to DEBUG. 
+    If multiple paths are passed, the first one is taken as output file path. The following paths are taken as input.
+
+    Optional log level setting to either set DEBUG, INFO, or WARNING to the readout. Example: add --loglevel DEBUG when calling script to set loglevel to DEBUG.
     """
     parser = argparse.ArgumentParser(description='Merge hdf5 files')
     parser.add_argument('files', nargs='+', help='input file or files')
@@ -239,9 +241,7 @@ if __name__ == "__main__":
         log_val = eval(f'logging.{args.loglevel}')
         logger.setLevel(log_val)
 
-    if(len(args.files) < 1):
-        print("usage: python merge_hdf5.py /path/to/simulation/output/folder\nor python merge_hdf5.py outputfilename input1 input2 ...")
-    elif(len(args.files) == 1):
+    if len(args.files) == 1:
         filenames = glob.glob("{}/*/*.hdf5.part????".format(args.files[0]))
         filenames = np.append(filenames, glob.glob("{}/*/*.hdf5.part??????".format(args.files[0])))
         filenames = sorted(filenames)
@@ -283,7 +283,7 @@ if __name__ == "__main__":
             with Pool(args.cores) as p:
                 p.map(tmp, input_args)
 
-    elif(len(args.files) > 1):
+    else:
         output_filename = args.files[0]
         if(os.path.exists(output_filename)):
             logger.error('file {} already exists, skipping'.format(output_filename))


### PR DESCRIPTION
…Improve doc-string

This mostly improves the doc-string. 

I have to say the code if `if len(args.files) == 1:` is hard to read. I imagine it was used for some specific library (Gen2?). Is it necessary to keep it where it is? Maybe we can store it in the analysis repo of the Gen2 analysis and simplify this code?

My intention: When I first looked at this script (and the previous doc-string) I thought the script is not suited for my purpose and would need quite some changes to be. I only later learned (when looking at a script by Steffen) that I indeed can use it simply by passing several inputs. 