### PR TITLE
Add other CSW variables in stationCoherentlySummedWaveforms.py

### DIFF
--- a/NuRadioReco/framework/parameters.py
+++ b/NuRadioReco/framework/parameters.py
@@ -90,6 +90,9 @@ class channelParametersRNOG(Enum):
 class stationParametersRNOG(Enum):
     # RNO-G specific station parameters
     coherent_snr = 1  #: Signal to Noise Ratio of the coherently summed waveform using the SNR definition of #63 avg_ch_snr
+    coherent_impulsivity = 2  #: impulsivity of the coherently summed waveform
+    coherent_entropy = 3  #: Shannon entropy of the coherently summed waveform
+    coherent_kurtosis = 4  #: kurtosis of the coherently summed waveform
 
 class electricFieldParameters(Enum):
     ray_path_type = 1  #: the type of the ray tracing solution ('direct', 'refracted' or 'reflected')

--- a/NuRadioReco/modules/RNO_G/stationCoherentlySummedWaveforms.py
+++ b/NuRadioReco/modules/RNO_G/stationCoherentlySummedWaveforms.py
@@ -75,7 +75,7 @@ class stationCoherentlySummedWaveforms:
         sum_trace = trace_utilities.get_coherent_sum(trace_set, ref_trace, use_envelope)
         rms = trace_utilities.get_split_trace_noise_RMS(sum_trace, segments=4, lowest=2)
         snr = trace_utilities.get_signal_to_noise_ratio(sum_trace, rms, window_size=coincidence_window_size_bins_ref)
-        impulsivity = trace_utilities.impulsivity(sum_trace)
+        impulsivity = trace_utilities.get_impulsivity(sum_trace)
         entropy = trace_utilities.get_entropy(sum_trace)
         kurtosis = trace_utilities.get_kurtosis(sum_trace)
         

--- a/NuRadioReco/modules/RNO_G/stationCoherentlySummedWaveforms.py
+++ b/NuRadioReco/modules/RNO_G/stationCoherentlySummedWaveforms.py
@@ -75,7 +75,14 @@ class stationCoherentlySummedWaveforms:
         sum_trace = trace_utilities.get_coherent_sum(trace_set, ref_trace, use_envelope)
         rms = trace_utilities.get_split_trace_noise_RMS(sum_trace, segments=4, lowest=2)
         snr = trace_utilities.get_signal_to_noise_ratio(sum_trace, rms, window_size=coincidence_window_size_bins_ref)
+        impulsivity = trace_utilities.impulsivity(sum_trace)
+        entropy = trace_utilities.get_entropy(sum_trace)
+        kurtosis = trace_utilities.get_kurtosis(sum_trace)
+        
         station.set_parameter(stpRNOG.coherent_snr, snr)
+        station.set_parameter(stpRNOG.coherent_impulsivity, impulsivity)
+        station.set_parameter(stpRNOG.coherent_entropy, entropy)
+        station.set_parameter(stpRNOG.coherent_kurtosis, kurtosis)
 
     def end(self):
         """(Unused)"""


### PR DESCRIPTION
**Adding variables:**
coherent impulsivity
coherent entropy
coherent kurtosis

We already have these vars in the channel level but we don't have them for the CSW (station level), we should add them too.