### PR TITLE
Use correct docstring format

### DIFF
--- a/NuRadioReco/detector/LOFAR/analog_components.py
+++ b/NuRadioReco/detector/LOFAR/analog_components.py
@@ -20,8 +20,9 @@ def load_cable_response(cable_length):
     default: dict
         A dictionary containing the cable attenuation values for the specified cable length.
         The dictionary has the following keys:
-            - 'frequencies': An array of frequency values ranging from 30 MHz to 80 MHz.
-            - 'attenuation': An array of cable attenuation values corresponding to the frequencies.
+
+        - 'frequencies': An array of frequency values ranging from 30 MHz to 80 MHz.
+        - 'attenuation': An array of cable attenuation values corresponding to the frequencies.
     """
     module_dir = os.path.dirname(__file__)
     file_path = os.path.join(module_dir, "signalchain", f"attenuation_RG58_{int(cable_length)}m.txt")
@@ -54,7 +55,8 @@ def get_cable_response(frequencies, cable_length):
     cable: dict
         A dictionary containing the interpolated cable attenuation values for the specified frequencies.
         The dictionary has the following key:
-          - 'attenuation': An array of interpolated attenuation values corresponding to the input frequencies.
+
+        - 'attenuation': An array of interpolated attenuation values corresponding to the input frequencies.
     """
 
     cable_response = load_cable_response(cable_length=cable_length)
@@ -81,8 +83,9 @@ def load_RCU_response():
     -------
     rcu_response: dict
         A dictionary containing the RCU response data with the following keys:
-          - 'frequencies': An array of frequency values ranging from 30 MHz to 80 MHz.
-          - 'gain': An array of gain values in dB corresponding to the frequencies.
+
+        - 'frequencies': An array of frequency values ranging from 30 MHz to 80 MHz.
+        - 'gain': An array of gain values in dB corresponding to the frequencies.
     """
 
     module_dir = os.path.dirname(__file__)
@@ -114,7 +117,8 @@ def get_RCU_response(frequencies):
     system: dict
         A dictionary containing the interpolated RCU gain values for the specified frequencies.
         The dictionary has the following key:
-          - 'gain': An array of interpolated gain values corresponding to the input frequencies.
+
+        - 'gain': An array of interpolated gain values corresponding to the input frequencies.
     """
 
     RCU_response = load_RCU_response()

--- a/NuRadioReco/detector/LOFAR/analog_components.py
+++ b/NuRadioReco/detector/LOFAR/analog_components.py
@@ -35,7 +35,6 @@ def load_cable_response(cable_length):
     return default
 
 def get_cable_response(frequencies, cable_length):
-
     """
     Calculate the cable response for given frequencies and cable length.
 
@@ -71,7 +70,6 @@ def get_cable_response(frequencies, cable_length):
 
 
 def load_RCU_response():
-
     """
     Load the RCU (Receiver Control Unit) response data.
 
@@ -100,7 +98,6 @@ def load_RCU_response():
     return rcu_response
 
 def get_RCU_response(frequencies):
-
     """
     Fetches the RCU response for given frequencies.
 

--- a/NuRadioReco/detector/LOFAR/analog_components.py
+++ b/NuRadioReco/detector/LOFAR/analog_components.py
@@ -12,21 +12,26 @@ def load_cable_response(cable_length):
     """
     Parameters
     ----------
-    cable_length: int
+    cable_length: int or float
         length of the coax cable of the corresponding channel
 
     Returns
     -------
-
+    default: dict
+        A dictionary containing the cable attenuation values for the specified cable length.
+        The dictionary has the following keys:
+            - 'frequencies': An array of frequency values ranging from 30 MHz to 80 MHz.
+            - 'attenuation': An array of cable attenuation values corresponding to the frequencies.
     """
     module_dir = os.path.dirname(__file__)
-    file_path = os.path.join(module_dir, "signalchain", f"attenuation_RG58_{cable_length}m.txt")
+    file_path = os.path.join(module_dir, "signalchain", f"attenuation_RG58_{int(cable_length)}m.txt")
 
     data = np.loadtxt(file_path)
 
-    default = {}
-    default['frequencies'] = np.arange(30,81) * units.MHz
-    default['attenuation'] = -1*data  #data is in dB
+    default = {
+        'frequencies': np.arange(30, 81) * units.MHz,
+        'attenuation': -1 * data
+    }
     return default
 
 def get_cable_response(frequencies, cable_length):
@@ -38,26 +43,30 @@ def get_cable_response(frequencies, cable_length):
     interpolates the attenuation values for the specified frequencies, and returns
     the interpolated cable response.
 
-    Parameters:
-    frequencies (array-like): An array of frequency values for which the cable response is to be calculated.
-    cable_length (float): The length of the cable for which the response is to be loaded.
+    Parameters
+    ----------
+    frequencies: array-like
+        An array of frequency values for which the cable response is to be calculated.
+    cable_length: int or float
+        The length of the cable for which the response is to be loaded.
 
-    Returns:
-    dict: A dictionary containing the interpolated cable attenuation values for the specified frequencies.
-          The dictionary has the following key:
+    Returns
+    -------
+    cable: dict
+        A dictionary containing the interpolated cable attenuation values for the specified frequencies.
+        The dictionary has the following key:
           - 'attenuation': An array of interpolated attenuation values corresponding to the input frequencies.
     """
 
-    cable_response = {}
-    cable_response['default'] = load_cable_response(cable_length=cable_length)
-
-    orig_frequencies = cable_response['default']['frequencies']
-    gain = cable_response['default']['attenuation']
+    cable_response = load_cable_response(cable_length=cable_length)
+    orig_frequencies = cable_response['frequencies']
+    gain = cable_response['attenuation']
 
     interp_gain = interp1d(orig_frequencies, gain[:,1], bounds_error=False, fill_value=0)
 
-    cable = {}
-    cable['attenuation'] = interp_gain(frequencies)
+    cable = {
+        'attenuation': interp_gain(frequencies)
+    }
     return cable
 
 
@@ -70,8 +79,10 @@ def load_RCU_response():
     relative to the current module's directory. It then constructs a dictionary containing the
     frequency range and the corresponding gain values.
 
-    Returns:
-    dict: A dictionary containing the RCU response data with the following keys:
+    Returns
+    -------
+    rcu_response: dict
+        A dictionary containing the RCU response data with the following keys:
           - 'frequencies': An array of frequency values ranging from 30 MHz to 80 MHz.
           - 'gain': An array of gain values in dB corresponding to the frequencies.
     """
@@ -81,11 +92,12 @@ def load_RCU_response():
 
     data = np.loadtxt(file_path)
 
-    default = {}
-    default['frequencies'] = np.arange(30,81) * units.MHz
-    default['gain'] = data   # data is in dB
+    rcu_response = {
+        'frequencies': np.arange(30, 81) * units.MHz,
+        'gain': data
+    }
 
-    return default
+    return rcu_response
 
 def get_RCU_response(frequencies):
 
@@ -95,24 +107,25 @@ def get_RCU_response(frequencies):
     This function loads the LOFAR RCU response, interpolates the gain values for the specified
     frequencies, and returns the interpolated RCU response.
 
-    Parameters:
-    frequencies (array-like): An array of frequency values for which the RCU response is to be calculated.
+    Parameters
+    ----------
+    frequencies: array-like
+        An array of frequency values for which the RCU response is to be calculated.
 
-    Returns:
-    dict: A dictionary containing the interpolated RCU gain values for the specified frequencies.
-          The dictionary has the following key:
+    Returns
+    -------
+    system: dict
+        A dictionary containing the interpolated RCU gain values for the specified frequencies.
+        The dictionary has the following key:
           - 'gain': An array of interpolated gain values corresponding to the input frequencies.
     """
 
-    RCU_response = {}
-    RCU_response['default'] = load_RCU_response()
-    orig_frequencies = RCU_response['default']['frequencies']
-
-    gain = RCU_response['default']['gain']
+    RCU_response = load_RCU_response()
+    orig_frequencies = RCU_response['frequencies']
+    gain = RCU_response['gain']
 
     interp_gain = interp1d(orig_frequencies, gain, bounds_error=False, fill_value=0)
 
-    system = {}
-    system['gain'] = interp_gain(frequencies)
+    system = {'gain': interp_gain(frequencies)}
 
     return system


### PR DESCRIPTION
Issue being addressed: one of the LOFAR files had the wrong docstring format, causing the documentation build to fail.

