### PR TITLE
Fix interferometry.get_time_shifts_plane

### DIFF
--- a/NuRadioReco/utilities/interferometry.py
+++ b/NuRadioReco/utilities/interferometry.py
@@ -2,7 +2,9 @@ import numpy as np
 import sys
 from scipy import signal, constants
 from radiotools import helper as hp
-from NuRadioReco.utilities import units
+from NuRadioReco.utilities import units, geometryUtilities as geo
+import warnings
+
 
 # to convert V**2/m**2 * ns -> V**2/m**2 * s -> J/m**2 -> eV/m**2
 conversion_factor_integrated_signal = 1 / units.s * \
@@ -239,8 +241,8 @@ def get_time_shifts_plane(positions, zenith, azimuth, n0):
                     [0, 0, 1]])
 
     # Rotation around x-axis -> rotation into "shower plane"
-    c = np.cos(-zenith)
-    s = np.sin(-zenith)
+    c = np.cos(zenith + np.pi)
+    s = np.sin(zenith + np.pi)
     e2 = np.matrix([[1, 0, 0],
                     [0, c, -s],
                     [0, s, c]])


### PR DESCRIPTION
`Fix interferometry.get_time_shifts_plane` did not return the same as `geometryUtilities.get_time_delay_from_direction` for observers which are not on a horizontal plane. Now they do. 

MWE:
```
from NuRadioReco.utilities import geometryUtilities, interferometry
from matplotlib import pyplot as plt
import numpy as np
pos = np.random.normal(0, 100, (2000, 3))


t1 = geometryUtilities.get_time_delay_from_direction(np.deg2rad(30), np.deg2rad(45), pos)

t2 = interferometry.get_time_shifts_plane(positions=pos, zenith=np.deg2rad(30), azimuth=np.deg2rad(45), n0=1.000293)

fig, ax = plt.subplots(1, 2, subplot_kw=dict(projection='3d'))

ax[0].scatter(*pos.T, c=t1)

sct = ax[1].scatter(*pos.T, c=t2)

print(np.allclose(t1, t2))
plt.colorbar(sct)

plt.show()
```

This leaves the question if we should remove one of the functions. The interferometry  method is actually much faster which is why I would go with this implementation (we can keep the function in the more general module `geometryUtilities`.
```
In [16]: %timeit geometryUtilities.get_time_delay_from_direction(np.deg2rad(30), np.deg2rad(45), pos)
711 µs ± 3.71 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [17]: %timeit interferometry.get_time_shifts_plane(positions=pos, zenith=np.deg2rad(30), azimuth=np.deg2rad(45), n0=1.000293)
12.5 µs ± 38 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```
What do you think @sjoerd-bouma 