### PR TITLE
Allow for storing frequency spectra directly to nur files

### DIFF
--- a/NuRadioReco/framework/base_trace.py
+++ b/NuRadioReco/framework/base_trace.py
@@ -298,13 +298,13 @@ class BaseTrace:
         self.set_trace(resampled_trace, sampling_rate)
 
     def serialize(self):
-        if (self._time_trace) is None and (self._frequency_spectrum is None):
+        if (self._time_trace is None) and (self._frequency_spectrum is None):
             return None
-        if (self._time_trace is not None) == (self._frequency_spectrum is not None):
+        if (self._time_trace is not None) and (self._frequency_spectrum is not None):
             raise ValueError("Both time trace and frequency spectrum are stored only one of the two should be kept")
         data = {'sampling_rate': self.get_sampling_rate(),
-                'time_trace' : self._time_trace,
-                'frequency_spectrum' : self._frequency_spectrum,
+                'time_trace': self._time_trace,
+                'frequency_spectrum': self._frequency_spectrum,
                 'trace_start_time': self.get_trace_start_time()}
         return pickle.dumps(data, protocol=4)
 


### PR DESCRIPTION
This PR aims to allow for storing frequency spectra directly to nur files. This allows for speedup in use cases in which a lot of filtered/cleaned frequency spectra are to be stored. This PR is based on issue https://github.com/nu-radio/NuRadioMC/issues/884 and should help in avoiding unnecessary FFTs