### PR TITLE
add page for LOFAR and experiment-specific features

### DIFF
--- a/documentation/source/Experiments/lofar/overview.rst
+++ b/documentation/source/Experiments/lofar/overview.rst
@@ -1,0 +1,11 @@
+LOFAR
+=====
+
+NuRadioReco is also used for analysis of LOFAR data. To this end, it
+includes some LOFAR-specific modules.
+
+To **read** LOFAR data, use the :py:mod:`readLOFARData <NuRadioReco.modules.io.LOFAR.readLOFARData>`
+module.
+
+For analysis and reconstruction of LOFAR data, we use the modules in
+:py:mod:`NuRadioReco.modules.LOFAR <NuRadioReco.modules.LOFAR>`

--- a/documentation/source/Experiments/welcome_page.rst
+++ b/documentation/source/Experiments/welcome_page.rst
@@ -1,0 +1,16 @@
+Experiment-specific features
+============================
+
+NuRadioMC (and NuRadioReco) are used by several different experiments.
+To facilitate this, NuRadioReco contains several experiment-specific
+features. Most of these are included under ``NuRadioReco.modules.<EXPERIMENT>``
+for analysis features, and readers for the raw experiment data under
+``NuRadioReco.modules.io.<EXPERIMENT>``.
+
+More information about the features available for each experiment
+are available on the pages below.
+
+.. toctree::
+    :maxdepth: 1
+
+    lofar/overview

--- a/documentation/source/main.rst
+++ b/documentation/source/main.rst
@@ -13,6 +13,7 @@ Welcome to NuRadio's documentation!
    Introduction/pages/welcome_page.rst
    NuRadioReco/pages/welcome_page.rst
    NuRadioMC/pages/welcome_page.rst
+   Experiments/welcome_page.rst
 
 Indices and tables
 ==================


### PR DESCRIPTION
I've added another page to the NuRadioMC documentation for 'experiment-specific features'. The intention is that different experiments (potentially also RNO-G?) can add documentation and examples relevant for their experiment.