### PR TITLE
This PR change the method used to integrate over the attenuation length in the cpp raytracer

### DIFF
--- a/NuRadioMC/SignalProp/CPPAnalyticRayTracing/wrapper.pyx
+++ b/NuRadioMC/SignalProp/CPPAnalyticRayTracing/wrapper.pyx
@@ -12,7 +12,7 @@ cdef extern from "numpy/arrayobject.h":
 
 cdef extern from "analytic_raytracing.cpp":
     void find_solutions2(double * &, double * &, int * &, int & , double, double, double, double, double, double, double, int, int, double)
-    double get_attenuation_along_path2(double, double, double, double, double, double, double, double, double, int)
+    double get_attenuation_along_path2(double, double, double, double, double, double, double, double, double, int, int)
 
 
 cpdef find_solutions(x1, x2, n_ice, delta_n, z_0, reflection, reflection_case, ice_reflection):
@@ -54,8 +54,5 @@ cpdef find_solutions(x1, x2, n_ice, delta_n, z_0, reflection, reflection_case, i
     return s
 
 
-cpdef get_attenuation_along_path(x1, x2, C0, frequency, n_ice, delta_n, z_0, model):
-
-#     t = time.time()
-    return get_attenuation_along_path2(x1[0], x1[1], x2[0], x2[1], C0, frequency, n_ice, delta_n, z_0, model)
-#     print((time.time() - t) * 1000)
+cpdef get_attenuation_along_path(x1, x2, C0, frequency, n_ice, delta_n, z_0, model, use_qags_integration):
+    return get_attenuation_along_path2(x1[0], x1[1], x2[0], x2[1], C0, frequency, n_ice, delta_n, z_0, model, use_qags_integration)

--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -428,6 +428,10 @@ class ray_tracing_2D(ray_tracing_base):
         if overwrite_speedup is not None:
             self._use_optimized_calculation = overwrite_speedup
 
+        # If true use gsl_integration_qags instead of gsl_integration_qag for the integration
+        # this is only used for the C++ implementation
+        self._use_qags_integration = 0
+
         self.use_cpp = use_cpp
         if compile_numba:
             if numba_available:
@@ -900,7 +904,8 @@ class ray_tracing_2D(ray_tracing_base):
                 for i, f in enumerate(freqs):
                     tmp[i] = wrapper.get_attenuation_along_path(
                         x1, x2, C_0, f, self.medium.n_ice, self.medium.delta_n,
-                        self.medium.z_0, self.attenuation_model_int)
+                        self.medium.z_0, self.attenuation_model_int,
+                        use_qags_integration=self._use_qags_integration)
                 if(np.sum(np.isnan(tmp)) > 0):
                     self.__logger.warning(f"attenuation calculation failed for {np.sum(np.isnan(tmp))}/{len(tmp)} frequencies," + \
                                             "setting attenuation to 0, i.e., no attenuation in these bins")


### PR DESCRIPTION
The CPP ray tracer is known to occasionally produce Nans for the attenuation length/factor. See #541. This PR changes the (default) method used for integration. The method seems to not produce the Nans and return the same/very similar results otherwise. 

This solution was though of by @EnriqueHuesca. He compiled a long document giving more details: 
[DESY_application_assingment_EHS.pdf](https://github.com/user-attachments/files/19762847/DESY_application_assingment_EHS.pdf)
