### PR TITLE
initialize trigger_channels to None in RNO-G hardwareResponseIncorporator

### DIFF
--- a/NuRadioReco/modules/RNO_G/hardwareResponseIncorporator.py
+++ b/NuRadioReco/modules/RNO_G/hardwareResponseIncorporator.py
@@ -23,6 +23,7 @@ class hardwareResponseIncorporator:
         self.__time_delays = {}
         self.__t = 0
         self.__mingainlin = None
+        self.trigger_channels = None
 
     def begin(self, trigger_channels=None):
         """


### PR DESCRIPTION
One-line change; initialize the `self.trigger_channels` to `None`. The introduction of this attribute meant that the `begin` method of the hardwareResponseIncorporator was no longer optional.

@fschlueter if this is intentional, feel free to close this PR; I can see the value in 'forcing' users to call `begin` so they are (hopefully) more aware of the `trigger_channels` option. But your change broke one of my scripts, and no behaviour is affected by this addition, so :shrug: 