### PR TITLE
Include option in channelGalacticNoiseAdder to select only specified …

### DIFF
--- a/NuRadioReco/modules/channelGalacticNoiseAdder.py
+++ b/NuRadioReco/modules/channelGalacticNoiseAdder.py
@@ -216,7 +216,7 @@ class channelGalacticNoiseAdder:
         """
         if selected_channel_ids is None:
             selected_channel_ids = station.get_channel_ids()
-            logger.info(f"Using all channel ids")
+            logger.info(f"Using all channels: {selected_channel_ids}")
         else:
             logger.info(f"Using selected channel ids: {selected_channel_ids}")
 
@@ -227,9 +227,8 @@ class channelGalacticNoiseAdder:
 
         # check that or all channels channel.get_frequencies() is identical
         last_freqs = None
-        for channel in station.iter_channels():
-            if channel.get_id() not in selected_channel_ids:
-                continue
+        for channel_id in selected_channel_ids:
+            channel = station.get_channel(channel_id)
             if last_freqs is not None and (
                     not np.allclose(last_freqs, channel.get_frequencies(), rtol=0, atol=0.1 * units.MHz)):
                 logger.error("The frequencies of each channel must be the same, but they are not!")
@@ -269,9 +268,8 @@ class channelGalacticNoiseAdder:
         c_vac = scipy.constants.c * units.m / units.s
 
         channel_spectra = {}
-        for channel in station.iter_channels():
-            if channel.get_id() not in selected_channel_ids:
-                continue
+        for channel_id in selected_channel_ids:
+            channel = station.get_channel(channel_id)
             channel_spectra[channel.get_id()] = channel.get_frequency_spectrum()
 
         for i_pixel in range(healpy.pixelfunc.nside2npix(self.__n_side)):
@@ -315,9 +313,8 @@ class channelGalacticNoiseAdder:
 
             channel_noise_spec = np.zeros_like(noise_spectrum)
 
-            for channel in station.iter_channels():
-                if channel.get_id() not in selected_channel_ids:
-                    continue
+            for channel_id in selected_channel_ids:
+                channel = station.get_channel(channel_id)
 
                 channel_pos = detector.get_relative_position(station.get_id(), channel.get_id())
                 if channel_pos[2] < 0:
@@ -373,9 +370,8 @@ class channelGalacticNoiseAdder:
                 channel_spectra[channel.get_id()] += channel_noise_spectrum
 
         # store the updated channel spectra
-        for channel in station.iter_channels():
-            if channel.get_id() not in selected_channel_ids:
-                continue
+        for channel_id in selected_channel_ids:
+            channel = station.get_channel(channel_id)
             channel.set_frequency_spectrum(channel_spectra[channel.get_id()], "same")
 
 


### PR DESCRIPTION
…channels. Useful when interpolating only selected channels in the readCoREASDetector module.




