### PR TITLE
Remove \d to get rid of SyntaxWarning

### DIFF
--- a/NuRadioReco/detector/RNO_G/db_mongo_read.py
+++ b/NuRadioReco/detector/RNO_G/db_mongo_read.py
@@ -882,8 +882,8 @@ class Database(object):
             supp_info = {k.replace(component + "_", ""): additional_information[k] for k in additional_information
                          if re.search(component, k)}
 
-            if re.search("_\d+", component, re.IGNORECASE):
-                collection_suffix = re.findall("(_\d+)", component, re.IGNORECASE)[0]
+            if re.search("_[0-9]+", component, re.IGNORECASE):
+                collection_suffix = re.findall("(_[0-9]+)", component, re.IGNORECASE)[0]
                 collection_component = component.replace(collection_suffix, "")
             else:
                 collection_component = component

--- a/NuRadioReco/detector/detector.py
+++ b/NuRadioReco/detector/detector.py
@@ -148,7 +148,7 @@ def Detector(*args, **kwargs):
 
         else:
             raise ValueError(f'Unknown source specifed (\"{source}\"). '
-                             f'Must be one of \"json\", \"sql\", "\dictionary\", \"mongo\"')
+                             f'Must be one of \"json\", \"sql\", \"dictionary\", \"mongo\"')
 
         has_reference_entry = _find_reference_entry(station_dict)
 


### PR DESCRIPTION
This is a nitpicky PR, but everytime I import `NuRadioReco.detector.detector` I got a `SyntaxWarning: invalid escape sequence '\d' `. There were two places were this came from:
1. detector.py: A quote and backslash were misplaced, resulting in \d appearing in the string on line 151 (this was just a mistake)
2. db_mongo_read.py: In this case the \d was not a mistake, but rather part of a regex expression. But the \d is equivalent to [0-9], so I replaced this to stop getting the `SyntaxWarning` .
