### PR TITLE
Lofar/add pipeline plots

### DIFF
--- a/NuRadioReco/modules/LOFAR/pipelineVisualizer_LOFAR.py
+++ b/NuRadioReco/modules/LOFAR/pipelineVisualizer_LOFAR.py
@@ -334,7 +334,7 @@ class pipelineVisualizer:
             # plot absolute station positions
             if station.get_parameter(stationParameters.triggered):
                 station_pos = detector.get_absolute_position(station.get_id())
-                ax.scatter(station_pos[0], station_pos[1], color=cmap(norm(i)), s=20, label=f'CS{station.get_id():03d}')
+                ax.scatter(station_pos[0], station_pos[1], color=cmap(norm(i)), s=20, marker = "*", label=f'CS{station.get_id():03d}')
                 i+=1
 
 


### PR DESCRIPTION
The module modules/LOFAR/pipelineVisualization_LOFAR.py creates some nice plots at the end of the pipeline, i.e. the polarisation of antennas, the reconstructed arrival directions for all stations and also the fluence/timing/direction plot. Unless otherwise specified, it saves the plots in the current working directory. Furthermore it raises warnings if the polarisations in single antennas are very off or if the event time was before the outer station clocks were synced with the core station clocks.