### PR TITLE
Fix formatting of logger debug output in antennapattern

### DIFF
--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -595,7 +595,7 @@ def get_pickle_antenna_response(path):
         antenna_directory = os.path.dirname(os.path.abspath(__file__))
         with open(os.path.join(antenna_directory, 'antenna_models_hash.json'), 'r') as fin:
             antenna_hashs = json.load(fin)
-            logger.info('search for', os.path.basename(path))
+            logger.info('search for {}'.format(os.path.basename(path)))
             if os.path.basename(path) in antenna_hashs.keys():
                 if sha1.hexdigest() != antenna_hashs[os.path.basename(path)]:
                     logger.status("antenna model {} has changed on the server. downloading newest version...".format(


### PR DESCRIPTION
One logger output in `antennapattern` was incorrectly formatted, leading to an error message in the logging output (though cleverly a badly formatted logger does not raise an actual error, it seems).

A tiny fix, but I couldn't think of another PR to include this. At least it should be easy to review!