### PR TITLE
[Hotfix] pin numpy<2

### DIFF
--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -1384,7 +1384,7 @@ class AntennaPatternAnalytic(AntennaPatternBase):
 
             index = np.argmax(freq > self._cutoff_freq)
             Gain = np.ones_like(freq)
-            from scipy.signal import hann
+            from scipy.signal.windows import hann
             gain_filter = hann(2 * index)
             Gain[:index] = gain_filter[:index]
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,11 @@ Changelog - to keep track of all relevant changes
 
 please update the categories "new features" and "bugfixes" before a pull request merge!
 
+version 2.2.2
+bugfixes:
+- replace deprecated import of scipy window in antennapattern
+- pin numpy<2 as .nur files generated with numpy 2.* cannot be read in with earlier versions of numpy.
+
 version 2.2.1
 bugfixes:
 - readRNOGDataMattak: fix bug where .root files would not be found if they are passed as relative paths (instead of absolute paths or folder)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ description = "A Monte Carlo simulation package for radio neutrino detectors and
 # classifiers = ["License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"]
 
 [tool.poetry.dependencies]
-numpy = "*"
+numpy = "<2"
 scipy = "*"
 tinydb = ">=4.1.1"
 tinydb-serialization = ">=2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "NuRadioMC"
-version = "2.2.1"
+version = "2.2.2"
 authors = ["Christian Glaser et al."]
 homepage = "https://github.com/nu-radio/NuRadioMC"
 documentation = "https://nu-radio.github.io/NuRadioMC/main.html"


### PR DESCRIPTION
See #695 for discussion

Currently, `.nur` files generated with numpy 2.* cannot be read in using earlier versions of numpy. This means we cannot guarantee compatibility even between two instances of the same version of NuRadioMC. This PR avoids this issue by pinning `numpy<2`; in order to switch to numpy 2.*, we will probably have to switch to `numpy>=2` in some future release of NuRadioMC in order to maintain cross-compatibility for a fixed NuRadioMC versions.

(This is a proposed hotfix release v2.2.2; if accepted, this should also be merged into `develop` afterwards)