### PR TITLE
Add ARIANNAparameters to Station by default to support older nur files

### DIFF
--- a/NuRadioReco/framework/station.py
+++ b/NuRadioReco/framework/station.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 import NuRadioReco.framework.base_station
 import NuRadioReco.framework.sim_station
 import NuRadioReco.framework.channel
+import NuRadioReco.framework.parameters
 from six import iteritems
 import pickle
 import logging
@@ -13,6 +14,7 @@ class Station(NuRadioReco.framework.base_station.BaseStation):
 
     def __init__(self, station_id):
         NuRadioReco.framework.base_station.BaseStation.__init__(self, station_id)
+        self.add_parameter_type(NuRadioReco.framework.parameters.ARIANNAParameters)
         self.__channels = collections.OrderedDict()
         self.__reference_reconstruction = 'RD'
         self.__sim_station = None


### PR DESCRIPTION
Adds ARIANNAparameters as a default allowed parameter type to `Station`. Currently, .nur files predating the new parameter_storage structure that contain ARIANNAparameters cannot be read in, because they are not an allowed parameter type.

The 'downside' is that this will become the default going forward, so that maybe the error message when passing invalid keys to `set_parameter` becomes slightly less helpful to new users. But the alternative of implementing a workaround in ParameterStorage.deserialize seems messier to me.