### PR TITLE
Cache antenna vector effective length in channelGalacticNoiseAdder

### DIFF
--- a/NuRadioReco/modules/channelGalacticNoiseAdder.py
+++ b/NuRadioReco/modules/channelGalacticNoiseAdder.py
@@ -114,9 +114,9 @@ class channelGalacticNoiseAdder:
 
         self.__caching = caching
         self.__freqs = None
-        if self.__caching and self.__n_side > 10:
+        if self.__caching and self.__n_side >= 10:
             logger.warning(
-                "Caching for the vector effective length is enabled (with `maxsize=1024`). `n_side` is larger 10 and thus "
+                "Caching for the vector effective length is enabled (with `maxsize=1024`) and `n_side >= 10`, and thus "
                 "it produces to many different caching entries for two antenna models to be stored of one `station_time`. "
                 "Either decrease `n_side` or increase `maxsize` (has to be done in the source code).")
 

--- a/NuRadioReco/modules/channelGalacticNoiseAdder.py
+++ b/NuRadioReco/modules/channelGalacticNoiseAdder.py
@@ -114,6 +114,11 @@ class channelGalacticNoiseAdder:
 
         self.__caching = caching
         self.__freqs = None
+        if self.__caching and self.__n_side > 10:
+            logger.warning(
+                "Caching for the vector effective length is enabled (with `maxsize=1024`). `n_side` is larger 10 and thus "
+                "it produces to many different caching entries for two antenna models to be stored of one `station_time`. "
+                "Either decrease `n_side` or increase `maxsize` (has to be done in the source code).")
 
         if interpolation_frequencies is None:
             if freq_range is None:
@@ -168,7 +173,7 @@ class channelGalacticNoiseAdder:
             self.__noise_temperatures[i_freq] = self.__radio_sky
 
 
-    @functools.lru_cache(maxsize=1024 * 32)
+    @functools.lru_cache(maxsize=1024)
     def get_cached_antenna_response(self, ant_pattern, zen, azi, *ant_orient):
         return ant_pattern.get_antenna_response_vectorized(self.__freqs, zen, azi, *ant_orient)
 


### PR DESCRIPTION
…nnelGalacticNoiseAdder

This hides the fact that getting the vector effective length from the `antenna_pattern` class is pretty slow. Since arrays/lists are not hashable we can not directly pass the frequency vector to the cached function but have to pass `self` and use `self.__freqs`. This means we have to make sure ourselves that `self.__freqs` does not change or we have to clear the cache.

I have run some very limited tests (I run it and checked that the resulting nur files are the same (fixing the seed of the module). However, it would be good if someone actually looked at the noise/vel this caching produces. Maybe @PhilippLaub, @JethroStoffels or @karenterveer can do that?

@sjoerd-bouma any comments about the implementation? 
