### PR TITLE
Implement sub nanosecond precision for station and event time in nur files

### DIFF
--- a/NuRadioReco/framework/base_station.py
+++ b/NuRadioReco/framework/base_station.py
@@ -344,7 +344,7 @@ class BaseStation():
         for efield in self.get_electric_fields():
             efield_pkls.append(efield.serialize(save_trace=save_efield_traces))
 
-        station_time_dict = io_utilities.astropy_to_dict(self.get_station_time())
+        station_time_dict = io_utilities._astropy_to_dict(self.get_station_time())
 
         data = {'_parameters': NuRadioReco.framework.parameter_serialization.serialize(self._parameters),
                 '_parameter_covariances': NuRadioReco.framework.parameter_serialization.serialize_covariances(self._parameter_covariances),
@@ -383,7 +383,7 @@ class BaseStation():
 
         self._station_id = data['_station_id']
         if data['_station_time'] is not None:
-            station_time = io_utilities.time_object_to_astropy(data['_station_time'])
+            station_time = io_utilities._time_object_to_astropy(data['_station_time'])
             self.set_station_time(station_time)
 
         self._particle_type = data['_particle_type']

--- a/NuRadioReco/framework/base_station.py
+++ b/NuRadioReco/framework/base_station.py
@@ -3,16 +3,19 @@ import NuRadioReco.framework.base_trace
 import NuRadioReco.framework.trigger
 import NuRadioReco.framework.electric_field
 import NuRadioReco.framework.parameters as parameters
+import NuRadioReco.framework.parameter_serialization
+
+from NuRadioReco.utilities import io_utilities
+
 import datetime
 import astropy.time
-import NuRadioReco.framework.parameter_serialization
+import logging
+import collections
 
 try:
     import cPickle as pickle
 except ImportError:
     import pickle
-import logging
-import collections
 
 logger = logging.getLogger('NuRadioReco.BaseStation')
 
@@ -119,13 +122,6 @@ class BaseStation():
 
         self._station_time.format = format
         return self._station_time
-
-    def get_station_time_dict(self):
-        """ Return the station time as dict {value, format}. Used for reading and writing """
-        if self._station_time is None:
-            return None
-        else:
-            return {'value': self._station_time.value, 'format': self._station_time.format}
 
     def get_id(self):
         return self._station_id
@@ -348,7 +344,7 @@ class BaseStation():
         for efield in self.get_electric_fields():
             efield_pkls.append(efield.serialize(save_trace=save_efield_traces))
 
-        station_time_dict = self.get_station_time_dict()
+        station_time_dict = io_utilities.astropy_to_dict(self.get_station_time())
 
         data = {'_parameters': NuRadioReco.framework.parameter_serialization.serialize(self._parameters),
                 '_parameter_covariances': NuRadioReco.framework.parameter_serialization.serialize_covariances(self._parameter_covariances),
@@ -387,12 +383,8 @@ class BaseStation():
 
         self._station_id = data['_station_id']
         if data['_station_time'] is not None:
-            if isinstance(data['_station_time'], dict):
-                station_time = astropy.time.Time(data['_station_time']['value'], format=data['_station_time']['format'])
-                self.set_station_time(station_time)
-            # For backward compatibility, we also keep supporting station times stored as astropy.time objects
-            else:
-                self.set_station_time(data['_station_time'])
+            station_time = io_utilities.time_object_to_astropy(data['_station_time'])
+            self.set_station_time(station_time)
 
         self._particle_type = data['_particle_type']
 

--- a/NuRadioReco/framework/base_station.py
+++ b/NuRadioReco/framework/base_station.py
@@ -78,11 +78,9 @@ class BaseStation():
     def set_station_time(self, time, format=None):
         """
         Set the (absolute) time for the station (stored as astropy.time.Time).
-        Not related to the event._event_time.
 
         Parameters
         ----------
-
         time: astropy.time.Time or datetime.datetime or float
             If "time" is a float, you have to specify its format.
 
@@ -97,6 +95,9 @@ class BaseStation():
         elif time is None:
             self._station_time = None
         else:
+            if format is None:
+                logger.error("If you provide a float for the time, you have to specify the format.")
+                raise ValueError("If you provide a float for the time, you have to specify the format.")
             self._station_time = astropy.time.Time(time, format=format)
 
     def get_station_time(self, format='isot'):
@@ -105,7 +106,6 @@ class BaseStation():
 
         Parameters
         ----------
-
         format: str
             Format in which the time object is displayed. (Default: isot)
 

--- a/NuRadioReco/framework/event.py
+++ b/NuRadioReco/framework/event.py
@@ -6,7 +6,8 @@ import NuRadioReco.framework.sim_emitter
 import NuRadioReco.framework.hybrid_information
 import NuRadioReco.framework.particle
 import NuRadioReco.framework.parameters as parameters
-import NuRadioReco.utilities.version
+
+from NuRadioReco.utilities import io_utilities, version
 
 import astropy.time
 import datetime
@@ -542,7 +543,7 @@ class Event:
     def serialize(self, mode):
         stations_pkl = []
         try:
-            commit_hash = NuRadioReco.utilities.version.get_NuRadioMC_commit_hash()
+            commit_hash = version.get_NuRadioMC_commit_hash()
             self.set_parameter(parameters.eventParameters.hash_NuRadioMC, commit_hash)
         except:
             logger.warning("Event is serialized without commit hash!")

--- a/NuRadioReco/framework/event.py
+++ b/NuRadioReco/framework/event.py
@@ -570,10 +570,12 @@ class Event:
                 if len(invalid_keys):
                     logger.warning(f"The following arguments to module {value[0]} could not be serialized and will not be stored: {invalid_keys}")
 
+        event_time_dict = io_utilities.astropy_to_dict(self.__event_time)
+
         data = {'_parameters': self._parameters,
                 '__run_number': self.__run_number,
                 '_id': self._id,
-                '__event_time': self.__event_time,
+                '__event_time': event_time_dict,
                 'stations': stations_pkl,
                 'showers': showers_pkl,
                 'sim_showers': sim_showers_pkl,
@@ -621,7 +623,7 @@ class Event:
         self._parameters = data['_parameters']
         self.__run_number = data['__run_number']
         self._id = data['_id']
-        self.__event_time = data['__event_time']
+        self.__event_time = io_utilities.time_object_to_astropy(data['__event_time'])
 
         if 'generator_info' in data.keys():
             self._generator_info = data['generator_info']

--- a/NuRadioReco/framework/event.py
+++ b/NuRadioReco/framework/event.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, division, print_function
-import pickle
 import NuRadioReco.framework.station
 import NuRadioReco.framework.radio_shower
 import NuRadioReco.framework.emitter
@@ -8,8 +7,13 @@ import NuRadioReco.framework.hybrid_information
 import NuRadioReco.framework.particle
 import NuRadioReco.framework.parameters as parameters
 import NuRadioReco.utilities.version
+
+import astropy.time
+import datetime
 from six import itervalues
 import collections
+import pickle
+
 import logging
 logger = logging.getLogger('NuRadioReco.Event')
 

--- a/NuRadioReco/framework/event.py
+++ b/NuRadioReco/framework/event.py
@@ -158,7 +158,7 @@ class Event:
 
         return self.__stations[station_id]
 
-    def set_event_time(self, event_time, format=None):
+    def set_event_time(self, time, format=None):
         """
         Set the (absolute) event time (will be stored as astropy.time.Time).
 
@@ -172,16 +172,16 @@ class Event:
         """
 
         if isinstance(time, datetime.datetime):
-            self._station_time = astropy.time.Time(time)
+            self.__event_time = astropy.time.Time(time)
         elif isinstance(time, astropy.time.Time):
-            self._station_time = time
+            self.__event_time = time
         elif time is None:
-            self._station_time = None
+            self.__event_time = None
         else:
             if format is None:
                 logger.error("If you provide a float for the time, you have to specify the format.")
                 raise ValueError("If you provide a float for the time, you have to specify the format.")
-            self._station_time = astropy.time.Time(time, format=format)
+            self.__event_time = astropy.time.Time(time, format=format)
 
     def get_event_time(self):
         """

--- a/NuRadioReco/framework/event.py
+++ b/NuRadioReco/framework/event.py
@@ -24,7 +24,7 @@ class Event:
         self.__radio_showers = collections.OrderedDict()
         self.__sim_showers = collections.OrderedDict()
         self.__sim_emitters = collections.OrderedDict()
-        self.__event_time = 0
+        self.__event_time = None
         self.__particles = collections.OrderedDict() # stores a dictionary of simulated MC particles in an event
         self._generator_info = {} # copies over the relevant information on event generation from the input file attributes
         self.__hybrid_information = NuRadioReco.framework.hybrid_information.HybridInformation()
@@ -158,10 +158,47 @@ class Event:
 
         return self.__stations[station_id]
 
-    def set_event_time(self, event_time):
-        self.__event_time = event_time
+    def set_event_time(self, event_time, format=None):
+        """
+        Set the (absolute) event time (will be stored as astropy.time.Time).
+
+        Parameters
+        ----------
+        time: astropy.time.Time or datetime.datetime or float
+            If "time" is a float, you have to specify its format.
+
+        format: str (Default: None)
+            Only used when "time" is a float. Format to interpret "time".
+        """
+
+        if isinstance(time, datetime.datetime):
+            self._station_time = astropy.time.Time(time)
+        elif isinstance(time, astropy.time.Time):
+            self._station_time = time
+        elif time is None:
+            self._station_time = None
+        else:
+            if format is None:
+                logger.error("If you provide a float for the time, you have to specify the format.")
+                raise ValueError("If you provide a float for the time, you have to specify the format.")
+            self._station_time = astropy.time.Time(time, format=format)
 
     def get_event_time(self):
+        """
+        Returns the event time (as astropy.time.Time object).
+
+        If the event time is not set, an error is raised. The event time is often only used in simulations
+        and typially the same a `station.get_station_time()`.
+
+        Returns
+        -------
+        event_time : astropy.time.Time
+            The event time.
+        """
+        if self.__event_time is None:
+            logger.error("Event time is not set. You either have to set it or use `station.get_station_time()`")
+            raise ValueError("Event time is not set. You either have to set it or use `station.get_station_time()`")
+
         return self.__event_time
 
     def get_stations(self):

--- a/NuRadioReco/framework/event.py
+++ b/NuRadioReco/framework/event.py
@@ -193,7 +193,7 @@ class Event:
         Returns the event time (as astropy.time.Time object).
 
         If the event time is not set, an error is raised. The event time is often only used in simulations
-        and typially the same a `station.get_station_time()`.
+        and typically the same a `station.get_station_time()`.
 
         Returns
         -------
@@ -575,7 +575,7 @@ class Event:
                 if len(invalid_keys):
                     logger.warning(f"The following arguments to module {value[0]} could not be serialized and will not be stored: {invalid_keys}")
 
-        event_time_dict = io_utilities.astropy_to_dict(self.__event_time)
+        event_time_dict = io_utilities._astropy_to_dict(self.__event_time)
 
         data = {'_parameters': self._parameters,
                 '__run_number': self.__run_number,
@@ -628,7 +628,7 @@ class Event:
         self._parameters = data['_parameters']
         self.__run_number = data['__run_number']
         self._id = data['_id']
-        self.__event_time = io_utilities.time_object_to_astropy(data['__event_time'])
+        self.__event_time = io_utilities._time_object_to_astropy(data['__event_time'])
 
         if 'generator_info' in data.keys():
             self._generator_info = data['generator_info']

--- a/NuRadioReco/modules/io/NuRadioRecoio.py
+++ b/NuRadioReco/modules/io/NuRadioRecoio.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import NuRadioReco.framework.event
 import NuRadioReco.detector.detector
 import NuRadioReco.modules.io.event_parser_factory
+from NuRadioReco.utilities import io_utilities
 
 import numpy as np
 import astropy.time
@@ -188,18 +189,9 @@ class NuRadioRecoio(object):
                         self.__event_headers[station_id][key] = []
 
                     if key == stnp.station_time:
-                        station_time = None
-                        if value is not None:
-                            if isinstance(value, dict):
-                                station_time = astropy.time.Time(value["value"], format=value["format"])
-                            # For backward compatibility, we also keep supporting station times stored
-                            # as astropy.time objects
-                            elif isinstance(value, astropy.time.Time):
-                                station_time = value
-                            else:
-                                err = f"Station time not stored as dict or astropy.time.Time: ({type(value)})"
-                                self.logger.error(err)
-                                raise ValueError(err)
+                        station_time = io_utilities.time_object_to_astropy(value)
+
+                        if station_time is not None:
                             try:
                                 station_time.format = 'isot'
                             except AttributeError:

--- a/NuRadioReco/modules/io/NuRadioRecoio.py
+++ b/NuRadioReco/modules/io/NuRadioRecoio.py
@@ -189,7 +189,7 @@ class NuRadioRecoio(object):
                         self.__event_headers[station_id][key] = []
 
                     if key == stnp.station_time:
-                        station_time = io_utilities.time_object_to_astropy(value)
+                        station_time = io_utilities._time_object_to_astropy(value)
 
                         if station_time is not None:
                             try:

--- a/NuRadioReco/modules/io/eventWriter.py
+++ b/NuRadioReco/modules/io/eventWriter.py
@@ -15,7 +15,7 @@ def get_header(evt):
     header = {'stations': {}}
     for iS, station in enumerate(evt.get_stations()):
         header['stations'][station.get_id()] = station.get_parameters().copy()
-        header['stations'][station.get_id()][stnp.station_time] = io_utilities.astropy_to_dict(station.get_station_time())
+        header['stations'][station.get_id()][stnp.station_time] = io_utilities._astropy_to_dict(station.get_station_time())
 
         if station.has_sim_station():
             header['stations'][station.get_id()]['sim_station'] = {}

--- a/NuRadioReco/modules/io/eventWriter.py
+++ b/NuRadioReco/modules/io/eventWriter.py
@@ -1,10 +1,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
-import pickle
+
 from NuRadioReco.modules.base.module import register_run
 from NuRadioReco.modules.io.NuRadioRecoio import VERSION, VERSION_MINOR
-import logging
 from NuRadioReco.framework.parameters import stationParameters as stnp
 from NuRadioReco.detector import generic_detector
+from NuRadioReco.utilities import io_utilities
+
+import pickle
+import logging
 logger = logging.getLogger("NuRadioReco.eventWriter")
 
 
@@ -12,12 +15,12 @@ def get_header(evt):
     header = {'stations': {}}
     for iS, station in enumerate(evt.get_stations()):
         header['stations'][station.get_id()] = station.get_parameters().copy()
-        header['stations'][station.get_id()][stnp.station_time] = station.get_station_time_dict()
+        header['stations'][station.get_id()][stnp.station_time] = io_utilities.astropy_to_dict(station.get_station_time())
 
         if station.has_sim_station():
             header['stations'][station.get_id()]['sim_station'] = {}
             header['stations'][station.get_id()]['sim_station'] = station.get_sim_station().get_parameters().copy()
-    
+
     header['event_id'] = (evt.get_run_number(), evt.get_id())
     return header
 
@@ -79,10 +82,10 @@ class eventWriter:
             self.__filename = filename[:-4]
         else:
             self.__filename = filename
-        
+
         if filename.endswith('.ari'):
             logger.warning('The file ending .ari for NuRadioReco files is deprecated. Please use .nur instead.')
-        
+
         self.__check_for_duplicates = check_for_duplicates
         self.__number_of_events = 0
         self.__current_file_size = 0
@@ -105,7 +108,7 @@ class eventWriter:
         det: detector object
             If a detector object is passed, the detector description for the
             events is written in the file as well
-        mode: dictionary, optional 
+        mode: dictionary, optional
             Specifies what will be saved into the `*.nur` output file.
             Can contain the following keys:
 

--- a/NuRadioReco/utilities/io_utilities.py
+++ b/NuRadioReco/utilities/io_utilities.py
@@ -86,9 +86,11 @@ def time_object_to_astropy(time_object):
         return None
 
     if isinstance(time_object, astropy.time.Time):
+        # For backward compatibility, we also keep supporting station times stored as astropy.time objects
         return time_object
 
     if isinstance(time_object, datetime.datetime):
+        # For backward compatibility, we also keep supporting station times stored as datetime objects
         logger.warning(
             "Time object created from a `datetime` object. "
             "Nanosecond accuracy is not ensured.")

--- a/NuRadioReco/utilities/io_utilities.py
+++ b/NuRadioReco/utilities/io_utilities.py
@@ -81,7 +81,7 @@ def time_object_to_astropy(time_object):
     if time_object is None:
         return None
 
-    if isinstance(time_object, float) and time_boject == 0:
+    if isinstance(time_object, [int, float]) and time_object == 0:
         # 0 was an old default value for the event time. It was replaced by None.
         return None
 
@@ -95,7 +95,7 @@ def time_object_to_astropy(time_object):
             "Time object created from a `datetime` object. "
             "Nanosecond accuracy is not ensured.")
 
-        return astropy.time.Time(time)
+        return astropy.time.Time(time_object)
 
     if isinstance(time_object, dict):
 

--- a/NuRadioReco/utilities/io_utilities.py
+++ b/NuRadioReco/utilities/io_utilities.py
@@ -45,8 +45,8 @@ def astropy_to_dict(time):
         logger.error(f'Input is not an astropy object: {time}')
         raise ValueError(f'Input is not an astropy object: {time}')
 
-    # Internally, astropy stores the time in the modified julian date (mjd) fornat with a tuple of two double-precision floats.
-    # The first float has an integer value and represents the number of days since the epoch (1858-11-17)
+    # Internally, astropy stores the time in the julian date (jd) fornat with a tuple of two double-precision floats.
+    # The first float has an integer value and represents the number of days since the epoch (12:00 at January 1, 4713 BC)
     # and the second float gives the fraction of the day. That means we can reach a precision of (number of nanoseconds in a day) / 2^52:
     # 3600 * 24 * 1e9 / 2^52 = 0.02 ns. We choose to store the time object in its native format.
 
@@ -54,7 +54,7 @@ def astropy_to_dict(time):
         "val": time.jd1,
         "val2": time.jd2,
         "scale": time.scale,
-        "format": "mjd",
+        "format": "jd",
     }
 
     return data
@@ -77,11 +77,10 @@ def time_object_to_astropy(time_object):
     time: astropy.time.Time
         The time object
     """
-
     if time_object is None:
         return None
 
-    if isinstance(time_object, [int, float]) and time_object == 0:
+    if isinstance(time_object, (int, float)) and time_object == 0:
         # 0 was an old default value for the event time. It was replaced by None.
         return None
 
@@ -107,7 +106,7 @@ def time_object_to_astropy(time_object):
             return astropy.time.Time(time_object['value'], format=time_object['format'])
 
         elif 'val' in time_object and 'val2' in time_object:
-            if "format" not in time_object or time_object["format"] != "mjd":
+            if "format" not in time_object or time_object["format"] != "jd":
                 logger.error(f"Time object is a dictionary but the format is wrong: {time_object}")
                 raise ValueError(f"Time object is a dictionary but the format is wrong: {time_object}")
 

--- a/NuRadioReco/utilities/io_utilities.py
+++ b/NuRadioReco/utilities/io_utilities.py
@@ -29,7 +29,7 @@ def read_pickle(filename, encoding='latin1'):
             return pickle.load(file, encoding=encoding)
 
 
-def astropy_to_dict(time):
+def _astropy_to_dict(time):
     """
     Convert an astropy object to a dictionary.
 
@@ -60,7 +60,7 @@ def astropy_to_dict(time):
     return data
 
 
-def time_object_to_astropy(time_object):
+def _time_object_to_astropy(time_object):
     """
     Convert a time_object to an astropy object.
 


### PR DESCRIPTION
This PR does two things. 

- It implements sub nanosecond precision for station and event time in nur files.
- Properly implements the event time with an internal representation using astropy. This also changes its default value from 0 to None.

This PR addresses the issue #524. 