### PR TITLE
Move optional GitHub requirements

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -167,7 +167,7 @@ jobs:
     - name: "Test channelGalacticNoiseAdder"
       if: always()
       run: |
-        pip install -e .[galacticnoise]
+        pip install git+https://github.com/telegraphic/pygdsm pylfmap
         python NuRadioReco/examples/StandAloneScripts/B01galacticnoiseadder.py
     - name: "Test all examples"
       if: always()

--- a/NuRadioReco/modules/iftElectricFieldReconstructor/iftElectricFieldReconstructor.py
+++ b/NuRadioReco/modules/iftElectricFieldReconstructor/iftElectricFieldReconstructor.py
@@ -9,9 +9,20 @@ import NuRadioReco.modules.iftElectricFieldReconstructor.operators
 import NuRadioReco.framework.base_trace
 import NuRadioReco.framework.electric_field
 from NuRadioReco.modules.base.module import register_run
+import logging
+
+logger = logging.getLogger('NuRadioReco.iftElectricFieldReconstructor')
 
 import scipy
-import nifty5 as ift
+try:
+    import nifty5 as ift
+except ImportError as e:
+    logger.error(
+        "To use the iftElectricFieldReconstructor, 'nifty5' and 'pypocketfft' need to be installed:\n\n"
+        "\t pip install git+https://gitlab.mpcdf.mpg.de/ift/nifty.git@NIFTy_5 git+https://gitlab.mpcdf.mpg.de/mtr/pypocketfft"
+        )
+    raise(e)
+
 import matplotlib.pyplot as plt
 import scipy.signal
 import radiotools.helper

--- a/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
+++ b/NuRadioReco/modules/io/RNO_G/readRNOGDataMattak.py
@@ -18,7 +18,17 @@ import NuRadioReco.framework.trigger
 from NuRadioReco.framework.parameters import channelParameters
 
 from NuRadioReco.utilities import units
-import mattak.Dataset
+
+logger = logging.getLogger('NuRadioReco.RNOG.readRNOGData')
+
+try:
+    import mattak.Dataset
+except ImportError as e:
+    logger.error(
+        "To use the readRNOGDataMattak module, 'mattak' needs to be installed:\n\n"
+        "\t pip install git+https://github.com/RNO-G/mattak"
+        )
+    raise(e)
 
 
 def get_time_offset(trigger_type):

--- a/documentation/source/Introduction/pages/installation.rst
+++ b/documentation/source/Introduction/pages/installation.rst
@@ -233,7 +233,7 @@ use ``pip install nuradiomc[all]`` to install all optional dependencies (or ``[a
 
   .. code-block:: bash
 
-    pip install mattak
+    pip install git+https://github.com/RNO-G/mattak
 
   Optionally, to filter RNO-G data (during read in) the `RNO-G run table database <https://github.com/RNO-G/rnog-runtable>`__
   can be used. Note that this requires membership of the RNO-G Github organisation (not public):

--- a/documentation/source/Introduction/pages/installation.rst
+++ b/documentation/source/Introduction/pages/installation.rst
@@ -207,7 +207,7 @@ use ``pip install nuradiomc[all]`` to install all optional dependencies (or ``[a
 
   .. code-block:: bash
 
-    pip install git+https://github.com/nu-radio/cr-pulse-interpolator
+    pip install cr-pulse-interpolator
 
 - ``[dev]``
 

--- a/documentation/source/Introduction/pages/installation.rst
+++ b/documentation/source/Introduction/pages/installation.rst
@@ -169,23 +169,6 @@ These packages are recommended to be able to use all of NuRadioMC/NuRadioReco's 
 They can be installed by including adding ``[option]`` when installing NuRadioMC. Alternatively,
 use ``pip install nuradiomc[all]`` to install all optional dependencies (or ``[all,dev]`` to also install development dependencies).
 
-- ``[RNO-G]``
-
-  `mattak <https://github.com/RNO-G/mattak>`__ is required to open RNO-G root files:
-
-  .. code-block:: bash
-
-    pip install mattak
-
-- ``[rno-g-extras]``
-
-  Optionally, to filter RNO-G data (during read in) the `RNO-G run table database <https://github.com/RNO-G/rnog-runtable>`__
-  can be used. Note that this requires membership of the RNO-G Github organisation (not public):
-
-  .. code-block:: bash
-
-    pip install git+ssh://git@github.com/RNO-G/rnog-runtable.git
-
 - ``[proposal]``
 
   ``proposal`` is needed to use :mod:`NuRadioMC.EvtGen.NuRadioProposal` module (simulating secondary particles):
@@ -243,6 +226,21 @@ use ``pip install nuradiomc[all]`` to install all optional dependencies (or ``[a
   .. code-block:: Bash
 
     pip install sphinx sphinx_rtd_theme numpydoc
+
+- RNO-G-specific dependencies
+
+  `mattak <https://github.com/RNO-G/mattak>`__ is required to open RNO-G root files:
+
+  .. code-block:: bash
+
+    pip install mattak
+
+  Optionally, to filter RNO-G data (during read in) the `RNO-G run table database <https://github.com/RNO-G/rnog-runtable>`__
+  can be used. Note that this requires membership of the RNO-G Github organisation (not public):
+
+  .. code-block:: bash
+
+    pip install git+ssh://git@github.com/RNO-G/rnog-runtable.git
 
 - Some debug plots need peakutils:
 

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -1,0 +1,15 @@
+### Some optional dependencies are available only via GitHub
+### These dependencies cannot be included in the PyPI release
+### of NuRadioMC, and are therefore specified here, instead.
+
+# needed for galactic noise simulations
+pygdsm @ git+https://github.com/telegraphic/pygdsm
+
+# needed to read in RNO-G data
+mattak @ git+https://github.com/RNO-G/mattak
+# optional module, helps with data/run selection of RNO-G data
+rnog-runtable @ git+ssh://git@github.com/RNO-G/rnog-runtable.git
+
+# needed for IFT energy reconstruction
+nifty5 @ git+https://gitlab.mpcdf.mpg.de/ift/nifty.git@NIFTy_5
+pypocketfft @ git+https://gitlab.mpcdf.mpg.de/mtr/pypocketfft

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,16 +46,11 @@ Sphinx = {version = "*", optional = true}
 sphinx-rtd-theme = {version = "*", optional = true}
 numpydoc = {version = "*", optional = true}
 proposal = {version = "7.6.2", optional = true}
-pygdsm = {git = "https://github.com/telegraphic/pygdsm", optional = true}
 pylfmap = {version = "*", optional = true}
 healpy = {version = "*", optional = true}
-nifty5 = {git = "https://gitlab.mpcdf.mpg.de/ift/nifty.git", branch="NIFTy_5", optional = true}
-pypocketfft = {git = "https://gitlab.mpcdf.mpg.de/mtr/pypocketfft", optional = true}
 MCEq = {version = "*", optional = true}
 crflux = {version = "*", optional = true}
-mattak = {git = "https://github.com/RNO-G/mattak", optional = true}
-rnog-runtable = {git = "ssh://git@github.com/RNO-G/rnog-runtable.git", optional = true}
-cr-pulse-interpolator = {git = "https://github.com/nu-radio/cr-pulse-interpolator", optional = true}
+cr-pulse-interpolator = {version = ">=1.1.1", optional = true}
 pre-commit = {version = "*", optional = true}
 
 [tool.poetry.dev-dependencies]
@@ -64,10 +59,7 @@ pre-commit = "*"
 [tool.poetry.extras]
 dev = ["pre-commit", "Sphinx", "sphinx-rtd-theme", "numpydoc"]
 proposal = ["proposal"]
-galacticnoise = ['pygdsm', 'pylfmap', 'healpy']
-ift-reco = ['nifty5', 'pypocketfft']
+galacticnoise = ['pylfmap', 'healpy']
 muon-flux = ['MCEq', 'crflux']
-RNO-G = ["mattak"]
-RNO-G-extras = ["rnog-runtable"]
 cr_interpolator = ["cr-pulse-interpolator"]
-ALL = ["proposal", "pygdsm", "pylfmap", "healpy", "nifty5", "pypocketfft", "MCEq", "crflux", "mattak", "cr-pulse-interpolator"]
+ALL = ["proposal", "pylfmap", "healpy", "MCEq", "crflux", "cr-pulse-interpolator"]


### PR DESCRIPTION
As discussed in the call today, this PR moves the dependencies
```
pygdsm (needed for galactic noise simulations)
nifty, pypocketfft (needed for IFT energy reconstruction)
mattak (for reading RNO-G data)
rnog-runtable (optional, only for RNO-G run table support, only works for RNO-G authorized members)
```
out of the pyproject.toml and into a separate `optional_requirements.txt` file. I've optimistically assumed that the `cr-pulse-interpolator` will get an updated PyPI release soon.

This closes #907 
