### PR TITLE
add AERA antenna models

### DIFF
--- a/NuRadioReco/detector/antenna_models_hash.json
+++ b/NuRadioReco/detector/antenna_models_hash.json
@@ -55,5 +55,9 @@
   "SKALA_InfFirn": "69b3007da083bb722a4494af97221917973ab297",
   "SKALA_v4_Xpol.pkl": "358fd555653fe00ea9383139d6a14cc9d63e8b01",
   "SKALA_v4_Ypol.pkl": "daa13bcc559dbc4750be34d0bbc9fa12bbadb522",
-  "LOFAR_LBA.pkl": "19e1021d3c70fb64f663a0819130d1d91a97dbaa"
+  "LOFAR_LBA.pkl": "19e1021d3c70fb64f663a0819130d1d91a97dbaa",
+  "SmallBlackSpider_ground2_measured.pkl": "41a8b7786419e780abb76a6725a10d4b588e607d",
+  "Butterfly_ground2.pkl": "ad799d1aa17d6846452dcb3bd3105afacd2fc407",
+  "Butterfly_ground2_East.pkl": "c0de92602ec0090faadd7165739b617acdd65262",
+  "Butterfly_ground2_North.pkl": "84299595c0cf96d172fcee98dccf85c1f2ce732d"
 }

--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -627,7 +627,7 @@ def parse_AERA_XML_file(path):
         logger.error("AERA antenna file {} not found".format(path))
         raise OSError
 
-    antenna_file = open(path, "rb")
+    antenna_file = open(path, "r")
 
     antenna_data = "<antenna>" + antenna_file.read() + "</antenna>"  # add pseudo root element
 
@@ -714,7 +714,7 @@ def preprocess_AERA(path):
     orientation_theta, orientation_phi, rotation_theta, rotation_phi = 0 * units.deg, 0 * units.deg, 90 * units.deg, 90 * units.deg
 
     fname = os.path.split(os.path.basename(path))[1].replace('.xml', '')
-    output_filename = '{}_InfAir.pkl'.format(os.path.join(path_to_antennamodels, fname, fname))
+    output_filename = '{}.pkl'.format(os.path.join(path_to_antennamodels, fname, fname))
 
     directory = os.path.dirname(output_filename)
     if not os.path.exists(directory):

--- a/documentation/source/NuRadioReco/pages/detector/antennamodels.rst
+++ b/documentation/source/NuRadioReco/pages/detector/antennamodels.rst
@@ -482,12 +482,14 @@ The Small Black Spider LPDA of the AERA detector at the Pierre Auger Observatory
 The antenna model is based on an extensive in-situ measurement campaign which is documented in this paper: 10.1088/1748-0221/12/10/T10005
 Please note that the model contains the low-noise amplifier (LNA) which is integrated into the antenna terminals. Therefore, the 
 vector effective length is in the order of 5-10m.
+If you use this model in a paper, please cite: http://dx.doi.org/10.1088/1748-0221/7/10/P10011 and http://dx.doi.org/10.1016/j.nima.2011.01.049
 Added: 2025
 
 Butterfly_ground2
 -----------------
 The Butterfly antenna of the AERA detector at the Pierre Auger Observatory. The antenna model is based on simulations.
 Please note that the model contains the low-noise amplifier (LNA) which is integrated into the antenna terminals. 
+If you use this model in a paper, please cite: http://dx.doi.org/10.1088/1748-0221/7/10/P10011 and http://dx.doi.org/10.1016/j.nima.2011.01.049
 Added: 2025
 
 Butterfly_ground2_East
@@ -495,6 +497,7 @@ Butterfly_ground2_East
 The East arm of the Butterfly antenna of the AERA detector at the Pierre Auger Observatory.
 The antenna model is based on an extensive in-situ measurement campaign which is documented in this PhD thesis: http://doi.org/10.18154/RWTH-2018-225398
 Please note that the model contains the low-noise amplifier (LNA) which is integrated into the antenna terminals. 
+If you use this model in a paper, please cite: http://dx.doi.org/10.1088/1748-0221/7/10/P10011 and http://dx.doi.org/10.1016/j.nima.2011.01.049
 Added: 2025
 
 Butterfly_ground2_North
@@ -502,6 +505,7 @@ Butterfly_ground2_North
 The North arm of the Butterfly antenna of the AERA detector at the Pierre Auger Observatory.
 The antenna model is based on an extensive in-situ measurement campaign which is documented in this PhD thesis: http://doi.org/10.18154/RWTH-2018-225398
 Please note that the model contains the low-noise amplifier (LNA) which is integrated into the antenna terminals. 
+If you use this model in a paper, please cite: http://dx.doi.org/10.1088/1748-0221/7/10/P10011 and http://dx.doi.org/10.1016/j.nima.2011.01.049
 Added: 2025
 
 

--- a/documentation/source/NuRadioReco/pages/detector/antennamodels.rst
+++ b/documentation/source/NuRadioReco/pages/detector/antennamodels.rst
@@ -476,6 +476,34 @@ Theta range [0, 90]; Phi range [0, 360]; Freq range [50, 350]MHz
 For more information, see: https://ieeexplore.ieee.org/abstract/document/7297231/authors#authors
 Last updated: 2021
 
+SmallBlackSpider_ground2_measured
+---------------------------------
+The Small Black Spider LPDA of the AERA detector at the Pierre Auger Observatory.
+The antenna model is based on an extensive in-situ measurement campaign which is documented in this paper: 10.1088/1748-0221/12/10/T10005
+Please note that the model contains the low-noise amplifier (LNA) which is integrated into the antenna terminals. Therefore, the 
+vector effective length is in the order of 5-10m.
+Added: 2025
+
+Butterfly_ground2
+-----------------
+The Butterfly antenna of the AERA detector at the Pierre Auger Observatory. The antenna model is based on simulations.
+Please note that the model contains the low-noise amplifier (LNA) which is integrated into the antenna terminals. 
+Added: 2025
+
+Butterfly_ground2_East
+----------------------
+The East arm of the Butterfly antenna of the AERA detector at the Pierre Auger Observatory.
+The antenna model is based on an extensive in-situ measurement campaign which is documented in this PhD thesis: http://doi.org/10.18154/RWTH-2018-225398
+Please note that the model contains the low-noise amplifier (LNA) which is integrated into the antenna terminals. 
+Added: 2025
+
+Butterfly_ground2_North
+-----------------------
+The North arm of the Butterfly antenna of the AERA detector at the Pierre Auger Observatory.
+The antenna model is based on an extensive in-situ measurement campaign which is documented in this PhD thesis: http://doi.org/10.18154/RWTH-2018-225398
+Please note that the model contains the low-noise amplifier (LNA) which is integrated into the antenna terminals. 
+Added: 2025
+
 
 Additional Models
 ==================


### PR DESCRIPTION
Thanks to the permission of the Auger collaboration, we can include the AERA antenna pattern in NuRadioReco. 