### PR TITLE
Make flagged_channels parameter a dict to store flag reasons

### DIFF
--- a/NuRadioReco/framework/parameters.py
+++ b/NuRadioReco/framework/parameters.py
@@ -38,7 +38,7 @@ class stationParameters(Enum):
     distance_correlations = 30
     shower_energy = 31 #: the energy of the shower
     viewing_angles = 32 #: reconstructed viewing angles. A nested map structure. First key is channel id, second key is ray tracing solution id. Value is a float
-    flagged_channels = 60  #: a set of flagged channel ids (calculated by readLOFARData and adjusted by stationRFIFilter)
+    flagged_channels = 60  #: a defaultdict of flagged NRR channel ids with as value a list of the reason(s) for flagging (used in readLOFARData, stationRFIFilter)
     cr_dominant_polarisation = 61  #: the channel orientation containing the dominant cosmic ray signal (calculated by stationPulseFinder)
     dirty_fft_channels = 62  #: a list of FFT channels flagged as RFI (calculated by stationRFIFilter)
 


### PR DESCRIPTION
The LOFAR modules use a station parameter to store bad station ids. Previously this was just a list of channel IDs, but this change makes it a dictionary to store a list of flags per channel.

Note: this is a pure cosmetic change, as I only change the comment associated to the parameter. But this way PR #656 stays clean of any changes to the core NRR code