### PR TITLE
Allow response class to take freq list

### DIFF
--- a/NuRadioReco/detector/response.py
+++ b/NuRadioReco/detector/response.py
@@ -227,7 +227,7 @@ class Response:
                     if name not in component_names:  # if name *not* in whitelist skip
                         continue
 
-            _gain = gain(freq / units.GHz)
+            _gain = gain([f / units.GHz for f in freq])
 
             # to avoid RunTime warning and NANs in total reponse
             if weight == -1:

--- a/NuRadioReco/detector/response.py
+++ b/NuRadioReco/detector/response.py
@@ -213,6 +213,9 @@ class Response:
         """
         response = np.ones_like(freq, dtype=np.complex128)
 
+        if type(freq) is list:
+            freq = np.array(freq)
+
         if component_names is not None:
             if isinstance(component_names, str):
                 component_names = [component_names]
@@ -227,7 +230,7 @@ class Response:
                     if name not in component_names:  # if name *not* in whitelist skip
                         continue
 
-            _gain = gain([f / units.GHz for f in freq])
+            _gain = gain(freq / units.GHz)
 
             # to avoid RunTime warning and NANs in total reponse
             if weight == -1:

--- a/NuRadioReco/detector/response.py
+++ b/NuRadioReco/detector/response.py
@@ -213,8 +213,7 @@ class Response:
         """
         response = np.ones_like(freq, dtype=np.complex128)
 
-        if type(freq) is list:
-            freq = np.array(freq)
+        freq = np.asarray(freq)
 
         if component_names is not None:
             if isinstance(component_names, str):


### PR DESCRIPTION
I noticed that when defining a detector object using Detector from NuRadioReco.detector.RNO_G.rnog_detector and getting the signal chain response it only allows calling the response with frequencies in an array and crashes when passing frequencies in a lisr. Not sure how useful this is to people but I made a very minor change to allow for also passing "pure" python lists. The code now converts the list to a numpy array before applying the rest of the call method.

Code to reproduce original problem:

```
import datetime
from NuRadioReco.detector.RNO_G.rnog_detector import Detector

detector = Detector(select_stations=24)
detector_time = datetime.datetime(2022, 8, 1)
detector.update(detector_time)

station_id = 24
channel_id = 0
frequencies = [0.3, 0.4, 0.5]
det_resp = self.detector.get_signal_chain_response(station_id, channel_id)
det_resp = det_resp(frequencies)
print(det_resp)
```
