### PR TITLE
fallback to importing ErfaWarning from astropy for older versions

### DIFF
--- a/NuRadioReco/detector/detector_base.py
+++ b/NuRadioReco/detector/detector_base.py
@@ -13,7 +13,10 @@ from datetime import datetime
 from tinydb_serialization import Serializer
 import six  # # used for compatibility between py2 and py3
 import warnings
-from erfa import ErfaWarning
+try:
+    from erfa import ErfaWarning
+except ImportError: # users with astropy < 4.2 may not have pyerfa installed
+    from astropy.utils.exceptions import ErfaWarning
 import NuRadioReco.utilities.metaclasses
 
 logger = logging.getLogger('NuRadioReco.detector')


### PR DESCRIPTION
Prior to version 4.2, pyerfa was not a dependency of astropy, so users with older versions of astropy could get an ImportError due to the `from erfa import ErfaWarning` in `detector_base`. This adds a simple try/except statement to prevent this.

Alternative solutions include explicitly including `erfa` in our requirements, pinning `astropy>=4.2`, or just not caring about this unlikely scenario (it has been reported at least once, though!).