### PR TITLE
Change default to disallow overwritting channel objects in Station

### DIFF
--- a/NuRadioReco/framework/station.py
+++ b/NuRadioReco/framework/station.py
@@ -30,7 +30,7 @@ class Station(NuRadioReco.framework.base_station.BaseStation):
 
     def add_sim_station(self, sim_station):
         """
-        Adds a SimStation to the Station. If a SimStation is already present, 
+        Adds a SimStation to the Station. If a SimStation is already present,
         the new SimStation is merged to the existing one.
 
         Parameters
@@ -67,8 +67,8 @@ class Station(NuRadioReco.framework.base_station.BaseStation):
 
     def iter_channels(self, use_channels=None, sorted=False):
         """
-        Iterates over all channels of the station. If `use_channels` is not None, 
-        only the channels with the ids in `use_channels` are iterated over. If `sorted` 
+        Iterates over all channels of the station. If `use_channels` is not None,
+        only the channels with the ids in `use_channels` are iterated over. If `sorted`
         is True, the channels are iterated over in ascending order of their ids.
 
         Parameters
@@ -135,7 +135,7 @@ class Station(NuRadioReco.framework.base_station.BaseStation):
 
         return list(channel_ids)
 
-    def add_channel(self, channel, overwrite=True):
+    def add_channel(self, channel, overwrite=False):
         """
         Adds a channel to the station. If a channel with the same id is already present, it is overwritten.
 
@@ -144,7 +144,7 @@ class Station(NuRadioReco.framework.base_station.BaseStation):
         channel : `NuRadioReco.framework.channel.Channel`
             The channel to add to the station.
         overwrite : bool, (Default: True)
-            If True, allow to overwrite an existing channel (i.e., a channel with the same id). 
+            If True, allow to overwrite an existing channel (i.e., a channel with the same id).
             If False, raise AttributeError if a channel with the same id is being added.
         """
         if not isinstance(channel, NuRadioReco.framework.channel.Channel):
@@ -190,7 +190,7 @@ class Station(NuRadioReco.framework.base_station.BaseStation):
             return self.get_parameter('zenith'), self.get_parameter('azimuth')
         if self.__reference_reconstruction == 'MC':
             return (
-                self.get_sim_station().get_parameter('zenith'), 
+                self.get_sim_station().get_parameter('zenith'),
                 self.get_sim_station().get_parameter('azimuth')
             )
 

--- a/NuRadioReco/test/trigger_tests/trigger_tests.py
+++ b/NuRadioReco/test/trigger_tests/trigger_tests.py
@@ -30,6 +30,11 @@ hardware_response_incorporator = NuRadioReco.modules.ARIANNA.hardwareResponseInc
 
 for event in event_reader.run():
     station = event.get_station(1)
+
+    # First remove channels to reproduce them with the efieldToVoltageConverter
+    for chid in station.get_channel_ids():
+        station.remove_channel(chid)
+
     efield_to_voltage_converter.run(event, station, det)
     hardware_response_incorporator.run(event, station, det, True)
     high_low_trigger.run(event, station, det, threshold_high=40 * units.mV, threshold_low=-40 * units.mV)


### PR DESCRIPTION
See PR #787 for an explanation. 
