### PR TITLE
Clean up voltageToEfieldConverter and use exact solution if possible

### DIFF
--- a/NuRadioReco/modules/voltageToEfieldConverter.py
+++ b/NuRadioReco/modules/voltageToEfieldConverter.py
@@ -101,7 +101,14 @@ def stacked_lstsq(L, b, rcond=1e-10):
     Note that if L is symmetric, it is inverted analytically instead.
     """
     if L.shape[-2] == L.shape[-1]: # try analytic matrix inversion if possible
-        return np.sum(np.linalg.inv(L) * b[:, None], axis=-1)
+
+        if L.shape[-1] == 2: # use explicit formula for matrix inverse
+            denom = (L[:,0,0] * L[:,1,1] - L[:,0,1] * L[:,1,0])
+            e_theta = (b[:,0] * L[:,1,1] - b[:,1] * L[:,0,1]) / denom
+            e_phi = (b[:,1] - L[:,1,0] * e_theta) / L[:,1,1]
+            return np.stack((e_theta, e_phi), axis=-1)
+        else:
+            return np.sum(np.linalg.inv(L) * b[:, None], axis=-1)
 
     u, s, v = np.linalg.svd(L, full_matrices=False)
     s_max = s.max(axis=-1, keepdims=True)

--- a/NuRadioReco/modules/voltageToEfieldConverter.py
+++ b/NuRadioReco/modules/voltageToEfieldConverter.py
@@ -143,16 +143,16 @@ class voltageToEfieldConverter:
 
         Parameters
         ----------
-        evt
-        station
-        det
+        evt : `NuRadioReco.framework.event.Event`
+        station : `NuRadioReco.framework.base_station.BaseStation`
+        det : Detector object
         use_channels: array of ints (default: [0, 1, 2, 3])
             the channel ids to use for the electric field reconstruction
         use_MC_direction: bool, default: False
-            if True uses zenith and azimuth direction from simulated station
-            if False uses reconstructed direction from station parameters.
+            If True uses zenith and azimuth direction from simulated station.
+            Otherwise, uses reconstructed direction from station parameters.
         force_Polarization: str, optional
-            if eTheta or ePhi, then only reconstructs chosen polarization of electric field,
+            If eTheta or ePhi, then only reconstructs chosen polarization of electric field,
             assuming the other is 0. Otherwise (default), reconstructs electric field for both eTheta and ePhi
         """
         if use_channels is None:
@@ -169,7 +169,7 @@ class voltageToEfieldConverter:
 
         efield_antenna_factor, V = get_array_of_channels(station, use_channels, det, zenith, azimuth, self.antenna_provider)
         n_frequencies = len(V[0])
-        denom = (efield_antenna_factor[0][0] * efield_antenna_factor[1][1] - efield_antenna_factor[0][1] * efield_antenna_factor[1][0])
+        denom = (efield_antenna_factor[0][0] * efield_antenna_factor[-1][1] - efield_antenna_factor[0][1] * efield_antenna_factor[-1][0])
         mask = np.abs(denom) != 0
 
         # solve it in a vectorized way

--- a/NuRadioReco/modules/voltageToEfieldConverter.py
+++ b/NuRadioReco/modules/voltageToEfieldConverter.py
@@ -173,17 +173,13 @@ class voltageToEfieldConverter:
         mask = np.abs(denom) != 0
 
         # solve it in a vectorized way
-        efield3_f = np.zeros((2, n_frequencies), dtype=complex)
+        efield3_f = np.zeros((3, n_frequencies), dtype=complex)
         if force_Polarization == 'eTheta':
-            efield3_f[:1, mask] = np.moveaxis(stacked_lstsq(np.moveaxis(efield_antenna_factor[:, 0, mask], 1, 0)[:, :, np.newaxis], np.moveaxis(V[:, mask], 1, 0)), 0, 1)
+            efield3_f[1:2, mask] = np.moveaxis(stacked_lstsq(np.moveaxis(efield_antenna_factor[:, 0, mask], 1, 0)[:, :, np.newaxis], np.moveaxis(V[:, mask], 1, 0)), 0, 1)
         elif force_Polarization == 'ePhi':
-            efield3_f[1:, mask] = np.moveaxis(stacked_lstsq(np.moveaxis(efield_antenna_factor[:, 1, mask], 1, 0)[:, :, np.newaxis], np.moveaxis(V[:, mask], 1, 0)), 0, 1)
+            efield3_f[2:, mask] = np.moveaxis(stacked_lstsq(np.moveaxis(efield_antenna_factor[:, 1, mask], 1, 0)[:, :, np.newaxis], np.moveaxis(V[:, mask], 1, 0)), 0, 1)
         else:
-            efield3_f[:, mask] = np.moveaxis(stacked_lstsq(np.moveaxis(efield_antenna_factor[:, :, mask], 2, 0), np.moveaxis(V[:, mask], 1, 0)), 0, 1)
-        # add eR direction
-        efield3_f = np.array([np.zeros_like(efield3_f[0], dtype=complex),
-                             efield3_f[0],
-                             efield3_f[1]])
+            efield3_f[1:, mask] = np.moveaxis(stacked_lstsq(np.moveaxis(efield_antenna_factor[:, :, mask], 2, 0), np.moveaxis(V[:, mask], 1, 0)), 0, 1)
 
         efield_position = np.mean([
             det.get_relative_position(station.get_id(), channel_id)

--- a/NuRadioReco/modules/voltageToEfieldConverter.py
+++ b/NuRadioReco/modules/voltageToEfieldConverter.py
@@ -185,7 +185,11 @@ class voltageToEfieldConverter:
                              efield3_f[0],
                              efield3_f[1]])
 
-        electric_field = NuRadioReco.framework.electric_field.ElectricField(use_channels, [0, 0, 0])
+        efield_position = np.mean([
+            det.get_relative_position(station.get_id(), channel_id)
+            for channel_id in use_channels], axis=0)
+
+        electric_field = NuRadioReco.framework.electric_field.ElectricField(use_channels, efield_position)
         electric_field.set_frequency_spectrum(efield3_f, station.get_channel(use_channels[0]).get_sampling_rate())
         electric_field.set_parameter(efp.zenith, zenith)
         electric_field.set_parameter(efp.azimuth, azimuth)


### PR DESCRIPTION
Removes some unused code from the voltageToEfieldConverter, and uses the exact solution for the matrix inversion in the case of only two antennas. This was previously discussed in #527. It is useful e.g. for LOFAR where unfolding is always done per antenna pair. The output is unchanged, but it makes things a bit quicker (the inversion is sped up by ~a factor 2)

MWE below to demonstrate that the output is unchanged:
```
import numpy as np
from NuRadioReco.utilities import fft

def stacked_lstsq(L, b, rcond=1e-10): # old version of the function
    """
    Solve L x = b, via SVD least squares cutting of small singular values
    L is an array of shape (..., M, N) and b of shape (..., M).
    Returns x of shape (..., N)
    """
    u, s, v = np.linalg.svd(L, full_matrices=False)
    s_max = s.max(axis=-1, keepdims=True)
    s_min = rcond * s_max
    inv_s = np.zeros_like(s)
    inv_s[s >= s_min] = 1 / s[s >= s_min]
    x = np.einsum('...ji,...j->...i', v,
                  inv_s * np.einsum('...ji,...j->...i', u, b.conj()))
    return np.conj(x, x)

def solve_2x2(L, b):
    denom = (L[:,0,0] * L[:,1,1] - L[:,0,1] * L[:,1,0])
    e_theta = (b[:,0] * L[:,1,1] - b[:,1] * L[:,0,1]) / denom
    e_phi = (b[:,1] - L[:,1,0] * e_theta) / L[:,1,1]
    return np.stack((e_theta, e_phi), axis=-1)


np.random.seed(1234)
L = np.random.normal(size=(1025, 2, 2)) + 1.j * np.random.normal(size=(1025, 2, 2))
b = fft.time2freq(np.random.normal(size=(2, 2048)), sampling_rate=2).T

sol_svd = stacked_lstsq(L, b)
sol_ana = np.sum(np.linalg.inv(L)* b[:, None], axis=-1)
sol_ana_2x2 = solve_2x2(L, b)

print(np.allclose(sol_svd, sol_ana, rtol=1e-8, atol=1e-8))
print(np.allclose(sol_svd, sol_ana_2x2, rtol=1e-8, atol=1e-8))
>>> True
>>> True
```