### PR TITLE
Fix bugs in get_cable_delay() get_time_delay() of the rnog_detector class ...

### DIFF
--- a/NuRadioReco/detector/RNO_G/rnog_detector.py
+++ b/NuRadioReco/detector/RNO_G/rnog_detector.py
@@ -37,6 +37,9 @@ def _keys_not_in_dict(d, keys):
 
     Returns False if d["key1"]["key2"] exsits, True otherwise.
     """
+    if isinstance(keys, str):
+        keys = [keys]
+
     d_tmp = d
     for key in keys:
         try:
@@ -59,7 +62,7 @@ def _check_detector_time(method):
 
 
 class Detector():
-    def __init__(self, database_connection='RNOG_test_public', log_level=logging.INFO, over_write_handset_values={},
+    def __init__(self, database_connection='RNOG_test_public', log_level=logging.INFO, over_write_handset_values=None,
                  database_time=None, always_query_entire_description=True, detector_file=None,
                  select_stations=None, create_new=False):
         """
@@ -75,8 +78,10 @@ class Detector():
             Other options are: `logging.WARNING`, `logging.DEBUG`, ...
 
         over_write_handset_values : dict (Default: {})
-            Overwrite the default values for the manually set parameter which are not (yet) implemented in the database.
-            (Default: {}, the acutally default values for the parameters in question are defined below)
+            Overwrite the default values for (channel) parameters which are not (yet) implemented in the database.
+            You can not specify keys which already exist in the database. If the value is a dict it should be contain
+            a value for each channel_id (key). (Default: None, the acutally default values for the parameters in question
+            are defined below)
 
         database_time : `datetime.datetime` or `astropy.time.Time`
             Set database time which is used to select the primary measurement. By default (= None) the database time
@@ -98,11 +103,11 @@ class Detector():
             new connection. Set to True to create a new database connection.
         """
 
-        self.logger = logging.getLogger("NuRadioReco.RNOGdetector")
+        self.logger = logging.getLogger("NuRadioReco.RNOGDetector")
         self.__log_level = log_level
         self.logger.setLevel(self.__log_level)
 
-        # Define default values for parameter not (yet) implemented in DB. Those values are taken for all channels.
+        # Define default values for parameter not (yet) implemented in DB.
         self.__default_values = {
             "noise_temperature": 300 * units.kelvin,
             "is_noiseless": False,
@@ -155,17 +160,22 @@ class Detector():
             self._import_from_file(detector_file)
 
         # Allow overwriting the hard-coded values
+        over_write_handset_values = over_write_handset_values or {}
         self.__default_values.update(over_write_handset_values)
 
         info = f"Query entire detector description at once: {self._query_all}"
 
         info += "\nUsing the following hand-set values:"
+        n = np.amax([len(key) for key in self.__default_values.keys()]) + 3
         for key, value in self.__default_values.items():
-            info += f"\n\t{key:<20}: {value}"
+            info += f"\n\t{key:<{n}}: {value}"
 
         self.logger.info(info)
 
-    def export(self, filename, json_kwargs=None):
+        self.assume_inf = None  # Compatibility with other detectors classes
+        self.antenna_by_depth = None  # Compatibility with other detectors classes
+
+    def export(self, filename, json_kwargs=None, additional_data=None):
         """
         Export the buffered detector description.
 
@@ -177,6 +187,9 @@ class Detector():
 
         json_kwargs: dict
             Arguments passed to json.dumps(..). (Default: None -> dict(indent=0, default=_json_serial))
+
+        additional_data: dict (Default: None)
+            If specified the content of this dict will be added to the exported detector description.
         """
 
         periods = {}
@@ -191,10 +204,11 @@ class Detector():
             if idx == 0 or idx == len(self._time_periods_per_station[station_id]["modification_timestamps"]):
                 self.logger.error("You try to export a decomissioned station")
 
-            periods[station_id] = {"modification_timestamps":
-                                   [self._time_periods_per_station[station_id]["modification_timestamps"][idx - 1],
-                                    self._time_periods_per_station[station_id]["modification_timestamps"][idx]]
-                                   }
+            periods[station_id] = {
+                "modification_timestamps":
+                    [self._time_periods_per_station[station_id]["modification_timestamps"][idx - 1],
+                    self._time_periods_per_station[station_id]["modification_timestamps"][idx]]
+            }
 
         export_dict = {
             "version": 1,
@@ -202,6 +216,9 @@ class Detector():
             "periods": periods,
             "default_values": self.__default_values
         }
+
+        if additional_data is not None:
+            export_dict["additional_data"] = additional_data
 
         if not filename.endswith(".xz"):
             if not filename.endswith(".json"):
@@ -259,6 +276,7 @@ class Detector():
 
         if "version" in import_dict and import_dict["version"] == 1:
             self.__buffered_stations = {}
+            self.additional_data = import_dict.get("additional_data", None)
 
             # need to convert station/channel id keys back to integers
             for station_id, station_data in import_dict["data"].items():
@@ -595,7 +613,20 @@ class Detector():
             Dictionary of channel parameters
         """
         self.get_signal_chain_response(station_id, channel_id)  # this adds `total_response` to dict
-        return self.__get_channel(station_id, channel_id, with_position=True, with_signal_chain=True)
+        # Since we are not actually overwritting existing values we can use a shallow copy
+        channel_data = copy.copy(self.__get_channel(station_id, channel_id, with_position=True, with_signal_chain=True))
+
+        for key in self.__default_values:
+
+            if key in channel_data:
+                raise ValueError(f"{key} already in channel data. You can not update this in the this detector class. Use the ModDetector class.")
+
+            if isinstance(self.__default_values[key], dict):
+                channel_data[key] = self.__default_values[key][channel_id]
+            else:
+                channel_data[key] = self.__default_values[key]
+
+        return channel_data
 
     @_check_detector_time
     def get_station(self, station_id):
@@ -1086,17 +1117,20 @@ class Detector():
         return int(self.__buffered_stations[station_id]['number_of_samples'])
 
 
-    def get_sampling_frequency(self, station_id, channel_id):
+    def get_sampling_frequency(self, station_id, channel_id=None):
         """ Get sampling frequency per station / channel
 
         All RNO-G channels have the same sampling frequency, the argument channel_id is not used but we keep
-        it here for consistency with outer detector classes.
+        it here for consistency with other detector classes.
 
         Parameters
         ----------
 
         station_id: int
             Station id
+
+        channel_id: int (default: None)
+            Not Used!
 
         Returns
         -------
@@ -1118,25 +1152,11 @@ class Detector():
 
     def get_noise_temperature(self, station_id, channel_id):
         """ Get noise temperture per station / channel """
-        noise_temperature = self.__default_values["noise_temperature"]
-        if isinstance(noise_temperature, float):
-            self.logger.warn(
-                f"Return a hard-coded value for the noise temperature of {noise_temperature / units.kelvin} K. "
-                "This information is not (yet) implemented in the DB.")
-            return noise_temperature
-        elif isinstance(noise_temperature, dict):
-            self.logger.warn(
-                f"Return a hard-coded value for the noise temperature of {noise_temperature / units.kelvin} K for channel {channel_id}. "
-                "This information is not (yet) implemented in the DB.")
-            return noise_temperature[channel_id]
-        else:
-            raise ValueError("Unkown type for hard-coded value")
+        noise_temperature = self.get_channel(station_id, channel_id)["noise_temperature"]
+        return noise_temperature
 
     def is_channel_noiseless(self, station_id, channel_id):
-        is_noiseless = self.__default_values["is_noiseless"]
-        self.logger.warn(
-            f"Return a hard-coded value for \"is_noiseless\" of {is_noiseless} for all stations / channels. "
-            "This information is not (yet) implemented in the DB.")
+        is_noiseless = self.get_channel(station_id, channel_id)["is_noiseless"]
         return is_noiseless
 
 
@@ -1146,7 +1166,10 @@ class Detector():
         This interface is required by simulation.py. See get_time_delay for description of
         arguments.
         """
-        return self.get_time_delay(station_id, channel_id, cable_only=True, use_stored=use_stored)
+        # FS: For the RNO-G detector description it is not easy to determine the cable delay alone
+        # because it is not clear which reference components may need to be substraced.
+        # However, having the cable delay without amplifiers is anyway weird.
+        return self.get_time_delay(station_id, channel_id, cable_only=False, use_stored=use_stored)
 
     def get_time_delay(self, station_id, channel_id, cable_only=False, use_stored=True):
         """ Return the sum of the time delay of all components in the signal chain calculated from the phase
@@ -1179,20 +1202,20 @@ class Detector():
         time_delay = 0
         for key, value in signal_chain_dict["response_chain"].items():
 
-            if re.search("cable", key) is None and cable_only:
+            if re.search("cable", key) is None and re.search("fiber", key) and cable_only:
                 continue
 
             if use_stored:
-                if "time_delay" not in value or "cable_delay" not in value:
+                if "time_delay" not in value and "cable_delay" not in value:
                     self.logger.warning(
                         f"The signal chain component \"{key}\" of station.channel "
-                        f"{station_id}.{channel_id} has no cable/time delay stored... Skip it")
+                        f"{station_id}.{channel_id} has no cable/time delay stored... (hence return time delay without it)")
                     continue
 
                 try:
-                    time_delay += value["time_delay"]
+                    time_delay += value["weight"] * value["time_delay"]
                 except KeyError:
-                    time_delay += value["cable_delay"]
+                    time_delay += value["weight"] * value["cable_delay"]
 
             else:
                 ydata = [value["mag"], value["phase"]]

--- a/NuRadioReco/detector/RNO_G/rnog_detector.py
+++ b/NuRadioReco/detector/RNO_G/rnog_detector.py
@@ -1205,6 +1205,7 @@ class Detector():
             if re.search("cable", key) is None and re.search("fiber", key) and cable_only:
                 continue
 
+            weight = value.get("weight", 1)
             if use_stored:
                 if "time_delay" not in value and "cable_delay" not in value:
                     self.logger.warning(
@@ -1213,9 +1214,9 @@ class Detector():
                     continue
 
                 try:
-                    time_delay += value["weight"] * value["time_delay"]
+                    time_delay += weight * value["time_delay"]
                 except KeyError:
-                    time_delay += value["weight"] * value["cable_delay"]
+                    time_delay += weight * value["cable_delay"]
 
             else:
                 ydata = [value["mag"], value["phase"]]
@@ -1223,7 +1224,7 @@ class Detector():
                                     name=key, station_id=station_id, channel_id=channel_id,
                                     log_level=self.__log_level)
 
-                time_delay += response._calculate_time_delay()
+                time_delay += weight * response._calculate_time_delay()
 
         return time_delay
 

--- a/NuRadioReco/detector/RNO_G/rnog_detector.py
+++ b/NuRadioReco/detector/RNO_G/rnog_detector.py
@@ -1223,7 +1223,7 @@ class Detector():
                                     name=key, station_id=station_id, channel_id=channel_id,
                                     log_level=self.__log_level)
 
-                time_delay += response._get_time_delay()
+                time_delay += response._calculate_time_delay()
 
         return time_delay
 

--- a/NuRadioReco/detector/response.py
+++ b/NuRadioReco/detector/response.py
@@ -85,7 +85,7 @@ class Response:
 
         self._sanity_check = True # Tmp
 
-        if self._station_id is None or self._channel_id is None:
+        if self._station_id is None or self._channel_id is None and self._station_id != -1:
             self.logger.error(f"Station and channel id were not defined for response {name}. Please do that.")
 
         self.__frequency = np.array(frequency) * units.GHz
@@ -113,7 +113,7 @@ class Response:
             raise KeyError
 
         # Remove the average group delay from response
-        if remove_time_delay:
+        if remove_time_delay and time_delay:
             self.logger.debug(f"Remove a time delay of {time_delay:.2f} ns from {name}")
             y_phase_orig = np.copy(np.unwrap(y_phase))
             _response = subtract_time_delay_from_response(self.__frequency, gain, y_phase, time_delay)
@@ -219,9 +219,12 @@ class Response:
 
             # to avoid RunTime warning and NANs in total reponse
             if weight == -1:
-                _gain = np.where(_gain > 0, _gain, 1e-6)
-
-            response *= (_gain * np.exp(1j * phase(freq / units.GHz))) ** weight
+                mask = _gain > 0
+                tmp_response = np.zeros_like(freq, dtype=np.complex128)
+                tmp_response[mask] = (_gain[mask] * np.exp(1j * phase(freq[mask] / units.GHz))) ** weight
+                response *= tmp_response
+            else:
+                response *= (_gain * np.exp(1j * phase(freq / units.GHz))) ** weight
 
         if np.allclose(response, np.ones_like(freq, dtype=np.complex128)):
             if component_names is not None:
@@ -237,6 +240,26 @@ class Response:
         """ Get list of the names of all individual responses """
         return self.__names
 
+    def remove(self, name):
+        """
+        Remove a component response from the response object.
+
+        Parameters
+        ----------
+
+        name: str
+            Name of the component to remove
+        """
+        if name not in self.get_names():
+            raise ValueError(f"Component {name} not found in response. Options are: {self.get_names()}")
+
+        idx = self.__names.index(name)
+        self.__names.pop(idx)
+        self.__gains.pop(idx)
+        self.__phases.pop(idx)
+        self.__weights.pop(idx)
+        self.__time_delays.pop(idx)
+
     def __mul__(self, other):
         """
         Define multiplication operator for
@@ -246,8 +269,9 @@ class Response:
 
         if isinstance(other, Response):
             self = copy.deepcopy(self)
-            if self._station_id != other._station_id or \
-                self._channel_id != other._channel_id:
+            if (self._station_id != other._station_id or
+                self._channel_id != other._channel_id) and (other._station_id != -1 and self._station_id != -1):
+                # station_id == -1 is a special case to all non-station specific responses
                 self.logger.error("It looks like you are combining responses from "
                                   f"two different channels: {self._station_id}.{self._channel_id} "
                                   f" vs {other._station_id}.{other._channel_id} (station_id.channel_id)")
@@ -290,9 +314,9 @@ class Response:
         return self.__mul__(other)
 
     def __str__(self):
-        ampl = 20 * np.log10(np.abs(self(0.5 * units.GHz)))
+        ampl = 20 * np.log10(np.abs(self(np.array([0.15, 0.5]) * units.GHz)))
         return "Response of " + ", ".join([f"{name} ({weight})" for name, weight in zip(self.get_names(), self.__weights)]) \
-            + f": |R(0.5 GHz)| = {ampl:.2f} dB (amplitude) ({np.sum(self.__time_delays):.2f} ns)"
+            + f": |R([0.15, 0.5] GHz)| = [{ampl[0]:.2f}, {ampl[1]:.2f}] dB (amplitude) ({np.sum(self.__time_delays):.2f} ns)"
 
     def plot(self, ax1=None, show=False, in_dB=True, plt_kwargs={}):
         import matplotlib.pyplot as plt
@@ -304,24 +328,32 @@ class Response:
         else:
             ax = ax1
 
-        for gain, weight, name in zip(self.__gains, self.__weights, self.__names):
+        for gain, weight, name, td in zip(self.__gains, self.__weights, self.__names, self.__time_delays):
             _gain = gain(freqs)
 
             name = name.replace("_", " ")
             ls = "-" if weight == 1 else "--"
 
+            if name.startswith("golden"):
+                name = name.replace("golden downhole components", "ref. comp.")
+
+            if name.endswith(" "):
+                name = name[:-1]
+
+            label = f"{name:<25} : {weight:<3} | {td:.1f}ns"
             if in_dB:
                 mask = _gain > 0  # to avoid RunTime warning
-                ax.plot(freqs[mask] / units.MHz, 20 * np.log10(_gain[mask]), ls=ls, label=name + f": {weight}", **plt_kwargs)
+                ax.plot(freqs[mask] / units.MHz, 20 * np.log10(_gain[mask]), lw=1, ls=ls, label=label, **plt_kwargs)
             else:
-                ax.plot(freqs / units.MHz, _gain, label=name + f": {weight}", ls=ls, **plt_kwargs)
+                ax.plot(freqs / units.MHz, _gain, label=label, lw=1, ls=ls, **plt_kwargs)
 
         _gain = np.abs(self(freqs))
+        label = f"total: {np.sum(self.__time_delays):.1f}ns"
         if in_dB:
             mask = _gain > 0  # to avoid RunTime warning
-            ax.plot(freqs[mask] / units.MHz, 20 * np.log10(_gain[mask]), color="k", label="total", **plt_kwargs)
+            ax.plot(freqs[mask] / units.MHz, 20 * np.log10(_gain[mask]), color="k", label=label, **plt_kwargs)
         else:
-            ax.plot(freqs / units.MHz, _gain, color="k", label="total", **plt_kwargs)
+            ax.plot(freqs / units.MHz, _gain, color="k", label=label, **plt_kwargs)
 
         ax.set_xlabel("frequency / MHz")
         if in_dB:
@@ -330,7 +362,7 @@ class Response:
             ax.set_ylabel("gain")
             ax.set_yscale("log")
 
-        ax.legend()
+        ax.legend(fontsize="x-small")
         ax.grid()
 
         if show:


### PR DESCRIPTION
… Some more modifications. Some fixes changes in the response class as well.

These changes are already included in the `rnog_trigger` and `rnog_trigger_3.0` branches. But it is crucial that the fixes get merged sooner to the develop branch. 

This PR also adds a few new features and modification to both classes. However, the main things are:

RNO-G detector:
- The function get_cable_delay returns now the time delay of the entire response chain, not just the cables.
- If one selects only cables, now also responses which contain "fiber" and "cable" are used.
- Take golden components correctly into account to get the total time delay

Response class:
- How to treat cases where one divides through very low amplifications. Avoid exploding responses when dividing through golden components.

