### PR TITLE
set the correct efield position (relative antenna position)

### DIFF
--- a/NuRadioReco/modules/io/coreas/readCoREASDetector.py
+++ b/NuRadioReco/modules/io/coreas/readCoREASDetector.py
@@ -290,7 +290,8 @@ class readCoREASDetector:
                     # Store the trace in an ElecticField object
                     coreas.add_electric_field_to_sim_station(
                         sim_station, channel_ids_for_group_id, smooth_res_efield.T, res_trace_start_time,
-                        sim_shower[shp.zenith], sim_shower[shp.azimuth], self.coreas_interpolator.sampling_rate)
+                        sim_shower[shp.zenith], sim_shower[shp.azimuth], self.coreas_interpolator.sampling_rate,
+                        efield_position=antenna_position_rel)
 
                 sim_station.set_parameter(stnp.zenith, sim_shower[shp.zenith])
                 sim_station.set_parameter(stnp.azimuth, sim_shower[shp.azimuth])


### PR DESCRIPTION
Before that the positions of the efields were not set and would default to `[0,0,0]`. Now they are set to the antenna positions relative to the station. Fixes a bug in `efieldToVoltageConverter` where travel time shifts are calculated based on the difference between efield and antenna position.
