### PR TITLE
Add different colors to the different logging levels

### DIFF
--- a/NuRadioReco/utilities/logging.py
+++ b/NuRadioReco/utilities/logging.py
@@ -128,10 +128,37 @@ def get_fancy_formatter():
     -------
     formatter : logging.Formatter
     """
-    formatter = logging.Formatter(
-        '\033[33;20m%(levelname)s - \033[93m%(asctime)s - \033[32m%(name)s - \033[0m%(message)s',
+
+    class CustomFormatter(logging.Formatter):
+
+        def __init__(self, format, datefmt):
+            super().__init__(datefmt=datefmt)
+            grey = "\033[38;1m"
+            yellow = "\033[33;1m"
+            purple = "\033[35;1m"
+            green = "\033[32;1m"
+            red = "\033[31;1m"
+            reset = "\033[0m"
+
+            self.FORMATS = {
+                logging.DEBUG: grey + "%(levelname)s - " + reset + format,
+                logging.INFO: green + "%(levelname)s - " + reset + format,
+                logging.WARNING: purple + "%(levelname)s - " + reset + format,
+                logging.ERROR: red + "%(levelname)s - " + reset + format,
+                logging.CRITICAL: red + "%(levelname)s - " + reset + format
+            }
+
+        def format(self, record):
+            log_fmt = self.FORMATS.get(record.levelno)
+            formatter = logging.Formatter(log_fmt)
+            return formatter.format(record)
+
+
+    formatter = CustomFormatter(
+        format='\033[33m%(asctime)s - \033[32m%(name)s - \033[0m%(message)s',
         datefmt="%H:%M:%S"
     )
+
     return formatter
 
 

--- a/NuRadioReco/utilities/logging.py
+++ b/NuRadioReco/utilities/logging.py
@@ -143,6 +143,7 @@ def get_fancy_formatter():
             self.FORMATS = {
                 logging.DEBUG: grey + "%(levelname)s - " + reset + format,
                 logging.INFO: green + "%(levelname)s - " + reset + format,
+                LOGGING_STATUS: yellow + "%(levelname)s - " + reset + format,
                 logging.WARNING: purple + "%(levelname)s - " + reset + format,
                 logging.ERROR: red + "%(levelname)s - " + reset + format,
                 logging.CRITICAL: red + "%(levelname)s - " + reset + format


### PR DESCRIPTION
This PR adds some different colors to the log level in the logging message. E.g.: 
<img width="1048" alt="image" src="https://github.com/user-attachments/assets/c05f25ba-496c-41e9-b6b1-2dbdff2a3f62">
<img width="1048" alt="image" src="https://github.com/user-attachments/assets/bcf4658b-b2e6-4d46-8d35-38ae2a5161d9">

What is missing is something for the loglevel STATUS