### PR TITLE
[RNO-G] make channelBlockOffsetFitter automatically pick appropriate block offset removal mode

### DIFF
--- a/NuRadioReco/modules/RNO_G/channelBlockOffsetFitter.py
+++ b/NuRadioReco/modules/RNO_G/channelBlockOffsetFitter.py
@@ -53,8 +53,8 @@ class channelBlockOffsets:
 
         Parameters
         ----------
-        event: Event object | None
-        station: Station
+        event : `NuRadioReco.framework.event.Event` | None
+        station : `NuRadioReco.framework.station.Station`
             The station to add block offsets to
         offsets: float | array | dict
             offsets to add to the event. Default: 1 mV
@@ -110,8 +110,8 @@ class channelBlockOffsets:
 
         Parameters
         ----------
-        event: NuRadioReco.framework.event.Event | None
-        station: NuRadioReco.framework.station.Station
+        event : `NuRadioReco.framework.event.Event` | None
+        station : `NuRadioReco.framework.station.Station`
             The station to remove the block offsets from
         mode: str {'auto', 'fit', 'approximate', 'stored'}, optional
             
@@ -126,12 +126,16 @@ class channelBlockOffsets:
 
         channel_ids: list | None
             List of channel ids to remove offsets from. If None (default),
-            remove offsets from all channels in ``station``
+            remove offsets from all channels in `station`
         maxiter: int, default 5
             (Only if mode=='fit') The maximum number of fit iterations.
             This can be increased to more accurately remove the block offsets
             at the cost of performance. (The default value removes 'most' offsets
             to about 1%)
+
+        See Also
+        --------
+        run : alias of this method
 
         """
         if channel_ids  is None:
@@ -155,6 +159,59 @@ class channelBlockOffsets:
                 offsets[channel_id] = -block_offsets
         
         self.add_offsets(event, station, offsets, channel_ids)
+
+    def begin(self):
+        """(Unused)"""
+        pass
+
+    @register_run()
+    def run(self, event, station, det=None, mode='auto', channel_ids=None, **kwargs):
+        """
+        Remove the block offsets from all channels of a station.
+
+        Fits and removes the block offsets from an event. The removed offsets
+        are stored in the ``channelParameters.block_offsets``
+        parameter.
+
+        This method is an alias of `remove_offsets`, with the only difference the inclusion
+        of the (unused) `det` parameter, to be consistent with the `run` methods of other
+        NuRadio classes.
+
+        Parameters
+        ----------
+        event : `NuRadioReco.framework.event.Event` | None
+        station : `NuRadioReco.framework.station.Station`
+            The station to remove the block offsets from
+        det : Detector object, optional
+            Detector object (not used in this method,
+            included to have the same signature as other NuRadio classes)
+        mode : str {'auto', 'fit', 'approximate', 'stored'}, optional
+
+            - 'fit': fit the block offsets with a minimizer
+            - 'approximate' : use the first guess from the out-of-band component,
+              without any fitting (slightly faster)
+            - 'auto' (default): decide automatically between 'approximate' and 'fit'
+              based on the estimated size of the block offsets.
+            - 'stored': use the block offsets already stored in the
+              ``channelParameters.block_offsets`` parameter. Will raise an error
+              if this parameter is not present.
+
+        channel_ids : list | None
+            List of channel ids to remove offsets from. If None (default),
+            remove offsets from all channels in `station`.
+        **kwargs : keyword arguments
+            Other keyword arguments to be passed to the `remove_offsets` function.
+
+        See Also
+        --------
+        remove_offsets : alias of this method without the (unused) `det` parameter
+        """
+        self.remove_offsets(event, station, mode=mode, channel_ids=channel_ids, **kwargs)
+
+
+    def end(self):
+        """(Unused)"""
+        pass
 
 
 def fit_block_offsets(

--- a/NuRadioReco/modules/RNO_G/channelBlockOffsetFitter.py
+++ b/NuRadioReco/modules/RNO_G/channelBlockOffsetFitter.py
@@ -91,9 +91,9 @@ class channelBlockOffsets:
             # save the added offsets as a channelParameter
             if channel.has_parameter(channelParameters.block_offsets):
                 block_offsets_old = channel.get_parameter(channelParameters.block_offsets)
-                channel.set_parameter(channelParameters.block_offsets, block_offsets_old + offsets)
+                channel.set_parameter(channelParameters.block_offsets, block_offsets_old + add_offsets)
             else:
-                channel.set_parameter(channelParameters.block_offsets, offsets)
+                channel.set_parameter(channelParameters.block_offsets, add_offsets)
 
             channel.set_trace(
                 channel.get_trace() + np.repeat(add_offsets, self.block_size),

--- a/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
+++ b/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
@@ -324,11 +324,14 @@ class readRNOGData:
             the data in batches based on this number.
             NOTE: This is only relevant for the mattak uproot backend
         """
-
         t0 = time.time()
 
         self._read_calibrated_data = read_calibrated_data
+
         baseline_correction_valid_options = ['auto', 'approximate', 'fit', 'median', 'none']
+        if apply_baseline_correction is None:
+            apply_baseline_correction = 'none'
+
         if apply_baseline_correction.lower() not in baseline_correction_valid_options:
             raise ValueError(
                 f"Value for apply_baseline_correction ({apply_baseline_correction}) not recognized. "
@@ -572,7 +575,8 @@ class readRNOGData:
         skip: bool
             Returns False to skip/reject event, return True to keep/read event
         """
-        self.logger.debug(f"Processing event number {self.__counter} out of total {self._n_events_total}")
+        self.logger.debug(
+            f"(_select_events) Processing event number {self.__counter} out of total {self._n_events_total}")
 
         self.__counter += 1  # for logging
         if self._selectors is not None:
@@ -897,7 +901,7 @@ class readRNOGData:
         evt: `NuRadioReco.framework.event.Event`
         """
 
-        self.logger.debug(f"Processing event {event_id}")
+        self.logger.debug(f"Getting event {event_id}")
         t0 = time.time()
 
         event_infos = self.get_events_information(keys=["eventNumber", "run"])


### PR DESCRIPTION
- channelBlockOffsetFitter can now take the mode 'auto'; in this case the approximate block offset removal (faster) is used unless the estimated block offsets are larger than 50% of the Vrms, in which case it will automatically perform the full fit. This should be a considerable speed-up compared to using `fit` all the time with a minimal impact to accuracy.
- added a `run` method which is essentially just an alias of `remove_offsets`, with the only difference an additional `det` parameter (which is ignored) to be consistent with the `run` method of other NuRadio classes.
- minor bugfix: previously the block offsets for all channels were stored in each channel; now only the block offsets corresponding to the channel are stored in `channelParameters.block_offsets`.