### PR TITLE
Make numpy arrays contiguous before storing them

### DIFF
--- a/NuRadioReco/utilities/_fastnumpyio.py
+++ b/NuRadioReco/utilities/_fastnumpyio.py
@@ -39,8 +39,32 @@ def save(file, array):
     file.write(array.data)
 
 def pack(array):
-    size=len(array.shape)
-    return bytes(array.dtype.byteorder.replace('=','<' if sys.byteorder == 'little' else '>')+array.dtype.kind,'utf-8')+array.dtype.itemsize.to_bytes(1,byteorder='little')+struct.pack(f'<B{size}I',size,*array.shape)+array.data
+    """
+    Convert a numpy array to a storable bytes object
+
+    Parameters
+    ----------
+    array : np.ndarray
+        The numpy array to store.
+
+    Returns
+    -------
+    output_bytes : bytes
+        The bytes
+
+    """
+    # Only contiguous arrays can be stored directly as bytes
+    contiguous_array = np.ascontiguousarray(array)
+
+    size = len(contiguous_array.shape)
+    output_bytes = (
+        bytes(
+            contiguous_array.dtype.byteorder.replace('=', '<' if sys.byteorder == 'little' else '>')
+            + contiguous_array.dtype.kind,'utf-8')
+        + contiguous_array.dtype.itemsize.to_bytes(1, byteorder='little')
+        + struct.pack(f'<B{size}I', size, *contiguous_array.shape)
+        + contiguous_array.data)
+    return output_bytes
 
 def load(file):
     if type(file) == str:

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,11 @@ Changelog - to keep track of all relevant changes
 
 please update the categories "new features" and "bugfixes" before a pull request merge!
 
+version 2.2.3
+bugfixes:
+- Fixed an error when attempting to write an event that included non-contiguous
+  numpy arrays, by explicitly converting these to contiguous form in that case.
+
 version 2.2.2
 bugfixes:
 - Change to the way numpy objects are stored inside .nur files. This ensures .nur

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "NuRadioMC"
-version = "2.2.2"
+version = "2.2.3"
 authors = ["Christian Glaser et al."]
 homepage = "https://github.com/nu-radio/NuRadioMC"
 documentation = "https://nu-radio.github.io/NuRadioMC/main.html"


### PR DESCRIPTION
Fixes #836 

@MijnheerD found that the _fastnumpyio implementation to store numpy arrays only works for contiguous arrays, and raises an error otherwise. So I've added `np.ascontiguousarray` to the _fastnumpyio function, which copies the array data to contiguous ordering if this is not already the case.