### PR TITLE
remove * units.mV to yield everything in V (to get everything in mV should use: / units.mv)

### DIFF
--- a/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
+++ b/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
@@ -688,7 +688,7 @@ class readRNOGData:
                 selectors=self._select_events)):
 
                 if self._read_calibrated_data:
-                    wfs = wfs * units.mV
+                    wfs = wfs
                 else:
                     # wf stores ADC counts
                     if self._convert_to_voltage:
@@ -788,7 +788,7 @@ class readRNOGData:
         for channel_id, wf in enumerate(waveforms):
             channel = NuRadioReco.framework.channel.Channel(channel_id)
             if self._read_calibrated_data:
-                channel.set_trace(wf * units.mV, sampling_rate * units.GHz)
+                channel.set_trace(wf, sampling_rate * units.GHz)
             else:
                 # wf stores ADC counts
                 if self._convert_to_voltage:

--- a/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
+++ b/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
@@ -688,12 +688,12 @@ class readRNOGData:
                 selectors=self._select_events)):
 
                 if self._read_calibrated_data:
-                    wfs = wfs
+                    wfs = wfs * units.V
                 else:
                     # wf stores ADC counts
                     if self._convert_to_voltage:
                         # convert adc to voltage
-                        wfs = wfs * (self._adc_ref_voltage_range / (2 ** (self._adc_n_bits) - 1))
+                        wfs = wfs * (self._adc_ref_voltage_range / (2 ** (self._adc_n_bits) - 1)) * units.V
 
                 if apply_baseline_correction == 'median':
                     wfs = _baseline_correction(wfs)
@@ -788,12 +788,12 @@ class readRNOGData:
         for channel_id, wf in enumerate(waveforms):
             channel = NuRadioReco.framework.channel.Channel(channel_id)
             if self._read_calibrated_data:
-                channel.set_trace(wf, sampling_rate * units.GHz)
+                channel.set_trace(wf * units.V, sampling_rate * units.GHz)
             else:
                 # wf stores ADC counts
                 if self._convert_to_voltage:
                     # convert adc to voltage
-                    wf = wf * (self._adc_ref_voltage_range / (2 ** (self._adc_n_bits) - 1))
+                    wf = wf * (self._adc_ref_voltage_range / (2 ** (self._adc_n_bits) - 1)) * units.V
 
                 channel.set_trace(wf, sampling_rate * units.GHz)
 

--- a/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
+++ b/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
@@ -693,7 +693,7 @@ class readRNOGData:
                     # wf stores ADC counts
                     if self._convert_to_voltage:
                         # convert adc to voltage
-                        wfs = wfs * (self._adc_ref_voltage_range / (2 ** (self._adc_n_bits) - 1)) * units.V
+                        wfs = wfs * (self._adc_ref_voltage_range / (2 ** (self._adc_n_bits) - 1))
 
                 if apply_baseline_correction == 'median':
                     wfs = _baseline_correction(wfs)
@@ -793,7 +793,7 @@ class readRNOGData:
                 # wf stores ADC counts
                 if self._convert_to_voltage:
                     # convert adc to voltage
-                    wf = wf * (self._adc_ref_voltage_range / (2 ** (self._adc_n_bits) - 1)) * units.V
+                    wf = wf * (self._adc_ref_voltage_range / (2 ** (self._adc_n_bits) - 1))
 
                 channel.set_trace(wf, sampling_rate * units.GHz)
 


### PR DESCRIPTION
When using the rnog reader to loop over waveforms it was noticed that the full calibration (using the voltage calibration coefficients) was of by several orders of magnitude compared to expected values and linear conversion (V = cst * ADC). Using * units.mV seems to be the problem.
This PR changes the reader to always yield results in V. If results in mV are desired,
the  " * units.mV " should be replaced by a " / units.mV " and also added to the linear calibration logic.