### PR TITLE
add missing import statement modules/base/module.py 

### DIFF
--- a/NuRadioReco/modules/base/module.py
+++ b/NuRadioReco/modules/base/module.py
@@ -3,6 +3,7 @@ from timeit import default_timer as timer
 import NuRadioReco.framework.event
 import NuRadioReco.framework.base_station
 import NuRadioReco.detector.detector_base
+import NuRadioReco.detector.RNO_G.rnog_detector
 import inspect
 import pickle
 

--- a/NuRadioReco/modules/base/module.py
+++ b/NuRadioReco/modules/base/module.py
@@ -2,8 +2,7 @@ from functools import wraps
 from timeit import default_timer as timer
 import NuRadioReco.framework.event
 import NuRadioReco.framework.base_station
-import NuRadioReco.detector.detector_base
-import NuRadioReco.detector.RNO_G.rnog_detector
+import NuRadioReco.detector.detector as detectors
 import inspect
 import pickle
 
@@ -75,7 +74,7 @@ def register_run(level=None):
                 # station should be second argument
                 elif isinstance(value, NuRadioReco.framework.base_station.BaseStation) and idx == 1:
                     station = value
-                elif isinstance(value, (NuRadioReco.detector.detector_base.DetectorBase, NuRadioReco.detector.RNO_G.rnog_detector.Detector)):
+                elif isinstance(value, (detectors.detector_base.DetectorBase, detectors.rnog_detector.Detector)):
                     pass # we don't try to store detectors
                 else: # we try to store other arguments IF they are pickleable
                     try:


### PR DESCRIPTION
There was a missing import statement in modules/base/module.py, which sometimes caused an error in line 77 of the file. With this PR the missing import statement is added.