### PR TITLE
Add option to get all channel_group_ids to Station object

### DIFF
--- a/NuRadioReco/framework/station.py
+++ b/NuRadioReco/framework/station.py
@@ -125,7 +125,7 @@ class Station(NuRadioReco.framework.base_station.BaseStation):
             List of all channel ids
         """
         if return_group_ids:
-            channel_ids = {} # we use a set to avoid duplicates
+            channel_ids = set() # we use a set to avoid duplicates
             for channel in self.iter_channels():
                 channel_ids.add(channel.get_group_id())
         else:

--- a/NuRadioReco/framework/station.py
+++ b/NuRadioReco/framework/station.py
@@ -108,8 +108,30 @@ class Station(NuRadioReco.framework.base_station.BaseStation):
     def get_number_of_channels(self):
         return len(self.__channels)
 
-    def get_channel_ids(self):
-        return list(self.__channels.keys())
+    def get_channel_ids(self, return_group_ids=False):
+        """
+        Return all channel ids in the station
+
+        Parameters
+        ----------
+        return_group_ids : bool, default: False
+            If True, return a list of channel_group_ids
+            instead of channel ids. Note that if no channel group ids
+            are defined, these are the same as the channel ids
+
+        Returns
+        -------
+        channel_ids : list
+            List of all channel ids
+        """
+        if return_group_ids:
+            channel_ids = {} # we use a set to avoid duplicates
+            for channel in self.iter_channels():
+                channel_ids.add(channel.get_group_id())
+        else:
+            channel_ids = self.__channels.keys()
+
+        return list(channel_ids)
 
     def add_channel(self, channel):
         self.__channels[channel.get_id()] = channel


### PR DESCRIPTION
Adds the option to get group_ids from `station.get_channel_ids` through the optional kwarg `return_group_ids`.

For stations without group_ids, this flag doesn't change anything. 