### PR TITLE
Reduce date + time stamp in logging

### DIFF
--- a/NuRadioReco/utilities/logging.py
+++ b/NuRadioReco/utilities/logging.py
@@ -84,7 +84,7 @@ def _setup_logger(name="NuRadioReco", level=None):
 
     Notes
     -----
-    This function is only meant to be called once, on import, as part of the `__init__.py` scripts of the base packages 
+    This function is only meant to be called once, on import, as part of the `__init__.py` scripts of the base packages
     NuRadioReco and NuRadioMC. It is not meant nor necessary to call this function from a module or user script.
 
     Parameters
@@ -130,7 +130,7 @@ def get_fancy_formatter():
     """
     formatter = logging.Formatter(
         '\033[33;20m%(levelname)s - \033[93m%(asctime)s - \033[32m%(name)s - \033[0m%(message)s',
-        datefmt="%Y %b %d @ %H:%M:%S UTC%z"
+        datefmt="%H:%M:%S"
     )
     return formatter
 


### PR DESCRIPTION
I love how the now logging looks! But I feel that the "date and timestamp" is a bit large which decreases readability.

Currently I am for example getting: 
![image](https://github.com/user-attachments/assets/ec0f7cac-47a2-400f-bb19-7007e7cdcec5)

This PR changes it to: 
![image](https://github.com/user-attachments/assets/32f209e2-4aa8-4880-a529-35db3e234782)

Or maybe a good compromise is:
![image](https://github.com/user-attachments/assets/b0efd7b1-f49e-4514-88a6-7726d9e3b662)
