### PR TITLE
[CI] Change default Python version to 3.10

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -19,10 +19,10 @@ jobs:
         ref: 'refs/heads/master'
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.10
     - name: Cache pip
       uses: actions/cache@v4
       with:

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Cache pip
       uses: actions/cache@v4
       with:

--- a/.github/workflows/deploy_documentation.yaml
+++ b/.github/workflows/deploy_documentation.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Cache pip
         uses: actions/cache@v4

--- a/.github/workflows/deploy_documentation.yaml
+++ b/.github/workflows/deploy_documentation.yaml
@@ -13,10 +13,10 @@ jobs:
         with:
           ref: 'refs/heads/develop'
       - uses: actions/checkout@v4
-      - name: Set up Python 3.7
+      - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.10
 
       - name: Cache pip
         uses: actions/cache@v4

--- a/.github/workflows/python_version_compatibility.yaml
+++ b/.github/workflows/python_version_compatibility.yaml
@@ -12,11 +12,15 @@ jobs:
     strategy:
       fail-fast: false # continue even if one of the versions fails
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11", "3.x"] # 3.x = latest available
+        python_version: ["3.9", "3.11", "3.x"] # 3.x = latest available
         os: [ubuntu-latest]
         include:
           - python_version: "3.6"
             os: ubuntu-20.04 # python 3.6 is not available with 22.04 on github actions
+          - python_version: "3.7"
+            os: ubuntu-22.04
+          - python_version: "3.8" # technically available on 24.04 but not pre-installed
+            os: ubuntu-22.04
     uses: ./.github/workflows/run_tests.yaml
     with:
       python_version: ${{ matrix.python_version }}

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -9,7 +9,7 @@ on:
         description: Specify Python version to run tests on
         type: string
         required: true
-        default: '3.7'
+        default: '3.10'
       os:
         description: OS to run tests on
         type: string
@@ -20,14 +20,14 @@ on:
         description: Specify Python version to run tests on
         type: string
         required: true
-        default: '3.7'
+        default: '3.10'
       os:
         description: OS to run tests on
         type: string
         default: ubuntu-latest
 
-env: # set the python_version to 3.7 if the workflow is not triggered by workflow_call or workflow_dispatch
-  PYTHON_VERSION: ${{ inputs.python_version || '3.7' }}
+env: # set the python_version to 3.10 if the workflow is not triggered by workflow_call or workflow_dispatch
+  PYTHON_VERSION: ${{ inputs.python_version || '3.10' }}
 
 jobs:
   build:


### PR DESCRIPTION
`ubuntu-latest` has transitioned to 24.04, which no longer supports our default Python version of 3.7. This PR changes the default CI Python version to 3.10. Older Python versions are still tested on pushes to `develop` as before (by manually specifying older versions of Ubuntu).

Note that this change will need to make it into the next release on `master` as well, as the release to PyPI will fail otherwise.