### PR TITLE
modules.RNO_G.crRNOGTemplateCreator: fix channel overwrite bug

### DIFF
--- a/NuRadioReco/modules/RNO_G/crRNOGTemplateCreator.py
+++ b/NuRadioReco/modules/RNO_G/crRNOGTemplateCreator.py
@@ -187,6 +187,11 @@ class crRNOGTemplateCreator:
                         temp_evt = _create_Efield(det_temp, rid, eid, cid, sid, station_time, self.__template_sample_number, e_width,
                                                  self.__efield_amplitudes[1], self.__efield_amplitudes[0], cr_zen, cr_az, self.__sampling_rate, self.__debug)
 
+                        # First remove channels to reproduce them with the efieldToVoltageConverter
+                        station = temp_evt.get_station(sid)
+                        for chid in station.get_channel_ids():
+                            station.remove_channel(chid)
+
                         self.__efieldToVoltageConverter.run(temp_evt, temp_evt.get_station(sid), det_temp)
 
                         if include_hardware_response:

--- a/NuRadioReco/modules/RNO_G/crRNOGTemplateCreator.py
+++ b/NuRadioReco/modules/RNO_G/crRNOGTemplateCreator.py
@@ -187,11 +187,6 @@ class crRNOGTemplateCreator:
                         temp_evt = _create_Efield(det_temp, rid, eid, cid, sid, station_time, self.__template_sample_number, e_width,
                                                  self.__efield_amplitudes[1], self.__efield_amplitudes[0], cr_zen, cr_az, self.__sampling_rate, self.__debug)
 
-                        # First remove channels to reproduce them with the efieldToVoltageConverter
-                        station = temp_evt.get_station(sid)
-                        for chid in station.get_channel_ids():
-                            station.remove_channel(chid)
-
                         self.__efieldToVoltageConverter.run(temp_evt, temp_evt.get_station(sid), det_temp)
 
                         if include_hardware_response:
@@ -250,9 +245,6 @@ def _create_Efield(detector:detector.generic_detector.GenericDetector, run_id:in
     event.set_station(station)
 
     station.set_station_time(astropy.time.Time(station_time))
-
-    channel = Channel(channel_id)
-    station.add_channel(channel)
 
     sim_station = SimStation(station_id)
     station.set_sim_station(sim_station)


### PR DESCRIPTION
After introduction of the overwrite flag in PR #791 the eFieldToVoltageConverter raised an error. In this PR a fix for this issue is added. The fix is the same as used in PR #791 to fix the test.