### PR TITLE
Avoid zero-division in channelSignalReconstructor. Disable VEL caching in simulation.py

### DIFF
--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -1417,7 +1417,10 @@ class simulation:
                                                     self._propagator.get_number_of_raytracing_solutions(),
                                                     particle_mode=particle_mode)
 
-        efieldToVoltageConverter.begin()
+        # For neutrino simulations caching the VEL is not useful as it is unlikely that a electric field has the
+        # identical arrival direction at an antenna twice. On the other side the trace lengths vary from event to
+        # event which requires the clear the cache very often.
+        efieldToVoltageConverter.begin(caching=False)
         channelGenericNoiseAdder.begin(seed=self._config['seed'])
         if self._outputfilenameNuRadioReco is not None:
             eventWriter.begin(self._outputfilenameNuRadioReco, log_level=self._log_level)

--- a/NuRadioReco/modules/channelSignalReconstructor.py
+++ b/NuRadioReco/modules/channelSignalReconstructor.py
@@ -154,9 +154,11 @@ class channelSignalReconstructor:
         if coincidence_window_size_bins < 2:
             logger.warning(f"Coincidence window size of {coincidence_window_size_bins} samples is too small for channel {channel.get_id()}.")
 
-        snr['peak_2_peak_amplitude_split_noise_rms'] = np.amax(trace_utilities.peak_to_peak_amplitudes(channel.get_trace(), coincidence_window_size_bins))
-        snr['peak_2_peak_amplitude_split_noise_rms'] /= trace_utilities.get_split_trace_noise_RMS(channel.get_trace(), segments=4, lowest=2)
-        snr['peak_2_peak_amplitude_split_noise_rms'] /= 2
+        noise_rms = trace_utilities.get_split_trace_noise_RMS(channel.get_trace(), segments=4, lowest=2)
+        # only calculate when noise_rms is not zero (can happen in noiseless simulations)
+        if noise_rms != 0:
+            snr['peak_2_peak_amplitude_split_noise_rms'] = (
+                np.amax(trace_utilities.peak_to_peak_amplitudes(channel.get_trace(), coincidence_window_size_bins)) / (2 * noise_rms))
 
         if self.__debug:
             plt.figure()

--- a/NuRadioReco/modules/efieldToVoltageConverter.py
+++ b/NuRadioReco/modules/efieldToVoltageConverter.py
@@ -258,13 +258,17 @@ class efieldToVoltageConverter():
                             self._get_cached_antenna_response.cache_clear()
                             self.logger.warning(
                                 "Frequencies have changed (array length). Clearing antenna response cache. "
-                                "(If this happens often, something might be wrong...")
+                                "If you similate neutrinos/in-ice radio emission, this is not surprising. Please disable caching "
+                                "By passing `caching==False` to the begin method. If you simulate air showers and this happens often, "
+                                "something might be wrong...")
                         elif not np.allclose(self.__freqs, ff, rtol=0, atol=0.01 * units.MHz):
                             self.__freqs = ff
                             self._get_cached_antenna_response.cache_clear()
                             self.logger.warning(
                                 "Frequencies have changed (values). Clearing antenna response cache. "
-                                "(If this happens often, something might be wrong...")
+                                "If you similate neutrinos/in-ice radio emission, this is not surprising. Please disable caching "
+                                "By passing `caching==False` to the begin method. If you simulate air showers and this happens often, "
+                                "something might be wrong...")
 
 
                 if self.__caching:


### PR DESCRIPTION
…L caching in simulation.py. Add better warning to efieldToVoltageConverter

These change are already included in PR #863 (but I for see that this will take a while to be merged). This will avoid unnecessary warnings and math errors when running neutrino simulations.