### PR TITLE
update version of pypi publish action

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -57,14 +57,14 @@ jobs:
 
     - name: Publish distribution 📦 to Test PyPI
       if: ${{ github.ref == 'refs/heads/master'}} # only runs if the push is to master
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish distribution 📦 to PyPI
       if: ${{ github.ref == 'refs/heads/master'}} # only runs if the push is to master
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
 


### PR DESCRIPTION
The publication of NuRadioMC failed because we were using an outdated version of the [pypi-publish](https://github.com/marketplace/actions/pypi-publish) action; this should update it to the correct release version. The test failure can be ignored (it checks the version number does not already exist on `master` to prevent (attempting) multiple releases with the same version number - this is not an issue as the previous release failed).

Furthermore, the recommendation seems to be to switch from password authentication (current method) to [trusted publishing](https://docs.pypi.org/trusted-publishers/adding-a-publisher/#github-actions); this is something @cg-laser will have to set up, I am happy to update the workflow once this is done.