### PR TITLE
Hotfix: Add empty channels also if config[noise] is false and the cha…

### DIFF
--- a/NuRadioMC/simulation/output_writer_hdf5.py
+++ b/NuRadioMC/simulation/output_writer_hdf5.py
@@ -444,13 +444,15 @@ class outputWriterHDF5:
         if 'shower_ids' not in self._mout or len(self._mout['shower_ids']) == 0:
             logger.warning("no events to save, not writing output file")
             return False
+
         folder = os.path.dirname(self._output_filename)
         if not os.path.exists(folder) and folder != '':
             logger.warning(f"output folder {folder} does not exist, creating folder...")
             os.makedirs(folder)
+
+        logger.status("Start saving events to hdf5 ...")
         fout = h5py.File(self._output_filename, 'w')
 
-        logger.status("start saving events")
         # save data sets
         # all arrays need to be sorted by shower id
         sort = np.argsort(np.array(self._mout['shower_ids']))
@@ -471,7 +473,7 @@ class outputWriterHDF5:
             sort = np.argsort(np.array(value['shower_id']))
             for (key2, value2) in value.items():
                 # a few arrays are counting values for different events, so we need to sort them
-                if(key2 not in keys_per_event):
+                if key2 not in keys_per_event:
                     sg[key2] = np.array(value2)[sort]
                 else:
                     sg[key2] = np.array(value2)
@@ -483,13 +485,19 @@ class outputWriterHDF5:
         #     with open(self._detectorfile, 'r') as fdet:
         #         fout.attrs['detector'] = fdet.read()
 
-        # save antenna position separately to hdf5 output
+
+        # Save station level attributes
         for station_id in self._mout_groups:
             n_channels = self._det.get_number_of_channels(station_id)
             positions = np.zeros((n_channels, 3))
             for iCh, channel_id in enumerate(self._det.get_channel_ids(station_id)):
                 positions[iCh] = self._det.get_relative_position(station_id, channel_id) + self._det.get_absolute_position(station_id)
             fout[f"station_{station_id:d}"].attrs['antenna_positions'] = positions
+            for key in self._mout_groups_attributes[station_id]:
+                if key not in fout[f"station_{station_id:d}"].attrs:
+                    fout[f"station_{station_id:d}"].attrs[key] = self._mout_groups_attributes[station_id][key]
+
+        # Store top level attributes
         fout.attrs['config'] = yaml.dump(self._mout_attributes['config'])
 
         # save NuRadioMC and NuRadioReco versions
@@ -502,6 +510,7 @@ class outputWriterHDF5:
                     fout.attrs[key] = self._mout_attributes[key]
                 else:
                     logger.warning(f"attribute {key} is None, not saving it")
+
         fout.close()
         return True
 

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -1565,19 +1565,12 @@ class simulation:
                         logger.debug(f"adding sim_station to station {station_id} for event group {event_group.get_run_number()}, channel {channel_id}")
                         station.add_sim_station(sim_station)  # this will add the channels and efields to the existing sim_station object
                         for evt in output_buffer[station_id].values():
-                            # we need to use any existing channel to get the correct trace_start_time. All channels have the same start time at the end
-                            # of the simulation.
-                            trace_start_time = evt.get_station().get_channel(channel_ids[0]).get_trace_start_time()
-                            # # determine the trigger that was used to determine the readout window
+                            # determine the trigger that was used to determine the readout window
 
                             for sim_channel in sim_station.get_channels_by_channel_id(channel_id):
                                 if not station.has_channel(sim_channel.get_id()):
                                     # add empty channel with the correct length and time if it doesn't exist yet.
-                                    channel = NuRadioReco.framework.channel.Channel(channel_id)
-                                    n_samples = int(round(self._det.get_number_of_samples(station_id, channel_id)) * self._config['sampling_rate'] / self._det.get_sampling_frequency(station_id, sim_channel.get_id()))
-                                    channel.set_trace(np.zeros(n_samples), self._config['sampling_rate'])
-                                    channel.set_trace_start_time(trace_start_time)
-                                    station.add_channel(channel)
+                                    self._add_empty_channel(station, channel_id)
 
                                 # Add the sim_channel to the station channel:
                                 channel = station.get_channel(sim_channel.get_id())
@@ -1588,26 +1581,24 @@ class simulation:
                                 channel.add_to_trace(sim_channel_copy)
 
                 for evt in output_buffer[station_id].values():
+                    # we might not have a channel object in case there was no ray tracing solution to this channel, or if the timing did not match
+                    # the readout window. In this case we need to create a channel object and add it to the station
+                    for channel_id in non_trigger_channels:
+                        if not station.has_channel(channel_id):
+                            self._add_empty_channel(station, channel_id)
+
                     # the only thing left is to add noise to the non-trigger traces
-                    # we need to do it a bit differently than for the trigger traces, because we need to add noise to traces where the amplifier response
+                    # we need to do it a bit differently than for the trigger traces,
+                    # because we need to add noise to traces where the amplifier response
                     # was already applied to.
                     station = evt.get_station()
                     if bool(self._config['noise']):
                         for channel_id in non_trigger_channels:
+                            channel = station.get_channel(channel_id)
+
                             if channel_id in self._noiseless_channels[station_id]:
                                 continue
-                            # we might not have a channel object in case there was no ray tracing solution to this channel, or if the timing did not match
-                            # the readout window. In this case we need to create a channel object and add it to the station
-                            if station.has_channel(channel_id):
-                                channel = station.get_channel(channel_id)
-                            else:
-                                channel = NuRadioReco.framework.channel.Channel(channel_id)
-                                n_samples = int(round(self._det.get_number_of_samples(station_id, channel_id)) * self._config['sampling_rate'] / self._det.get_sampling_frequency(station_id, channel_id))
-                                channel.set_trace(np.zeros(n_samples), self._config['sampling_rate'])
-                                # we need to use any other channel to get the correct trace_start_time. All channels have the same start time at the end
-                                # of the simulation.
-                                channel.set_trace_start_time(station.get_channel(station.get_channel_ids()[0]).get_trace_start_time())
-                                station.add_channel(channel)
+
                             # logger.status(f"norm  = {norm}, Vrms = {Vrms[channel_id]}, max_freq = {max_freq}")
                             ff = channel.get_frequencies()
                             filt = np.ones_like(ff, dtype=complex)
@@ -1660,6 +1651,16 @@ class simulation:
             logger.warning("No events were triggered. Writing empty HDF5 output file.")
             self._output_writer_hdf5.write_empty_output_file(self._fin_attrs)
 
+    def _add_empty_channel(self, station, channel_id):
+        """ Adds a channel with an empty trace (all zeros) to the station with the correct length and trace_start_time """
+        channel = NuRadioReco.framework.channel.Channel(channel_id)
+        n_samples = int(round(self._det.get_number_of_samples(station.get_id(), channel_id))
+                        * self._config['sampling_rate'] / self._det.get_sampling_frequency(station.get_id(), channel_id))
+        channel.set_trace(np.zeros(n_samples), self._config['sampling_rate'])
+        # we need to use any other channel to get the correct trace_start_time. All channels have the same start time at the end
+        # of the simulation.
+        channel.set_trace_start_time(station.get_channel(station.get_channel_ids()[0]).get_trace_start_time())
+        station.add_channel(channel)
 
     def _is_in_fiducial_volume(self, pos):
         """ Checks if pos is in fiducial volume """


### PR DESCRIPTION
…nnel is noiseless.

In certain situations missing channels (because of no raytracing solution) were not added to the station at the end. This PR fixes that. I also added a helper function `_add_empty_channel` to avoid code duplication. 

Edit: I also added a commit to store the station-level attributes in the hdf5 files. I think this got maybe lost in the refactoring?
