### PR TITLE
Efield fluence rice dist estimator

### DIFF
--- a/NuRadioReco/modules/electricFieldSignalReconstructor.py
+++ b/NuRadioReco/modules/electricFieldSignalReconstructor.py
@@ -33,7 +33,7 @@ class electricFieldSignalReconstructor:
         logger.setLevel(log_level)
 
     @register_run()
-    def run(self, evt, station, det, debug=False):
+    def run(self, evt, station, det, fluence_method="noise_subtraction", debug=False):
         """
         reconstructs quantities for electric field
 
@@ -102,13 +102,7 @@ class electricFieldSignalReconstructor:
                 # set the noise window to the first "self.__noise_window" ns of the trace. If this cuts into the signal window, the noise window is reduced to not overlap with the signal window
                 mask_noise_window = times < min(times[0] + self.__noise_window, signal_time - self.__signal_window_pre)
 
-            signal_energy_fluence = trace_utilities.get_electric_field_energy_fluence(trace, times, mask_signal_window, mask_noise_window)
-            dt = times[1] - times[0]
-            signal_energy_fluence_error = np.zeros(3)
-            if(np.sum(mask_noise_window)):
-                RMSNoise = np.sqrt(np.mean(trace[:, mask_noise_window] ** 2, axis=1))
-                signal_energy_fluence_error = (4 * np.abs(signal_energy_fluence / self.__conversion_factor_integrated_signal) * RMSNoise ** 2 * dt + 2 * (self.__signal_window_pre + self.__signal_window_post) * RMSNoise ** 4 * dt) ** 0.5
-            signal_energy_fluence_error *= self.__conversion_factor_integrated_signal
+            signal_energy_fluence, signal_energy_fluence_error = trace_utilities.get_electric_field_energy_fluence(trace, times, mask_signal_window, mask_noise_window, return_error=True, method=fluence_method)
             electric_field.set_parameter(efp.signal_energy_fluence, signal_energy_fluence)
             electric_field.set_parameter_error(efp.signal_energy_fluence, signal_energy_fluence_error)
 

--- a/NuRadioReco/utilities/fluence_rice_dist_estimator.py
+++ b/NuRadioReco/utilities/fluence_rice_dist_estimator.py
@@ -1,0 +1,142 @@
+import numpy as np
+import scipy.constants
+import scipy.signal
+from NuRadioReco.utilities import units
+from NuRadioReco.utilities import ice
+from NuRadioReco.utilities import geometryUtilities as geo_utl
+from NuRadioReco.utilities import fft
+import logging
+logger = logging.getLogger('NuRadioReco.fluence_rice_dist_estimator')
+
+
+# def amp_spec(trace, dt_sec=1.e-9):
+# 	from scipy.fft import fft,fftfreq
+# 	micro = 1e-6
+# 	n = int(len(trace))
+# 	amp = np.abs(fft(trace))*dt_sec/micro
+# 	freq = fftfreq(n,dt_sec)*micro
+# 	return np.asarray(amp[:int(n/2)]), np.asarray(freq[:int(n/2)])
+
+#windowing is necessary to avoid artifacts when performing DFT.
+def tukey_window(n_samples, relative_taper_width):
+	"""
+	Generate a Tukey window.
+
+	Parameters
+	----------
+	n_samples : int
+		Number of samples in the window.
+	relative_taper_width : float
+		Relative width of the taper region. 0 corresponds to a rectangular window, 1 to a Hann window.
+
+	Returns
+	-------
+	np.ndarray
+		Tukey window of length `n_samples`.
+	"""
+	number_taper_samples = int(np.floor(relative_taper_width * n_samples))
+	window = np.ones(n_samples)
+
+	# Rising taper region
+	for i in range(number_taper_samples):
+		window[i] = 0.5 * (1 - np.cos(np.pi * i / number_taper_samples))
+
+    # Falling taper region
+	for i in range(n_samples - number_taper_samples, n_samples):
+		reverse_bin = n_samples - i - 1
+		window[i] = 0.5 * (1 - np.cos(np.pi * reverse_bin / number_taper_samples))
+
+	return window
+
+
+def get_noise_fluence_estimators(trace, times, t_peak, f_low=30*units.MHz, f_high=80*units.MHz, spacing_noise_signal=20*units.ns, window_length_tot=140*units.ns, relative_taper_width=0.142857143, use_median_value=True):
+
+	#times = np.arange(0, len(trace)*dt, dt)
+	dt = times[1] - times[0]
+	signal_start, signal_stop = t_peak - spacing_noise_signal - window_length_tot/2, t_peak + spacing_noise_signal + window_length_tot/2
+	list_ffts_squared=[]  
+	# Generate Tukey window
+	print()
+	print(window_length_tot)
+	window = tukey_window(int(window_length_tot / dt), relative_taper_width)
+
+	#loop over the trace defining noise windows (excluding the signal window)
+	noise_start=0
+	while noise_start < np.max(times):
+		
+		noise_stop = noise_start + window_length_tot
+		if noise_stop > (len(trace) * dt):
+			break
+
+		elif (noise_stop <= signal_start and noise_start < signal_start) or (noise_stop > signal_stop and noise_start >= signal_stop):
+
+			#clipping the noise window
+			mask_time = np.all([times >= noise_start, times<noise_stop], axis=0) 
+			time_trace_clipped = trace[mask_time]
+			
+			#applying the Tukey window
+			if len(time_trace_clipped) != len(window): # This is prbabaly not the best solution, but it will run
+				window = tukey_window(len(time_trace_clipped), relative_taper_width)
+			windowed_trace = time_trace_clipped * window
+
+			#calculating the spectrum and frequencies
+			frequencies_window = np.fft.rfftfreq(len(windowed_trace), d=dt)
+			spectrum_window = fft.time2freq(windowed_trace, 1/dt)
+			#spec_wind, ff_wind = amp_spec(windowed_trace, dt_sec=dt_ns*1.e-9)
+
+			#masking the frequencies outside the initial frequency bandwidt
+			mask_freq = np.all([frequencies_window >= f_low, frequencies_window <= f_high], axis=0)
+			frequencies_window = frequencies_window[mask_freq] 
+			spectrum_window = spectrum_window[mask_freq]
+			list_ffts_squared.append(spectrum_window**2)
+			noise_start = noise_stop
+
+		elif noise_stop > signal_start and noise_start <= signal_start:
+			noise_start = signal_stop
+
+		else:
+			print("Your peak is at zero or negative time...! ") 
+
+	list_ffts_squared = np.array(list_ffts_squared, dtype=float)
+	
+	if use_median_value:
+		#robust estimator in presence of outliers from the noise windows  
+		estimators = np.median(list_ffts_squared, axis=0) / 1.405 #from chi2 distribution
+	else:
+		#it works well in presence of small number of outliers 
+		estimators=np.mean(list_ffts_squared, axis=0) 
+	
+	return estimators, frequencies_window
+
+
+def get_signal_fluence_estimators(trace, times, t_peak, noise_estimators, f_low=30*units.MHz ,f_high=80*units.MHz, window_length_tot=140*units.ns, relative_taper_width=0.142857143):
+
+	#times = np.arange(0, len(trace)*dt, dt)
+	dt = times[1] - times[0]
+	signal_start, signal_stop = t_peak - window_length_tot/2, t_peak + window_length_tot/2
+
+	# Generate Tukey window
+	window = tukey_window(int(window_length_tot/dt), relative_taper_width)
+
+	#clipping the signal window around the pulse position
+	mask_time = np.all([times >= signal_start, times < signal_stop], axis=0) 
+	trace_clipped = trace[mask_time]
+
+	#applying the Tukey window 
+	windowed_trace = trace_clipped * window 
+
+	#calculating the spectrum and frequencies
+	frequencies_window = np.fft.rfftfreq(len(windowed_trace), d=dt)
+	spectrum_window = fft.time2freq(windowed_trace, 1/dt) #amp_spec(windowed_trace, dt_sec=dt_ns*1.e-9)
+
+	#masking the frequencies outside the initial frequency bandwidth
+	mask_freq = np.all([frequencies_window >= f_low, frequencies_window <= f_high], axis=0)
+	frequencies_window = frequencies_window[mask_freq] 
+	spectrum_window = spectrum_window[mask_freq]
+
+	#signal estimator and variance for each frequency bin 
+	signal_estimators = spectrum_window**2 - noise_estimators
+	signal_estimators[signal_estimators < 0] = 0
+	variances = noise_estimators * (noise_estimators + 2*signal_estimators)
+	
+	return signal_estimators, variances

--- a/NuRadioReco/utilities/fluence_rice_dist_estimator.py
+++ b/NuRadioReco/utilities/fluence_rice_dist_estimator.py
@@ -51,45 +51,38 @@ def tukey_window(n_samples, relative_taper_width):
 	return window
 
 
-def get_noise_fluence_estimators(trace, times, t_peak, f_low=30*units.MHz, f_high=80*units.MHz, spacing_noise_signal=20*units.ns, window_length_tot=140*units.ns, relative_taper_width=0.142857143, use_median_value=True):
+def get_noise_fluence_estimators(trace, times, t_peak, spacing_noise_signal=20*units.ns, window_length_tot=140*units.ns, relative_taper_width=0.142857143, use_median_value=True):
 
-	#times = np.arange(0, len(trace)*dt, dt)
 	dt = times[1] - times[0]
-	signal_start, signal_stop = t_peak - spacing_noise_signal - window_length_tot/2, t_peak + spacing_noise_signal + window_length_tot/2
+	n_samples_window = int(window_length_tot / dt)
+	signal_start = t_peak - spacing_noise_signal - n_samples_window * dt / 2
+	signal_stop = t_peak + spacing_noise_signal + n_samples_window * dt / 2
 	list_ffts_squared = []
 
-	# Generate Tukey window
-	window = tukey_window(int(window_length_tot / dt), relative_taper_width)
+	#generate Tukey window
+	window = tukey_window(n_samples_window, relative_taper_width)
 
 	#loop over the trace defining noise windows (excluding the signal window)
 	noise_start = times[0]
-	count = 0
-	while noise_start < np.max(times):
-		
-		noise_stop = noise_start + window_length_tot
-		if noise_stop > (len(trace) * dt):
+	while noise_start < times[-1]:
+
+		noise_stop = noise_start + n_samples_window * dt
+		if noise_stop > times[-1]:
 			break
 
 		elif (noise_stop <= signal_start and noise_start < signal_start) or (noise_stop > signal_stop and noise_start >= signal_stop):
 
 			#clipping the noise window
-			mask_time = np.all([times >= noise_start, times<noise_stop], axis=0) 
+			mask_time = np.all([np.round(times, 5) >= np.round(noise_start, 5), np.round(times, 5) < np.round(noise_stop, 5)], axis=0)
 			time_trace_clipped = trace[mask_time]
-			
+
 			#applying the Tukey window
-			if len(time_trace_clipped) != len(window): # This is prbabaly not the best solution, but it will run
-				window = tukey_window(len(time_trace_clipped), relative_taper_width)
-				print("Window length is not the same as the trace length. This is not optimal.")
 			windowed_trace = time_trace_clipped * window
 
 			#calculating the spectrum and frequencies
 			frequencies_window = np.fft.rfftfreq(len(windowed_trace), d=dt)
 			spectrum_window = np.abs(fft.time2freq(windowed_trace, 1/dt))
 
-			#masking the frequencies outside the initial frequency bandwidt
-			mask_freq = np.all([frequencies_window >= f_low, frequencies_window <= f_high], axis=0)
-			frequencies_window = frequencies_window[mask_freq] 
-			spectrum_window = spectrum_window[mask_freq]
 			list_ffts_squared.append(spectrum_window**2)
 			noise_start = noise_stop
 
@@ -97,51 +90,46 @@ def get_noise_fluence_estimators(trace, times, t_peak, f_low=30*units.MHz, f_hig
 			noise_start = signal_stop
 
 		else:
-			print("Your peak is at zero or negative time...! ") 
-			count += 1
-			if count > 1000:
-				break # find better solution
+			print("Your peak is at zero or negative time...! ")
+			break
 
 	list_ffts_squared = np.array(list_ffts_squared, dtype=float)
-	
+
 	if use_median_value:
 		#robust estimator in presence of outliers from the noise windows  
 		estimators = np.median(list_ffts_squared, axis=0) / 1.405 #from chi2 distribution
 	else:
 		#it works well in presence of small number of outliers 
 		estimators=np.mean(list_ffts_squared, axis=0) 
-	
+
 	return estimators, frequencies_window
 
 
-def get_signal_fluence_estimators(trace, times, t_peak, noise_estimators, f_low=30*units.MHz ,f_high=80*units.MHz, window_length_tot=140*units.ns, relative_taper_width=0.142857143):
 
-	#times = np.arange(0, len(trace)*dt, dt)
+
+def get_signal_fluence_estimators(trace, times, t_peak, noise_estimators, window_length_tot=140*units.ns, relative_taper_width=0.142857143):
+	
 	dt = times[1] - times[0]
-	signal_start, signal_stop = t_peak - window_length_tot/2, t_peak + window_length_tot/2
+	n_samples_window = int(window_length_tot / dt)
+	signal_start = t_peak - n_samples_window * dt / 2
+	signal_stop = t_peak + n_samples_window * dt / 2
 
-	# Generate Tukey window
-	window = tukey_window(int(window_length_tot/dt), relative_taper_width)
+	#generate Tukey window
+	window = tukey_window(n_samples_window, relative_taper_width)
 
 	#clipping the signal window around the pulse position
-	mask_time = np.all([times >= signal_start, times < signal_stop], axis=0) 
+	mask_time = np.all([np.round(times, 5) >= np.round(signal_start, 5), np.round(times, 5) < np.round(signal_stop, 5)], axis=0)
 	trace_clipped = trace[mask_time]
 
 	#applying the Tukey window 
 	windowed_trace = trace_clipped * window 
 
 	#calculating the spectrum and frequencies
-	frequencies_window = np.fft.rfftfreq(len(windowed_trace), d=dt)
 	spectrum_window = np.abs(fft.time2freq(windowed_trace, 1/dt))
-
-	#masking the frequencies outside the initial frequency bandwidth
-	mask_freq = np.all([frequencies_window >= f_low, frequencies_window <= f_high], axis=0)
-	frequencies_window = frequencies_window[mask_freq] 
-	spectrum_window = spectrum_window[mask_freq]
 
 	#signal estimator and variance for each frequency bin 
 	signal_estimators = spectrum_window**2 - noise_estimators
 	signal_estimators[signal_estimators < 0] = 0
 	variances = noise_estimators * (noise_estimators + 2*signal_estimators)
-	
+
 	return signal_estimators, variances

--- a/NuRadioReco/utilities/trace_utilities.py
+++ b/NuRadioReco/utilities/trace_utilities.py
@@ -137,8 +137,6 @@ def get_electric_field_energy_fluence(electric_field_trace, times, signal_window
                 trace = electric_field_trace[i_pol,:],
                 times = times,
                 t_peak = np.mean(times[signal_window_mask]), # This is not necessarily the peak time
-                f_low = 30 * units.MHz,
-                f_high = 80 * units.MHz,
                 spacing_noise_signal = 20,
                 window_length_tot = sum(signal_window_mask) * dt,
                 relative_taper_width = 0.142857143,
@@ -149,8 +147,6 @@ def get_electric_field_energy_fluence(electric_field_trace, times, signal_window
                 times = times,
                 t_peak = np.mean(times[signal_window_mask]),
                 noise_estimators = noise_estimators,
-                f_low = 30 * units.MHz,
-                f_high = 80 * units.MHz,
                 window_length_tot = sum(signal_window_mask) * dt,
                 relative_taper_width = 0.142857143,
                 )
@@ -183,8 +179,8 @@ def get_electric_field_energy_fluence(electric_field_trace, times, signal_window
             noise_estimators, frequencies_window = get_noise_fluence_estimators_sara(
                 time_trace = electric_field_trace[i_pol,:],
                 t_peak_ns = np.mean(times[signal_window_mask]), # This is not necessarily the peak time
-                f_low_MHz = 30, #* units.MHz,
-                f_high_MHz = 80, #* units.MHz,
+                f_low_MHz = 0, #* units.MHz,
+                f_high_MHz = 1000, #* units.MHz,
                 spacing_noise_signal_ns = 20,
                 window_length_tot_ns = sum(signal_window_mask) * dt,
                 relative_taper_width = 0.142857143,
@@ -195,8 +191,8 @@ def get_electric_field_energy_fluence(electric_field_trace, times, signal_window
                 time_trace = electric_field_trace[i_pol,:],
                 t_peak_ns = np.mean(times[signal_window_mask]),
                 noise_estimators = noise_estimators,
-                f_low_MHz = 30,# * units.MHz,
-                f_high_MHz = 80,# * units.MHz,
+                f_low_MHz = 0,# * units.MHz,
+                f_high_MHz = 1000,# * units.MHz,
                 window_length_tot_ns = sum(signal_window_mask) * dt,
                 relative_taper_width = 0.142857143,
                 dt_ns=dt,

--- a/NuRadioReco/utilities/trace_utilities.py
+++ b/NuRadioReco/utilities/trace_utilities.py
@@ -14,6 +14,11 @@ conversion_factor_integrated_signal = scipy.constants.c * scipy.constants.epsilo
 
 from NuRadioReco.utilities.fluence_rice_dist_estimator import get_signal_fluence_estimators, get_noise_fluence_estimators
 
+import sys
+sys.path.append("/home/mravn/fluence-and-uncertainty-estimation-based-on-rice-distribution")
+from signal_estimator import get_signal_fluence_estimators as get_signal_fluence_estimators_sara
+from noise_estimator import get_noise_fluence_estimators as get_noise_fluence_estimators_sara
+
 def get_efield_antenna_factor(station, frequencies, channels, detector, zenith, azimuth, antenna_pattern_provider):
     """
     Returns the antenna response to a radio signal coming from a specific direction
@@ -147,29 +152,76 @@ def get_electric_field_energy_fluence(electric_field_trace, times, signal_window
                 f_low = 30 * units.MHz,
                 f_high = 80 * units.MHz,
                 window_length_tot = sum(signal_window_mask) * dt,
-                relative_taper_width = 0.142857143
+                relative_taper_width = 0.142857143,
+                )
+            
+            #sample frequency (after the windowing) in MHz
+            delta_f = frequencies_window[1] - frequencies_window[0]
+
+            #to convert the amplitudes squared into energy fluence units
+            conversion_factor = conversion_factor_integrated_signal #scipy.constants.epsilon_0 * scipy.constants.c / scipy.constants.e
+
+            #correcting for selecting positive frequencies
+            one_side_spectrum_corr_factor = 1 #np.sqrt(2)
+
+            #get the fluence of the trace summing up the frequency estimators and converting in eV/m^2
+            fluence_freq = np.sum(estimators) * ((dt * one_side_spectrum_corr_factor) **2) * delta_f * conversion_factor
+
+            #get the variance of the trace fluence summing up the frequency variances and converting in (eV/m^2)^2
+            fluence_freq_variance = np.sum(variances) * (((dt * one_side_spectrum_corr_factor) **2) * delta_f * conversion_factor) **2
+
+            #get the fluence uncertainty as the root square of the variance
+            fluence_freq_error = np.sqrt(fluence_freq_variance)
+
+            signal_energy_fluence[i_pol] = fluence_freq
+            signal_energy_fluence_error[i_pol] = fluence_freq_error
+
+    elif method == "rice_disttribution_sara":
+        signal_energy_fluence = np.zeros(len(electric_field_trace))
+        signal_energy_fluence_error = np.zeros(len(electric_field_trace))
+        for i_pol in range(len(electric_field_trace)):
+            noise_estimators, frequencies_window = get_noise_fluence_estimators_sara(
+                time_trace = electric_field_trace[i_pol,:],
+                t_peak_ns = np.mean(times[signal_window_mask]), # This is not necessarily the peak time
+                f_low_MHz = 30, #* units.MHz,
+                f_high_MHz = 80, #* units.MHz,
+                spacing_noise_signal_ns = 20,
+                window_length_tot_ns = sum(signal_window_mask) * dt,
+                relative_taper_width = 0.142857143,
+                dt_ns=dt,
+                use_median_value = True
+                )
+            estimators, variances = get_signal_fluence_estimators_sara(
+                time_trace = electric_field_trace[i_pol,:],
+                t_peak_ns = np.mean(times[signal_window_mask]),
+                noise_estimators = noise_estimators,
+                f_low_MHz = 30,# * units.MHz,
+                f_high_MHz = 80,# * units.MHz,
+                window_length_tot_ns = sum(signal_window_mask) * dt,
+                relative_taper_width = 0.142857143,
+                dt_ns=dt,
                 )
 
-        #sample frequency (after the windowing) in MHz
-        delta_f = frequencies_window[1] - frequencies_window[0]
+            #sample frequency (after the windowing) in MHz
+            delta_f = frequencies_window[1] - frequencies_window[0]
 
-        #to convert the amplitudes squared into energy fluence units
-        conversion_factor = scipy.constants.epsilon_0 * scipy.constants.c / scipy.constants.e 
+            #to convert the amplitudes squared into energy fluence units
+            conversion_factor = conversion_factor_integrated_signal #scipy.constants.epsilon_0 * scipy.constants.c / scipy.constants.e
 
-        #correcting for selecting positive frequencies
-        one_side_spectrum_corr_factor = np.sqrt(2)
+            #correcting for selecting positive frequencies
+            one_side_spectrum_corr_factor = np.sqrt(2)
 
-        #get the fluence of the trace summing up the frequency estimators and converting in eV/m^2
-        fluence_freq = np.sum(estimators) * ((dt * one_side_spectrum_corr_factor) **2) * delta_f * conversion_factor
+            #get the fluence of the trace summing up the frequency estimators and converting in eV/m^2
+            fluence_freq = np.sum(estimators) * ((dt * one_side_spectrum_corr_factor) **2) * delta_f * conversion_factor
 
-        #get the variance of the trace fluence summing up the frequency variances and converting in (eV/m^2)^2
-        fluence_freq_variance = np.sum(variances) * (((dt * one_side_spectrum_corr_factor) **2) * delta_f * conversion_factor) **2
+            #get the variance of the trace fluence summing up the frequency variances and converting in (eV/m^2)^2
+            fluence_freq_variance = np.sum(variances) * (((dt * one_side_spectrum_corr_factor) **2) * delta_f * conversion_factor) **2
+            
+            #get the fluence uncertainty as the root square of the variance
+            fluence_freq_error = np.sqrt(fluence_freq_variance)
 
-        #get the fluence uncertainty as the root square of the variance
-        fluence_freq_error = np.sqrt(fluence_freq_variance)
-
-        signal_energy_fluence[i_pol] = fluence_freq
-        signal_energy_fluence_error[i_pol] = fluence_freq_error
+            signal_energy_fluence[i_pol] = fluence_freq * 1000
+            signal_energy_fluence_error[i_pol] = fluence_freq_error * 1000
 
     if return_error:
         return signal_energy_fluence, signal_energy_fluence_error

--- a/NuRadioReco/utilities/trace_utilities.py
+++ b/NuRadioReco/utilities/trace_utilities.py
@@ -115,13 +115,14 @@ def get_electric_field_energy_fluence(electric_field_trace, times, signal_window
     times : numpy.ndarray
         The time grid for the electric field trace
     signal_window_mask : numpy.ndarray
-        A boolean mask that selects the signal window
+        A boolean mask that selects the signal window in which the energy fluence is calculated
     noise_window_mask : numpy.ndarray
         A boolean mask that selects the noise window. Only used if method is "noise_subtraction"
     return_uncertainty : bool
         If True, the uncertainty of the energy fluence is returned
     method : str
-        The method to use for the energy fluence calculation. Can be either "noise_subtraction" or "rice_distribution" (also "rice_disttribution_sara" but this will be removed in future commits)
+        The method to use for the energy fluence calculation. Can be either "noise_subtraction" or "rice_distribution".
+        The Rice distribution is method implementation is based on the code published alongside S. Martinelli et al.: https://arxiv.org/pdf/2407.18654
     """
 
     dt = times[1] - times[0]

--- a/NuRadioReco/utilities/trace_utilities.py
+++ b/NuRadioReco/utilities/trace_utilities.py
@@ -136,21 +136,19 @@ def get_electric_field_energy_fluence(electric_field_trace, times, signal_window
             noise_estimators, frequencies_window = get_noise_fluence_estimators(
                 trace = electric_field_trace[i_pol,:],
                 times = times,
-                t_peak = np.mean(times[signal_window_mask]), # This is not necessarily the peak time
+                signal_window_mask = signal_window_mask,
                 spacing_noise_signal = 20,
-                window_length_tot = sum(signal_window_mask) * dt,
                 relative_taper_width = 0.142857143,
                 use_median_value = True
                 )
             estimators, variances = get_signal_fluence_estimators(
                 trace = electric_field_trace[i_pol,:],
                 times = times,
-                t_peak = np.mean(times[signal_window_mask]),
+                signal_window_mask = signal_window_mask,
                 noise_estimators = noise_estimators,
-                window_length_tot = sum(signal_window_mask) * dt,
                 relative_taper_width = 0.142857143,
                 )
-            
+
             #sample frequency (after the windowing) in MHz
             delta_f = frequencies_window[1] - frequencies_window[0]
 

--- a/NuRadioReco/utilities/trace_utilities.py
+++ b/NuRadioReco/utilities/trace_utilities.py
@@ -149,22 +149,22 @@ def get_electric_field_energy_fluence(electric_field_trace, times, signal_window
             signal_window_duration = sum(signal_window_mask) * dt if signal_window_mask is not None else len(times) * dt
             signal_energy_fluence_error = (4 * np.abs(signal_energy_fluence / conversion_factor_integrated_signal) * RMSNoise ** 2 * dt + 2 * signal_window_duration * RMSNoise ** 4 * dt) ** 0.5  * conversion_factor_integrated_signal
         else:
-            pass #signal_energy_fluence_error = np.zeros(3)
+            signal_energy_fluence_error = np.zeros(3)
     
     elif method == "rice_disttribution":
         signal_energy_fluence = np.zeros(len(electric_field_trace))
         signal_energy_fluence_error = np.zeros(len(electric_field_trace))
         for i_pol in range(len(electric_field_trace)):
             noise_estimators, frequencies_window = get_noise_fluence_estimators(
-                trace = electric_field_trace[i_pol,:],
+                trace = electric_field_trace[i_pol, :],
                 times = times,
                 signal_window_mask = signal_window_mask,
-                spacing_noise_signal = 20,
+                spacing_noise_signal = 20 * units.ns,
                 relative_taper_width = 0.142857143,
-                use_median_value = True
+                use_median_value = False
                 )
             estimators, variances = get_signal_fluence_estimators(
-                trace = electric_field_trace[i_pol,:],
+                trace = electric_field_trace[i_pol, :],
                 times = times,
                 signal_window_mask = signal_window_mask,
                 noise_estimators = noise_estimators,
@@ -175,7 +175,7 @@ def get_electric_field_energy_fluence(electric_field_trace, times, signal_window
             delta_f = frequencies_window[1] - frequencies_window[0]
 
             #to convert the amplitudes squared into energy fluence units
-            conversion_factor = conversion_factor_integrated_signal #scipy.constants.epsilon_0 * scipy.constants.c / scipy.constants.e
+            conversion_factor = conversion_factor_integrated_signal
 
             #correcting for selecting positive frequencies
             one_side_spectrum_corr_factor = 1 #np.sqrt(2)
@@ -205,7 +205,7 @@ def get_electric_field_energy_fluence(electric_field_trace, times, signal_window
                 window_length_tot_ns = sum(signal_window_mask) * dt,
                 relative_taper_width = 0.142857143,
                 dt_ns=dt,
-                use_median_value = True
+                use_median_value = False
                 )
             estimators, variances = get_signal_fluence_estimators_sara(
                 time_trace = electric_field_trace[i_pol,:],

--- a/NuRadioReco/utilities/trace_utilities.py
+++ b/NuRadioReco/utilities/trace_utilities.py
@@ -116,6 +116,7 @@ def get_electric_field_energy_fluence(electric_field_trace, times, signal_window
         if noise_window_mask is not None and np.sum(noise_window_mask) > 0:
             f_noise = np.sum(electric_field_trace[:, noise_window_mask] ** 2, axis=1)
             f_signal -= f_noise * np.sum(signal_window_mask) / np.sum(noise_window_mask)
+            f_signal[f_signal < 0] = 0
 
             if RMSNoise is None:
                 RMSNoise = np.sqrt(np.mean(electric_field_trace[:, noise_window_mask] ** 2, axis=1))


### PR DESCRIPTION
S. Martinelli et al. have recently proposed a method for estimating electric field energy fluences based on Rice distributions in this paper: https://arxiv.org/pdf/2407.18654. This method is a replacement for the noise subtraction we do here https://github.com/nu-radio/NuRadioMC/blob/10902608d54e723977371be43f920dc6e69c1170/NuRadioReco/utilities/trace_utilities.py#L100 and should give a smaller bias at low SNR and correctly estimate uncertainties.

The code was published alongside the paper. I have ported it to NuRadioReco and implemented it in the `electricFieldSignalReconstructor`.