### PR TITLE
Implement core resampling method (from BaseTrace class) in utilities. Make warning smarter

### DIFF
--- a/NuRadioReco/framework/base_trace.py
+++ b/NuRadioReco/framework/base_trace.py
@@ -2,15 +2,11 @@ from __future__ import absolute_import, division, print_function
 
 from NuRadioReco.utilities import fft, bandpass_filter
 import NuRadioReco.detector.response
-from NuRadioReco.utilities import units
+from NuRadioReco.utilities import units, signal_processing
 
 import numpy as np
 import logging
-import fractions
-import decimal
 import numbers
-import functools
-import scipy.signal
 import copy
 import pickle
 logger = logging.getLogger("NuRadioReco.BaseTrace")
@@ -279,22 +275,17 @@ class BaseTrace:
             self.set_frequency_spectrum(spec, self.get_sampling_rate())
 
     def resample(self, sampling_rate):
+        """ Resamples the trace to a new sampling rate.
+
+        Parameters
+        ----------
+        sampling_rate: float
+            The new sampling rate.
+        """
         if sampling_rate == self.get_sampling_rate():
             return
-        resampling_factor = fractions.Fraction(decimal.Decimal(sampling_rate / self.get_sampling_rate())).limit_denominator(5000)
 
-        resampled_trace = self.get_trace()
-        if resampling_factor.numerator != 1:
-            # resample and use axis -1 since trace might be either shape (N) for analytic trace or shape (3,N) for E-field
-            resampled_trace = scipy.signal.resample(resampled_trace, resampling_factor.numerator * self.get_number_of_samples(), axis=-1)
-
-        if resampling_factor.denominator != 1:
-            # resample and use axis -1 since trace might be either shape (N) for analytic trace or shape (3,N) for E-field
-            resampled_trace = scipy.signal.resample(resampled_trace, np.shape(resampled_trace)[-1] // resampling_factor.denominator, axis=-1)
-
-        if resampled_trace.shape[-1] % 2 != 0:
-            resampled_trace = resampled_trace.T[:-1].T
-
+        resampled_trace = signal_processing.resample(self.get_trace(), sampling_rate / self.get_sampling_rate())
         self.set_trace(resampled_trace, sampling_rate)
 
     def serialize(self):

--- a/NuRadioReco/modules/ARA/hardwareResponseIncorporator.py
+++ b/NuRadioReco/modules/ARA/hardwareResponseIncorporator.py
@@ -1,6 +1,7 @@
 from NuRadioReco.detector.ARA import analog_components
 from NuRadioReco.modules.base.module import register_run
-from NuRadioReco.utilities import units, signal_processing
+from NuRadioReco.modules.channelAddCableDelay import add_cable_delay
+
 import numpy as np
 import time
 import logging
@@ -57,7 +58,7 @@ class hardwareResponseIncorporator:
             # Subtraces the cable delay. For `sim_to_data=True`, the cable delay is added
             # in the efieldToVoltageConverter or with the channelCableDelayAdder
             # (if efieldToVoltageConverterPerEfield was used).
-            signal_processing.add_cable_delay(station, det, sim_to_data=False, logger=self.logger)
+            add_cable_delay(station, det, sim_to_data=False, logger=self.logger)
 
         self.__t += time.time() - t
 

--- a/NuRadioReco/modules/ARIANNA/hardwareResponseIncorporator.py
+++ b/NuRadioReco/modules/ARIANNA/hardwareResponseIncorporator.py
@@ -1,7 +1,9 @@
 from NuRadioReco.modules.base.module import register_run
 from NuRadioReco.detector.ARIANNA import analog_components
+from NuRadioReco.modules.channelAddCableDelay import add_cable_delay
+from NuRadioReco.utilities import units, fft
+
 import numpy as np
-from NuRadioReco.utilities import units, fft, signal_processing
 import time
 import logging
 
@@ -151,7 +153,7 @@ class hardwareResponseIncorporator:
             # Subtraces the cable delay. For `sim_to_data=True`, the cable delay is added
             # in the efieldToVoltageConverter or with the channelCableDelayAdder
             # (if efieldToVoltageConverterPerEfield was used).
-            signal_processing.add_cable_delay(station, det, sim_to_data=False, logger=self.logger)
+            add_cable_delay(station, det, sim_to_data=False, logger=self.logger)
 
         self.__t += time.time() - t
 

--- a/NuRadioReco/modules/channelAddCableDelay.py
+++ b/NuRadioReco/modules/channelAddCableDelay.py
@@ -1,5 +1,5 @@
 from NuRadioReco.modules.base.module import register_run
-from NuRadioReco.utilities import units, signal_processing
+from NuRadioReco.utilities import units
 import logging
 
 
@@ -32,4 +32,51 @@ class channelAddCableDelay:
                             "Valid options are 'add' or 'subtract'.")
 
         sim_to_data = mode == "add"
-        signal_processing.add_cable_delay(station, det, sim_to_data, trigger=False, logger=self.logger)
+        add_cable_delay(station, det, sim_to_data, trigger=False, logger=self.logger)
+
+
+def add_cable_delay(station, det, sim_to_data=None, trigger=False, logger=None):
+    """
+    Add or subtract cable delay by modifying the ``trace_start_time``.
+
+    Parameters
+    ----------
+    station: Station
+        The station to add the cable delay to.
+
+    det: Detector
+        The detector description
+
+    trigger: bool
+        If True, take the time delay from the trigger channel response.
+        Only possible if ``det`` is of type `rnog_detector.Detector`. (Default: False)
+
+    logger: logging.Logger, default=None
+        If set, use ``logger.debug(..)`` to log the cable delay.
+    """
+    assert sim_to_data is not None, "``sim_to_data`` is None, please specify."
+
+    add_or_subtract = 1 if sim_to_data else -1
+    msg = "Add" if sim_to_data else "Subtract"
+
+    if trigger and not isinstance(det, detector.rnog_detector.Detector):
+        raise ValueError("Simulating extra trigger channels is only possible with the `rnog_detector.Detector` class.")
+
+    for channel in station.iter_channels():
+
+        if trigger:
+            if not channel.has_extra_trigger_channel():
+                continue
+
+            channel = channel.get_trigger_channel()
+            cable_delay = det.get_cable_delay(station.get_id(), channel.get_id(), trigger=True)
+
+        else:
+            # Only the RNOG detector has the argument `trigger`. Default is false
+            cable_delay = det.get_cable_delay(station.get_id(), channel.get_id())
+
+        if logger is not None:
+            logger.debug(f"{msg} {cable_delay / units.ns:.2f}ns "
+                        f"of cable delay to channel {channel.get_id()}")
+
+        channel.add_trace_start_time(add_or_subtract * cable_delay)

--- a/NuRadioReco/modules/channelAddCableDelay.py
+++ b/NuRadioReco/modules/channelAddCableDelay.py
@@ -1,4 +1,5 @@
 from NuRadioReco.modules.base.module import register_run
+from NuRadioReco.detector import detector
 from NuRadioReco.utilities import units
 import logging
 

--- a/NuRadioReco/modules/channelReadoutWindowCutter.py
+++ b/NuRadioReco/modules/channelReadoutWindowCutter.py
@@ -1,6 +1,6 @@
 from NuRadioReco.modules.base.module import register_run
 import NuRadioReco.framework.channel
-from NuRadioReco.utilities import units
+from NuRadioReco.utilities import units, signal_processing
 
 import numpy as np
 import logging
@@ -158,20 +158,26 @@ def _get_number_of_samples(sampling_rate, detector_sampling_rate, detector_n_sam
     # the number of samples after resampling will be correct
     valid_sampling_rate = sampling_rate % detector_sampling_rate < 1e-8
 
-    if issue_warning and not valid_sampling_rate:
-            logger.warning(
-                'The current sampling rate '
-                f'({sampling_rate/units.GHz:.3f} GHz) is not a multiple of '
-                f'the target detector sampling rate ({detector_sampling_rate/units.GHz:.3f} GHz). '
-                'Traces may not have the correct trace length after resampling.'
-            )
-
     # this should ensure that 1) the number of samples is even and
     # 2) resampling to the detector sampling rate results in the correct number of samples
     # (note that 2) can only be guaranteed if the detector sampling rate is lower than the
     # current sampling rate)
     number_of_samples = int(
         2 * np.ceil(detector_n_samples / 2 * sampling_rate / detector_sampling_rate))
+
+    if not valid_sampling_rate:
+        # actually check if the number of samples is correct after resampling
+        n_final = len(signal_processing.resample(np.zeros(number_of_samples), detector_sampling_rate / sampling_rate))
+        valid_sampling_rate = n_final == detector_n_samples
+
+        if not valid_sampling_rate and issue_warning:
+            logger.warning(
+                'The current sampling rate '
+                f'({sampling_rate/units.GHz:.3f} GHz) is not a multiple of '
+                f'the target detector sampling rate ({detector_sampling_rate/units.GHz:.3f} GHz). '
+                f'Traces may not have the correct trace length after resampling. Desired number of samples: {detector_n_samples}, '
+                f'expected number of samples after resampling: {n_final}.'
+            )
 
     return number_of_samples, valid_sampling_rate
 
@@ -182,14 +188,14 @@ def get_empty_channel(station_id, channel_id, detector, trigger, sampling_rate):
     Returns a channel with a trace containing zeros.
 
     The trace start time is given by the trigger,
-    the duration of the trace is determined by the detector description, and the number of samples 
+    the duration of the trace is determined by the detector description, and the number of samples
     determined by the duration and the given sampling rate.
 
     Parameters
     ----------
     station_id: int
         The station id
-    
+
     channel_id: int
         The channel id
 

--- a/NuRadioReco/utilities/signal_processing.py
+++ b/NuRadioReco/utilities/signal_processing.py
@@ -1,8 +1,5 @@
-from NuRadioReco.utilities import units
-from NuRadioReco.detector import detector
-
 from scipy.signal.windows import hann
-from scipy import constants, signal
+from scipy import signal
 import numpy as np
 import fractions
 import decimal
@@ -34,57 +31,6 @@ def half_hann_window(length, half_percent=None, hann_window_length=None):
     half_hann_widow[-hann_window_length:] = hann_window[hann_window_length:]
 
     return half_hann_widow
-
-
-def add_cable_delay(station, det, sim_to_data=None, trigger=False, logger=None):
-    """
-    Add or subtract cable delay by modifying the ``trace_start_time``.
-
-    Parameters
-    ----------
-    station: Station
-        The station to add the cable delay to.
-
-    det: Detector
-        The detector description
-
-    trigger: bool
-        If True, take the time delay from the trigger channel response.
-        Only possible if ``det`` is of type `rnog_detector.Detector`. (Default: False)
-
-    logger: logging.Logger, default=None
-        If set, use ``logger.debug(..)`` to log the cable delay.
-
-    See Also
-    --------
-    NuRadioReco.modules.channelAddCableDelay.channelAddCableDelay : module that automatically applies / corrects for cable delays.
-    """
-    assert sim_to_data is not None, "``sim_to_data`` is None, please specify."
-
-    add_or_subtract = 1 if sim_to_data else -1
-    msg = "Add" if sim_to_data else "Subtract"
-
-    if trigger and not isinstance(det, detector.rnog_detector.Detector):
-        raise ValueError("Simulating extra trigger channels is only possible with the `rnog_detector.Detector` class.")
-
-    for channel in station.iter_channels():
-
-        if trigger:
-            if not channel.has_extra_trigger_channel():
-                continue
-
-            channel = channel.get_trigger_channel()
-            cable_delay = det.get_cable_delay(station.get_id(), channel.get_id(), trigger=True)
-
-        else:
-            # Only the RNOG detector has the argument `trigger`. Default is false
-            cable_delay = det.get_cable_delay(station.get_id(), channel.get_id())
-
-        if logger is not None:
-            logger.debug(f"{msg} {cable_delay / units.ns:.2f}ns "
-                        f"of cable delay to channel {channel.get_id()}")
-
-        channel.add_trace_start_time(add_or_subtract * cable_delay)
 
 
 def resample(trace, sampling_factor):

--- a/NuRadioReco/utilities/signal_processing.py
+++ b/NuRadioReco/utilities/signal_processing.py
@@ -88,8 +88,19 @@ def add_cable_delay(station, det, sim_to_data=None, trigger=False, logger=None):
 
 
 def resample(trace, sampling_factor):
-    """
-    Resample the trace to the sampling rate of the detector.
+    """ Resample a trace by a given resampling factor.
+
+    Parameters
+    ----------
+    trace : ndarray
+        The trace to resample. Can have multiple dimensions, but the last dimension should be the one to resample.
+    sampling_factor : float
+        The resampling factor. If the factor is a fraction, the denominator should be less than 5000.
+
+    Returns
+    -------
+    resampled_trace : ndarray
+        The resampled trace.
     """
     resampling_factor = fractions.Fraction(decimal.Decimal(sampling_factor)).limit_denominator(5000)
     n_samples = trace.shape[-1]


### PR DESCRIPTION
This implements the resampling method in utilities thus it can be used without creating a BaseTrace object to check if the resampling would yield the correct number of samples.

@sjoerd-bouma did you intentionally not calculate the final number of samples to be more efficient or are you fine with that?