### PR TITLE
Fix trigger time and readout delays set by the readRNOGDataMattak module

### DIFF
--- a/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
+++ b/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
@@ -775,7 +775,6 @@ class readRNOGData:
         evt = NuRadioReco.framework.event.Event(event_info.run, event_info.eventNumber)
         station = NuRadioReco.framework.station.Station(event_info.station)
         station.set_station_time(astropy.time.Time(trigger_time, format='unix'))
-        evt.set_event_time(astropy.time.Time(trigger_time, format='unix'))  # Typically event time = station time
 
         trigger = NuRadioReco.framework.trigger.Trigger(event_info.triggerType)
         trigger.set_triggered()


### PR DESCRIPTION
to the NuRadio convention: The trigger time is not not absolute anymore but relative to the station/event time. It also now read outs and applies the readoutDelays which are stored along side the data.

This PR corrects for the convention correctly documented with PR #773.

What is yet missing is a verification whether the "intrinsic" readout delays are correctly represented with function `get_time_offset`. Furthermore, we have to fix the `Event` class to not store Astropy objects in nur files.