### PR TITLE
Update detector_base.py: Fix astropy deprecation warning

### DIFF
--- a/NuRadioReco/detector/detector_base.py
+++ b/NuRadioReco/detector/detector_base.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from tinydb_serialization import Serializer
 import six  # # used for compatibility between py2 and py3
 import warnings
-from astropy.utils.exceptions import ErfaWarning
+from erfa import ErfaWarning
 import NuRadioReco.utilities.metaclasses
 
 logger = logging.getLogger('NuRadioReco.detector')


### PR DESCRIPTION
Fix:
```
WARNING: AstropyDeprecationWarning: Importing ErfaWarning from astropy.utils.exceptions was deprecated in version 6.1 and will stop working in a future version. Instead, please use
from erfa import ErfaWarning

 [astropy.utils.exceptions]
```
