### PR TITLE
Implement add_to_trace method (refactor)

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -112,6 +112,12 @@ jobs:
         export GSLDIR=$(gsl-config --prefix)
         export PYTHONPATH=$(pwd):$PYTHONPATH
         NuRadioMC/test/SignalGen/test_build.sh
+    - name: "Validate separate trigger channels"
+      if: always()
+      run: |
+        export GSLDIR=$(gsl-config --prefix)
+        export PYTHONPATH=$(pwd):$PYTHONPATH
+        NuRadioMC/test/SingleEvents/validate_separate_trigger_channels.sh
     - name: "Signal propagation tests"
       if: always()
       run: |

--- a/NuRadioReco/framework/base_trace.py
+++ b/NuRadioReco/framework/base_trace.py
@@ -246,6 +246,75 @@ class BaseTrace:
         if 'trace_start_time' in data.keys():
             self.set_trace_start_time(data['trace_start_time'])
 
+    def add_to_trace(self, channel):
+        """
+        Adds the trace of another channel (with potentially diffrent length and _trace_start_time) to
+        the trace of this channel without changing the sampling. If used on an empty trace with a defined
+        self._sampling_rate and self.self._trace_start_time, and self._time_trace containing zeros, this
+        function can be seen as recording the channel in a specific readout window.
+
+        Parameters
+        ----------
+        channel: BaseTrace
+            Channel to add to current channel
+        """
+
+        assert self.get_number_of_samples() is not None, "No trace is set for this channel"
+        assert self.get_sampling_rate() == channel.get_sampling_rate(), "Sampling rates of the two channels do not match"
+
+        tt_readout = self.get_times()
+        t0_readout = self.get_trace_start_time()
+        t1_readout = t0_readout +  self.get_number_of_samples() / self.get_sampling_rate()
+        sampling_rate_readout = self.get_sampling_rate()
+        n_samples_readout = self.get_number_of_samples()
+
+        tt_channel = channel.get_times()
+        t0_channel = channel.get_trace_start_time()
+        t1_channel = t0_channel + channel.get_number_of_samples() / channel.get_sampling_rate()
+        sampling_rate_channel = channel.get_sampling_rate()
+        n_samples_channel = channel.get_number_of_samples()
+
+        # We handle 1+2x2 cases:
+        # 1. Channel is completely outside readout window:
+        if t1_channel < t0_readout or t1_readout < t0_channel:
+            return
+        # 2. Channel starts before readout window:
+        if t0_channel < t0_readout:
+            i_start_readout = 0
+            t_start_readout = t0_readout
+            i_start_channel = int( (t0_readout-t0_channel) * sampling_rate_channel ) + 1 # The first bin of channel inside readout
+            t_start_channel = tt_channel[i_start_channel]
+        # 3. Channel starts after readout window:
+        elif t0_channel >= t0_readout:
+            i_start_readout = int( (t0_channel-t0_readout) * sampling_rate_readout ) # The bin of readout right before channel starts
+            t_start_readout = tt_readout[i_start_readout]
+            i_start_channel = 0
+            t_start_channel = t0_channel
+        # 4. Channel ends after readout window:
+        if t1_channel >= t1_readout:
+            i_end_readout = n_samples_readout
+            t_end_readout = t1_readout
+            i_end_channel = int( (t1_readout - t0_channel) * sampling_rate_channel ) + 1 # The bin of channel right after readout ends
+            t_end_channel = tt_channel[i_end_channel]
+        # 5. Channel ends before readout window:
+        elif t1_channel < t1_readout:
+            i_end_readout = int( (t1_channel - t0_readout) * sampling_rate_readout ) # The bin of readout right before channel ends
+            t_end_readout = tt_readout[i_end_readout]
+            i_end_channel = n_samples_channel
+            t_end_channel = t1_channel
+        
+        # Determine the remaining time between the binning of the two traces and use time shift as interpolation:
+        residual_time_offset = t_start_channel - t_start_readout
+        tmp_channel = copy.deepcopy(channel)
+        tmp_channel.apply_time_shift(residual_time_offset)
+        trace_to_add = tmp_channel.get_trace()[i_start_channel:i_end_channel]
+
+        # Add the trace to the original trace:
+        original_trace = self.get_trace()
+        original_trace[i_start_readout:i_end_readout] += trace_to_add
+        self.set_trace(original_trace, sampling_rate_readout)
+
+
     def __add__(self, x):
         """
         Redefine the "+" operator for BaseTrace objects. The operation will return a

--- a/NuRadioReco/framework/trigger.py
+++ b/NuRadioReco/framework/trigger.py
@@ -291,7 +291,7 @@ class SimplePhasedTrigger(Trigger):
         maximum_amps: list of floats (length equal to that of `phasing_angles`)
             the maximum value of all the integration windows for each of the phased waveforms
         """
-        Trigger.__init__(self, name, channels, 'simple_phased', pre_trigger_times=pre_trigger_times))
+        Trigger.__init__(self, name, channels, 'simple_phased', pre_trigger_times=pre_trigger_times)
         self._primary_channels = channels
         self._primary_angles = primary_angles
         self._secondary_channels = secondary_channels
@@ -330,7 +330,7 @@ class HighLowTrigger(Trigger):
             the number of channels that need to fulfill the trigger condition
             default: 1
         """
-        Trigger.__init__(self, name, channels, 'high_low', pre_trigger_times=pre_trigger_times))
+        Trigger.__init__(self, name, channels, 'high_low', pre_trigger_times=pre_trigger_times)
         self._number_of_coincidences = number_of_coincidences
         self._threshold_high = threshold_high
         self._threshold_low = threshold_low


### PR DESCRIPTION
I implemented a method in the BaseTrace class that adds the trace of a different channel to the current trace without changing the binning, i.e., the same readout window. 