### PR TITLE
Add caching to BaseTrace.get_frequencies()

### DIFF
--- a/NuRadioReco/framework/base_trace.py
+++ b/NuRadioReco/framework/base_trace.py
@@ -4,6 +4,7 @@ import logging
 import fractions
 import decimal
 import numbers
+import functools
 from NuRadioReco.utilities import fft, bandpass_filter
 import NuRadioReco.detector.response
 import scipy.signal
@@ -177,8 +178,7 @@ class BaseTrace:
         return self._trace_start_time
 
     def get_frequencies(self):
-        length = self.get_number_of_samples()
-        return np.fft.rfftfreq(length, d=(1. / self._sampling_rate))
+        return get_frequencies(self.get_number_of_samples(), self._sampling_rate)
 
     def get_hilbert_envelope(self):
         from scipy import signal
@@ -376,3 +376,7 @@ class BaseTrace:
             raise ValueError('Cant divide baseTrace by number because no value is set for trace.')
         else:
             raise TypeError('Division of baseTrace object with object of type {} is not defined'.format(type(x)))
+
+@functools.lru_cache(maxsize=1024)
+def get_frequencies(length, sampling_rate):
+    return np.fft.rfftfreq(length, d=1. / sampling_rate)


### PR DESCRIPTION
Not that this was a bottle neck but why not saving some computing time. A small test with a 2048 sample waveforms improved the speed by a factor of 10 from 1.9us to 180ns. 