### PR TITLE
remove logger setting level in db_mongo read and write

### DIFF
--- a/NuRadioReco/detector/RNO_G/db_mongo_read.py
+++ b/NuRadioReco/detector/RNO_G/db_mongo_read.py
@@ -28,7 +28,6 @@ import astropy.time
 
 import logging
 logger = logging.getLogger("NuRadioReco.MongoDBRead")
-logger.setLevel(logging.INFO)
 
 
 def _convert_astro_time_to_datetime(time_astro):

--- a/NuRadioReco/detector/RNO_G/db_mongo_write.py
+++ b/NuRadioReco/detector/RNO_G/db_mongo_write.py
@@ -7,7 +7,6 @@ from bson import ObjectId
 
 import logging
 logger = logging.getLogger("NuRadioReco.MongoDBWrite")
-logger.setLevel(logging.DEBUG)
 
 
 @six.add_metaclass(NuRadioReco.utilities.metaclasses.Singleton)


### PR DESCRIPTION
I noticed that these two files set their log levels which caused my script's logger levels to print everything. I removed the setting such that these modules only print the log level of the root logger (unless there was a reason these levels had to be set explicitly?).