### PR TITLE
Fix in period-of-validity logic for RNO-G HW DB

### DIFF
--- a/NuRadioReco/detector/RNO_G/db_mongo_read.py
+++ b/NuRadioReco/detector/RNO_G/db_mongo_read.py
@@ -298,11 +298,11 @@ class Database(object):
         # filter out all decommissioned channels and devices
         commissioned_info = copy.deepcopy(stations_for_buffer)
         for key in ['channels', 'devices']:
-            for ientry, entry in enumerate(stations_for_buffer[0][key]):
+            for entry in stations_for_buffer[0][key]:
                 if entry['commission_time'] <= detector_time and entry['decommission_time'] >= detector_time:
                     pass
                 else:
-                    commissioned_info[0][key].pop(ientry)
+                    commissioned_info[0][key].remove(entry)
 
         # transform the output of db.aggregate to a dict
         # dictionarize the channel information

--- a/NuRadioReco/detector/RNO_G/db_mongo_read.py
+++ b/NuRadioReco/detector/RNO_G/db_mongo_read.py
@@ -299,9 +299,7 @@ class Database(object):
         commissioned_info = copy.deepcopy(stations_for_buffer)
         for key in ['channels', 'devices']:
             for entry in stations_for_buffer[0][key]:
-                if entry['commission_time'] <= detector_time and entry['decommission_time'] >= detector_time:
-                    pass
-                else:
+                if not entry['commission_time'] <= detector_time <= entry['decommission_time']:
                     commissioned_info[0][key].remove(entry)
 
         # transform the output of db.aggregate to a dict


### PR DESCRIPTION
Fixes a bug in removing channels and devices that are not commissioned at the requested time.

Simple script to validate this fix:

```
from datetime import datetime
from NuRadioReco.detector.RNO_G.db_mongo_write import Database

db = Database(database_connection = 'RNOG_public')
db.set_detector_time(datetime.utcnow())
station_info = db.get_general_station_information(23)

print(station_info)
```

Crashes before this PR, prints station information after.