### PR TITLE
Remove artificial dependency on "is_cosmic_ray" in efieldToVoltageConverter modules

### DIFF
--- a/NuRadioReco/eventbrowser/apps/trace_plots/multi_channel_plot.py
+++ b/NuRadioReco/eventbrowser/apps/trace_plots/multi_channel_plot.py
@@ -8,8 +8,7 @@ from NuRadioReco.framework.parameters import channelParameters as chp
 Used in the trace from efield and trace frm sim-efield plots. Keep them
 commented out for later
 from NuRadioReco.framework.parameters import electricFieldParameters as efp
-from NuRadioReco.utilities import geometryUtilities
-from NuRadioReco.utilities import trace_utilities
+from NuRadioReco.utilities import signal_processing, geometryUtilities
 """
 import numpy as np
 from dash import dcc, html, callback
@@ -206,7 +205,7 @@ def update_multi_channel_plot(evt_counter, filename, dropdown_traces, dropdown_i
                 opacity=0.7,
                 line=dict(
                     width=4,
-                    dash='dot'),  
+                    dash='dot'),
                 marker={
                     'color': colors[i % len(colors)],
                     'line': {'color': colors[i % len(colors)]}
@@ -351,7 +350,7 @@ def update_multi_channel_plot(evt_counter, filename, dropdown_traces, dropdown_i
             channel_ids.append(channel.get_id())
         for electric_field in station.get_electric_fields():
             for i_trace, trace in enumerate(
-                    trace_utilities.get_channel_voltage_from_efield(station, electric_field, channel_ids, det,
+                    signal_processing.get_channel_voltage_from_efield(station, electric_field, channel_ids, det,
                                                                     station.get_parameter(stnp.zenith),
                                                                     station.get_parameter(stnp.azimuth),
                                                                     antenna_pattern_provider)):
@@ -382,7 +381,7 @@ def update_multi_channel_plot(evt_counter, filename, dropdown_traces, dropdown_i
         for i_channel, channel in enumerate(station.iter_channels()):
             for electric_field in sim_station.get_electric_fields_for_channels([channel.get_id()]):
                 trace = \
-                    trace_utilities.get_channel_voltage_from_efield(sim_station, electric_field, [channel.get_id()],
+                    signal_processing.get_channel_voltage_from_efield(sim_station, electric_field, [channel.get_id()],
                                                                     det,
                                                                     electric_field.get_parameter(efp.zenith),
                                                                     electric_field.get_parameter(efp.azimuth),

--- a/NuRadioReco/modules/efieldToVoltageConverter.py
+++ b/NuRadioReco/modules/efieldToVoltageConverter.py
@@ -11,7 +11,7 @@ from NuRadioReco.framework.parameters import stationParameters as stnp
 
 from NuRadioReco.modules.base.module import register_run
 from NuRadioReco.detector import antennapattern
-from NuRadioReco.utilities import units, fft, ice, trace_utilities, geometryUtilities as geo_utl
+from NuRadioReco.utilities import units, fft, ice, signal_processing, geometryUtilities as geo_utl
 
 
 class efieldToVoltageConverter():
@@ -130,7 +130,7 @@ class efieldToVoltageConverter():
                 cab_delay = det.get_cable_delay(sim_station_id, channel_id)
                 t0 = electric_field.get_trace_start_time() + cab_delay
 
-                # if we have a cosmic ray event, the different signal travel time to the antennas has to be taken into account 
+                # if we have a cosmic ray event, the different signal travel time to the antennas has to be taken into account
                 if sim_station.is_cosmic_ray():
                     travel_time_shift = calculate_time_shift_for_cosmic_ray(det, sim_station, electric_field, channel_id)
                     t0 += travel_time_shift
@@ -223,7 +223,7 @@ class efieldToVoltageConverter():
                         start_bin = 0
 
                     new_trace[:, start_bin:stop_bin] = tr
-                
+
                 trace_object = NuRadioReco.framework.base_trace.BaseTrace()
                 trace_object.set_trace(new_trace, 1. / time_resolution)
 
@@ -269,7 +269,7 @@ class efieldToVoltageConverter():
                     VEL = [np.array([vel_tmp['theta'] * t_theta, vel_tmp['phi'] * t_phi])]
                 else:
                     # get antenna pattern for current channel
-                    VEL = trace_utilities.get_efield_antenna_factor(
+                    VEL = signal_processing.get_efield_antenna_factor(
                         sim_station, ff, [channel_id], det, zenith, azimuth, self.__antenna_provider)
 
                 if VEL is None:  # this can happen if there is not signal path to the antenna

--- a/NuRadioReco/modules/efieldToVoltageConverterPerEfield.py
+++ b/NuRadioReco/modules/efieldToVoltageConverterPerEfield.py
@@ -6,7 +6,7 @@ import NuRadioReco.framework.sim_channel
 from NuRadioReco.modules.base.module import register_run
 from NuRadioReco.detector import antennapattern
 from NuRadioReco.utilities import units, ice, geometryUtilities
-from NuRadioReco.utilities import trace_utilities
+from NuRadioReco.utilities import signal_processing
 from NuRadioReco.framework.parameters import electricFieldParameters as efp
 from NuRadioReco.framework.parameters import channelParameters as chp
 
@@ -33,7 +33,7 @@ class efieldToVoltageConverterPerEfield():
         evt : Event
             The event object.
         station : SimStation (or Station)
-            The SimStation object. If a Station object is provided, it is detected and the 
+            The SimStation object. If a Station object is provided, it is detected and the
             SimStation is automatically retrived from the Station object
         det : Detector
             The detector object.
@@ -73,7 +73,7 @@ class efieldToVoltageConverterPerEfield():
                 azimuth = electric_field[efp.azimuth]
 
                 # get antenna pattern for current channel
-                VEL = trace_utilities.get_efield_antenna_factor(sim_station, ff, [channel_id], det, zenith, azimuth, self.antenna_provider)
+                VEL = signal_processing.get_efield_antenna_factor(sim_station, ff, [channel_id], det, zenith, azimuth, self.antenna_provider)
 
                 if VEL is None:  # this can happen if there is not signal path to the antenna
                     voltage_fft = np.zeros_like(efield_fft[1])  # set voltage trace to zeros

--- a/NuRadioReco/modules/iftElectricFieldReconstructor/iftElectricFieldReconstructor.py
+++ b/NuRadioReco/modules/iftElectricFieldReconstructor/iftElectricFieldReconstructor.py
@@ -1,6 +1,5 @@
 import numpy as np
-from NuRadioReco.utilities import units, fft, trace_utilities, bandpass_filter
-import NuRadioReco.utilities.trace_utilities
+from NuRadioReco.utilities import units, fft, trace_utilities, bandpass_filter, signal_processing
 import NuRadioReco.detector.antennapattern
 import NuRadioReco.detector.RNO_G.analog_components
 import NuRadioReco.detector.ARIANNA.analog_components
@@ -511,7 +510,7 @@ class IftElectricFieldReconstructor:
                 receive_azimuth = channel.get_parameter(chp.signal_receiving_azimuth)
             else:
                 receive_azimuth = 0.
-            antenna_response = NuRadioReco.utilities.trace_utilities.get_efield_antenna_factor(station, frequencies, [channel_id], detector, receiving_zenith, receive_azimuth, self.__antenna_pattern_provider)[0]
+            antenna_response = signal_processing.get_efield_antenna_factor(station, frequencies, [channel_id], detector, receiving_zenith, receive_azimuth, self.__antenna_pattern_provider)[0]
             amp_response = detector.get_amplifier_response(station.get_id(), channel_id, frequencies)
             amp_gain = np.abs(amp_response)
             amp_phase = np.unwrap(np.angle(amp_response))

--- a/NuRadioReco/modules/neutrinoVertexReconstructor/neutrino3DVertexReconstructor.py
+++ b/NuRadioReco/modules/neutrinoVertexReconstructor/neutrino3DVertexReconstructor.py
@@ -8,7 +8,7 @@ import NuRadioReco.framework.electric_field
 import NuRadioReco.detector.antennapattern
 from NuRadioReco.framework.parameters import stationParameters as stnp
 from NuRadioReco.framework.parameters import showerParameters as shp
-from NuRadioReco.utilities import trace_utilities, fft, bandpass_filter
+from NuRadioReco.utilities import signal_processing, fft, bandpass_filter
 import radiotools.helper as hp
 
 
@@ -185,7 +185,7 @@ class neutrino3DVertexReconstructor:
         for i_pair, channel_pair in enumerate(self.__channel_pairs):
             channel_1 = station.get_channel(channel_pair[0])
             channel_2 = station.get_channel(channel_pair[1])
-            antenna_response = trace_utilities.get_efield_antenna_factor(
+            antenna_response = signal_processing.get_efield_antenna_factor(
                 station=station,
                 frequencies=self.__electric_field_template.get_frequencies(),
                 channels=[channel_pair[0]],
@@ -340,7 +340,7 @@ class neutrino3DVertexReconstructor:
         self_correlation_sum = np.zeros_like(z_coords)
         for i_channel, channel_id in enumerate(self.__channel_ids):
             channel = station.get_channel(channel_id)
-            antenna_response = trace_utilities.get_efield_antenna_factor(
+            antenna_response = signal_processing.get_efield_antenna_factor(
                 station=station,
                 frequencies=self.__electric_field_template.get_frequencies(),
                 channels=[channel_id],

--- a/NuRadioReco/modules/voltageToAnalyticEfieldConverter.py
+++ b/NuRadioReco/modules/voltageToAnalyticEfieldConverter.py
@@ -10,7 +10,7 @@ from radiotools import helper as hp
 from radiotools import coordinatesystems
 from NuRadioReco.detector import antennapattern
 from NuRadioReco.utilities import geometryUtilities as geo_utl
-from NuRadioReco.utilities import units, fft, trace_utilities
+from NuRadioReco.utilities import units, fft, trace_utilities, signal_processing
 from NuRadioReco.utilities import analytic_pulse as pulse
 from NuRadioReco.modules.voltageToEfieldConverter import get_array_of_channels
 from NuRadioReco.framework.parameters import stationParameters as stnp
@@ -625,7 +625,7 @@ class voltageToAnalyticEfieldConverter:
         second_order_correction = res_amp_second_order.x[2]
         electric_field.set_parameter(efp.cr_spectrum_quadratic_term, second_order_correction)
         # figure out the timing of the electric field
-        voltages_from_efield = trace_utilities.get_channel_voltage_from_efield(station, electric_field, use_channels, det, zenith, azimuth, self.antenna_provider, False)
+        voltages_from_efield = signal_processing.get_channel_voltage_from_efield(station, electric_field, use_channels, det, zenith, azimuth, self.antenna_provider, False)
         correlation = np.zeros(voltages_from_efield.shape[1] + station.get_channel(use_channels[0]).get_trace().shape[0] - 1)
         channel_trace_start_times = []
         for channel_id in use_channels:

--- a/NuRadioReco/modules/voltageToEfieldConverter.py
+++ b/NuRadioReco/modules/voltageToEfieldConverter.py
@@ -5,7 +5,7 @@ from NuRadioReco.utilities import geometryUtilities as geo_utl
 from NuRadioReco.utilities import units
 from NuRadioReco.utilities import ice
 from NuRadioReco.detector import antennapattern
-from NuRadioReco.utilities import trace_utilities
+from NuRadioReco.utilities import signal_processing
 import NuRadioReco.framework.base_trace
 import NuRadioReco.framework.electric_field
 import matplotlib.pyplot as plt
@@ -81,7 +81,7 @@ def get_array_of_channels(station, use_channels, det, zenith, azimuth,
     for iCh, trace in enumerate(traces):
         V[iCh] = trace.get_frequency_spectrum()
 
-    efield_antenna_factor = trace_utilities.get_efield_antenna_factor(station, frequencies, use_channels, det, zenith, azimuth, antenna_pattern_provider)
+    efield_antenna_factor = signal_processing.get_efield_antenna_factor(station, frequencies, use_channels, det, zenith, azimuth, antenna_pattern_provider)
 
     if(debug_cut):
         plt.show()

--- a/NuRadioReco/modules/voltageToEfieldConverterPerChannel.py
+++ b/NuRadioReco/modules/voltageToEfieldConverterPerChannel.py
@@ -1,6 +1,6 @@
 from NuRadioReco.modules.base.module import register_run
 import numpy as np
-from NuRadioReco.utilities import trace_utilities
+from NuRadioReco.utilities import signal_processing
 from NuRadioReco.detector import antennapattern
 from NuRadioReco.framework.parameters import stationParameters as stnp
 from NuRadioReco.framework.parameters import electricFieldParameters as efp
@@ -58,7 +58,7 @@ class voltageToEfieldConverterPerChannel:
 
         use_channels = det.get_channel_ids(station.get_id())
         frequencies = station.get_channel(use_channels[0]).get_frequencies()  # assuming that all channels have the  same sampling rate and length
-        efield_antenna_factor = trace_utilities.get_efield_antenna_factor(station, frequencies, use_channels, det,
+        efield_antenna_factor = signal_processing.get_efield_antenna_factor(station, frequencies, use_channels, det,
                                                                           zenith, azimuth, self.antenna_provider)
 
         sampling_rate = station.get_channel(use_channels[0]).get_sampling_rate()

--- a/NuRadioReco/modules/voltageToEfieldConverterPerChannelGroup.py
+++ b/NuRadioReco/modules/voltageToEfieldConverterPerChannelGroup.py
@@ -1,6 +1,6 @@
 from NuRadioReco.modules.base.module import register_run
 import numpy as np
-from NuRadioReco.utilities import trace_utilities
+from NuRadioReco.utilities import signal_processing
 from NuRadioReco.detector import antennapattern
 from NuRadioReco.framework.parameters import stationParameters as stnp
 from NuRadioReco.framework.parameters import electricFieldParameters as efp
@@ -12,9 +12,9 @@ import logging
 
 class voltageToEfieldConverterPerChannelGroup:
     """
-    This module is intended to reconstruct the electric field from dual-polarized antennas, 
-    i.e., two antennas with orthogonal polarizations combined in one mechanical structure. 
-    This is the typical case for air-shower detectors such as Auger and LOFAR. 
+    This module is intended to reconstruct the electric field from dual-polarized antennas,
+    i.e., two antennas with orthogonal polarizations combined in one mechanical structure.
+    This is the typical case for air-shower detectors such as Auger and LOFAR.
 
     Converts voltage trace to electric field per channel group.
     """
@@ -77,7 +77,7 @@ class voltageToEfieldConverterPerChannelGroup:
                 pos.append(det.get_relative_position(station.get_id(), channel_id))
             pos = np.array(pos)
             pos = np.average(pos, axis=0)
-            efield_antenna_factor = trace_utilities.get_efield_antenna_factor(station, frequencies, use_channels, det,
+            efield_antenna_factor = signal_processing.get_efield_antenna_factor(station, frequencies, use_channels, det,
                                                                             zenith, azimuth, self.antenna_provider)
             V = np.zeros((len(use_channels), len(frequencies)), dtype=complex)
             for i_ch, channel_id in enumerate(use_channels):

--- a/NuRadioReco/utilities/geometryUtilities.py
+++ b/NuRadioReco/utilities/geometryUtilities.py
@@ -8,11 +8,10 @@ logger = logging.getLogger('NuRadioReco.geometryUtilities')
 
 def get_time_delay_from_direction(zenith, azimuth, positions, n=1.000293):
     """
-    Calculate the time delay between given positions for an arrival direction
+    Calculate the time delay between given positions for an arrival direction (plane wave)
 
     Parameters
     ----------
-
     zenith: float [rad]
         Zenith angle in convention up = 0
     azimuth: float [rad]
@@ -88,7 +87,7 @@ def get_efield_in_spherical_coords(efield, theta, phi):
         Zenith angle of the arriving signal
     phi: float
         Azimuth angle of the arriving signal
-    
+
     Returns
     -------
     np.array
@@ -113,7 +112,7 @@ def get_efield_in_spherical_coords(efield, theta, phi):
 
 
 def get_fresnel_angle(zenith_incoming, n_2=1.3, n_1=1.):
-    """ Apply Snell's law for given zenith angle, when a signal travels from n1 to n2 
+    """ Apply Snell's law for given zenith angle, when a signal travels from n1 to n2
 
     Parameters
     ----------
@@ -261,9 +260,9 @@ def get_fresnel_r_s(zenith_incoming, n_2=1.3, n_1=1.):
 
 def fresnel_factors_and_signal_zenith(detector, station, channel_id, zenith):
     """
-    Returns the zenith angle at the antenna and the fresnel coefficients t for theta (parallel) 
-    and phi (perpendicular) polarization. Handles potential refraction into the firn if that 
-    applies to the antenna position. 
+    Returns the zenith angle at the antenna and the fresnel coefficients t for theta (parallel)
+    and phi (perpendicular) polarization. Handles potential refraction into the firn if that
+    applies to the antenna position.
     WARNING: for deeper channels this function might be inacccurate. Consider using raytracing.
 
     parallel and perpendicular refers to the signal's polarization with respect
@@ -281,7 +280,7 @@ def fresnel_factors_and_signal_zenith(detector, station, channel_id, zenith):
         Channel ID of the desired channel
     zenith: float
         Zenith angle of the incoming signal
-    
+
     Returns
     -------
     zenith_antenna: float

--- a/NuRadioReco/utilities/signal_processing.py
+++ b/NuRadioReco/utilities/signal_processing.py
@@ -1,9 +1,14 @@
-from NuRadioReco.utilities import units
+from NuRadioReco.utilities import units, geometryUtilities as geo_utl, fft
+
 from NuRadioReco.detector import detector
 from NuRadioReco.framework.sim_station import SimStation
 
 from scipy.signal.windows import hann
 import numpy as np
+
+import logging
+logger = logging.getLogger('NuRadioReco.signal_processing')
+
 
 
 def half_hann_window(length, half_percent=None, hann_window_length=None):
@@ -82,3 +87,80 @@ def add_cable_delay(station, det, sim_to_data=None, trigger=False, logger=None):
                         f"of cable delay to channel {channel.get_id()}")
 
         channel.add_trace_start_time(add_or_subtract * cable_delay)
+
+
+def get_efield_antenna_factor(station, frequencies, channels, detector, zenith, azimuth, antenna_pattern_provider):
+    """
+    Returns the antenna response to a radio signal coming from a specific direction
+
+    Parameters
+    ----------
+
+    station: Station
+    frequencies: array of complex
+        frequencies of the radio signal for which the antenna response is needed
+    channels: array of int
+        IDs of the channels
+    detector: Detector
+    zenith, azimuth: float, float
+        incoming direction of the signal. Note that refraction and reflection at the ice/air boundary are taken into account
+    antenna_pattern_provider: AntennaPatternProvider
+    """
+
+    efield_antenna_factor = np.zeros((len(channels), 2, len(frequencies)), dtype=complex)  # from antenna model in e_theta, e_phi
+    for iCh, channel_id in enumerate(channels):
+        zenith_antenna, t_theta, t_phi = geo_utl.fresnel_factors_and_signal_zenith(detector, station, channel_id, zenith)
+
+        if zenith_antenna is None:
+            logger.warning("Fresnel reflection at air-firn boundary leads to unphysical results, no reconstruction possible")
+            return None
+
+        logger.debug("angles: zenith {0:.0f}, zenith antenna {1:.0f}, azimuth {2:.0f}".format(
+            np.rad2deg(zenith), np.rad2deg(zenith_antenna), np.rad2deg(azimuth)))
+        antenna_model = detector.get_antenna_model(station.get_id(), channel_id, zenith_antenna)
+        antenna_pattern = antenna_pattern_provider.load_antenna_pattern(antenna_model)
+        ori = detector.get_antenna_orientation(station.get_id(), channel_id)
+        VEL = antenna_pattern.get_antenna_response_vectorized(frequencies, zenith_antenna, azimuth, *ori)
+        efield_antenna_factor[iCh] = np.array([VEL['theta'] * t_theta, VEL['phi'] * t_phi])
+
+    return efield_antenna_factor
+
+
+def get_channel_voltage_from_efield(
+        station, electric_field, channels, detector,
+        zenith, azimuth, antenna_pattern_provider, return_spectrum=True):
+    """
+    Returns the voltage traces that would result in the channels from the station's E-field.
+
+    Parameters
+    ----------
+
+    station: Station
+    electric_field: ElectricField
+    channels: array of int
+        IDs of the channels for which the expected voltages should be calculated
+    detector: Detector
+    zenith, azimuth: float
+        incoming direction of the signal. Note that reflection and refraction
+        at the air/ice boundary are already being taken into account.
+    antenna_pattern_provider: AntennaPatternProvider
+    return_spectrum: boolean
+        if True, returns the spectrum, if False return the time trace
+    """
+
+    frequencies = electric_field.get_frequencies()
+    spectrum = electric_field.get_frequency_spectrum()
+    efield_antenna_factor = get_efield_antenna_factor(station, frequencies, channels, detector, zenith, azimuth, antenna_pattern_provider)
+    if return_spectrum:
+        voltage_spectrum = np.zeros((len(channels), len(frequencies)), dtype=complex)
+        for i_ch, ch in enumerate(channels):
+            voltage_spectrum[i_ch] = np.sum(efield_antenna_factor[i_ch] * np.array([spectrum[1], spectrum[2]]), axis=0)
+        return voltage_spectrum
+    else:
+        voltage_trace = np.zeros((len(channels), 2 * (len(frequencies) - 1)), dtype=complex)
+        for i_ch, ch in enumerate(channels):
+            voltage_trace[i_ch] = fft.freq2time(
+                np.sum(efield_antenna_factor[i_ch] * np.array([spectrum[1], spectrum[2]]), axis=0),
+                electric_field.get_sampling_rate())
+
+        return np.real(voltage_trace)

--- a/NuRadioReco/utilities/trace_utilities.py
+++ b/NuRadioReco/utilities/trace_utilities.py
@@ -1,4 +1,4 @@
-from NuRadioReco.utilities import units, ice, geometryUtilities as geo_utl, fft
+from NuRadioReco.utilities import units, fft, signal_processing
 import NuRadioReco.framework.base_trace
 
 import numpy as np
@@ -12,91 +12,48 @@ conversion_factor_integrated_signal = scipy.constants.c * scipy.constants.epsilo
 # see Phys. Rev. D DOI: 10.1103/PhysRevD.93.122005
 # to convert V**2/m**2 * s -> J/m**2 -> eV/m**2
 
-
-def get_efield_antenna_factor(station, frequencies, channels, detector, zenith, azimuth, antenna_pattern_provider):
-    """
-    Returns the antenna response to a radio signal coming from a specific direction
-
-    Parameters
-    ----------
-
-    station: Station
-    frequencies: array of complex
-        frequencies of the radio signal for which the antenna response is needed
-    channels: array of int
-        IDs of the channels
-    detector: Detector
-    zenith, azimuth: float, float
-        incoming direction of the signal. Note that refraction and reflection at the ice/air boundary are taken into account
-    antenna_pattern_provider: AntennaPatternProvider
-    """
-
-    efield_antenna_factor = np.zeros((len(channels), 2, len(frequencies)), dtype=complex)  # from antenna model in e_theta, e_phi
-    for iCh, channel_id in enumerate(channels):
-        zenith_antenna, t_theta, t_phi = geo_utl.fresnel_factors_and_signal_zenith(detector, station, channel_id, zenith)
-
-        if zenith_antenna is None:
-            logger.warning("Fresnel reflection at air-firn boundary leads to unphysical results, no reconstruction possible")
-            return None
-
-        logger.debug("angles: zenith {0:.0f}, zenith antenna {1:.0f}, azimuth {2:.0f}".format(
-            np.rad2deg(zenith), np.rad2deg(zenith_antenna), np.rad2deg(azimuth)))
-        antenna_model = detector.get_antenna_model(station.get_id(), channel_id, zenith_antenna)
-        antenna_pattern = antenna_pattern_provider.load_antenna_pattern(antenna_model)
-        ori = detector.get_antenna_orientation(station.get_id(), channel_id)
-        VEL = antenna_pattern.get_antenna_response_vectorized(frequencies, zenith_antenna, azimuth, *ori)
-        efield_antenna_factor[iCh] = np.array([VEL['theta'] * t_theta, VEL['phi'] * t_phi])
-
-    return efield_antenna_factor
+def get_efield_antenna_factor(*args, **kwargs):
+    logger.warning("get_efield_antenna_factor is moved to NuRadioReco.utilities.signal_processing.get_efield_antenna_factor")
+    return signal_processing.get_efield_antenna_factor(*args, **kwargs)
 
 
-def get_channel_voltage_from_efield(station, electric_field, channels, detector, zenith, azimuth, antenna_pattern_provider, return_spectrum=True):
-    """
-    Returns the voltage traces that would result in the channels from the station's E-field.
-
-    Parameters
-    ----------
-
-    station: Station
-    electric_field: ElectricField
-    channels: array of int
-        IDs of the channels for which the expected voltages should be calculated
-    detector: Detector
-    zenith, azimuth: float
-        incoming direction of the signal. Note that reflection and refraction
-        at the air/ice boundary are already being taken into account.
-    antenna_pattern_provider: AntennaPatternProvider
-    return_spectrum: boolean
-        if True, returns the spectrum, if False return the time trace
-    """
-
-    frequencies = electric_field.get_frequencies()
-    spectrum = electric_field.get_frequency_spectrum()
-    efield_antenna_factor = get_efield_antenna_factor(station, frequencies, channels, detector, zenith, azimuth, antenna_pattern_provider)
-    if return_spectrum:
-        voltage_spectrum = np.zeros((len(channels), len(frequencies)), dtype=complex)
-        for i_ch, ch in enumerate(channels):
-            voltage_spectrum[i_ch] = np.sum(efield_antenna_factor[i_ch] * np.array([spectrum[1], spectrum[2]]), axis=0)
-        return voltage_spectrum
-    else:
-        voltage_trace = np.zeros((len(channels), 2 * (len(frequencies) - 1)), dtype=complex)
-        for i_ch, ch in enumerate(channels):
-            voltage_trace[i_ch] = fft.freq2time(np.sum(efield_antenna_factor[i_ch] * np.array([spectrum[1], spectrum[2]]), axis=0), electric_field.get_sampling_rate())
-        return np.real(voltage_trace)
+def get_channel_voltage_from_efield(*args, **kwargs):
+    logger.warning("get_channel_voltage_from_efield is moved to NuRadioReco.utilities.signal_processing.get_channel_voltage_from_efield")
+    return signal_processing.get_channel_voltage_from_efield(*args, **kwargs)
 
 
 def get_electric_field_energy_fluence(electric_field_trace, times, signal_window_mask=None, noise_window_mask=None):
+    """ Compute the energy fluence of an electric field trace.
 
+    Parameters
+    ----------
+    electric_field_trace : 2d array
+        The electric field trace. The first dimension corresponds to the number of traces/polarizations,
+        the second dimension to the number of samples.
+    times : 1d array
+        The times corresponding to the electric field trace.
+    signal_window_mask : 1d array, default=None
+        A boolean mask to select the signal window.
+    noise_window_mask : 1d array, default=None
+        A boolean mask to select the noise window.
+
+    Returns
+    -------
+    energy_fluence : 1d array
+        The energy fluence of the electric field per polarization.
+    """
     if signal_window_mask is None:
         f_signal = np.sum(electric_field_trace ** 2, axis=1)
     else:
         f_signal = np.sum(electric_field_trace[:, signal_window_mask] ** 2, axis=1)
-    dt = times[1] - times[0]
+
     if noise_window_mask is not None and np.sum(noise_window_mask) > 0:
         f_noise = np.sum(electric_field_trace[:, noise_window_mask] ** 2, axis=1)
         f_signal -= f_noise * np.sum(signal_window_mask) / np.sum(noise_window_mask)
 
+    dt = times[1] - times[0]
     return f_signal * dt * conversion_factor_integrated_signal
+
 
 def get_stokes(trace_u, trace_v, window_samples=128, squeeze=True):
     """
@@ -174,6 +131,7 @@ def get_stokes(trace_u, trace_v, window_samples=128, squeeze=True):
         return np.squeeze(stokes)
     return stokes
 
+
 def upsampling_fir(trace, original_sampling_frequency, int_factor=2, ntaps=2 ** 7):
     """
     This function performs an upsampling by inserting a number of zeroes
@@ -249,7 +207,7 @@ def butterworth_filter_trace(trace, sampling_frequency, passband, order=8):
     n_samples = len(trace)
 
     spectrum = fft.time2freq(trace, sampling_frequency)
-    frequencies = np.fft.rfftfreq(n_samples, 1 / sampling_frequency)
+    frequencies = fft.freqs(n_samples, sampling_frequency)
 
     filtered_spectrum = apply_butterworth(spectrum, frequencies, passband, order)
     filtered_trace = fft.freq2time(filtered_spectrum, sampling_frequency)
@@ -340,7 +298,7 @@ def delay_trace(trace, sampling_frequency, time_delay, crop_trace=True):
     else:
         n_samples = len(trace)
         spectrum = fft.time2freq(trace, sampling_frequency)
-        frequencies = np.fft.rfftfreq(n_samples, 1 / sampling_frequency)
+        frequencies = fft.freqs(n_samples, sampling_frequency)
 
     spectrum *= np.exp(-1j * 2 * np.pi * frequencies * time_delay)
 


### PR DESCRIPTION
This PR does three things:
- It replace the `sim_station.is_cosmic_ray()` condition with `dist_antenna_efield < 0.01 * units.mm` to add an additional time shift to the signals.
- It lets the module `efieldToVoltageConverterPerEfield` use the function `calculate_time_shift_for_cosmic_ray` defined in `efieldToVoltageConverter` to calculate the time shift
- It modifies `calculate_time_shift_for_cosmic_ray` in two ways. Instead of using the antenna position relative to the efield position to define the refractive index, it now uses the antenna position relative to the station and instead of the signal direction in sim_station it now uses the signal direction in the electric field.