### PR TITLE
Updates attenuation calculation for the cpp wrapper. Implements numba support for the python version of the GL3 attenuation model

### DIFF
--- a/NuRadioMC/SignalProp/CPPAnalyticRayTracing/analytic_raytracing.cpp
+++ b/NuRadioMC/SignalProp/CPPAnalyticRayTracing/analytic_raytracing.cpp
@@ -297,9 +297,18 @@ double get_attenuation_along_path(double pos[2], double pos2[2], double C0,
 	F.params=&params;
 
 	double result, error;
-	double epsabs = 1.e-4; // small initial absolute error
-	double epsrel = 1.e-5; // small initial relative error
-	double max_epsrel = 1.e-3; // max excepted relative error
+	double epsabs = 0; // 0 -> only take into account relative error
+	double epsrel = 1.e-7; // small initial relative error
+	double max_epsrel = 1.e-5; // max excepted relative error
+
+	// We have to tolerate larger uncertainties for the GL3 model because it's rougthness is
+	// a challange for the integration
+	if (model == 5) {
+		epsabs = 1.e-4;
+		epsrel = 1.e-5;
+		max_epsrel = 1.e-3;
+	}
+	
 	int max_badfunc_tries = 5;
 	int num_badfunc_tries = 0;
 	double delta_epsrel = (max_epsrel - epsrel) / max_badfunc_tries; // small initial relative error

--- a/NuRadioMC/SignalProp/CPPAnalyticRayTracing/analytic_raytracing.cpp
+++ b/NuRadioMC/SignalProp/CPPAnalyticRayTracing/analytic_raytracing.cpp
@@ -287,14 +287,14 @@ double dt_freq (double t, void *p){
 double get_attenuation_along_path(double pos[2], double pos2[2], double C0,
 		double frequency, double n_ice, double delta_n, double z_0, int model) {
 
-	double x2_mirrored[2]={0.};
-	get_z_mirrored(pos,pos2,C0,x2_mirrored, n_ice, delta_n, z_0);
+	double x2_mirrored[2] = {0.};
+	get_z_mirrored(pos, pos2, C0, x2_mirrored, n_ice, delta_n, z_0);
 
 	gsl_integration_workspace *w = gsl_integration_workspace_alloc(2000);
 	gsl_function F;
 	F.function = &dt_freq;
 	struct dt_freq_params params = {C0, frequency, n_ice, delta_n, z_0, model};
-	F.params=&params;
+	F.params = &params;
 
 	double result, error;
 	double epsabs = 0; // 0 -> only take into account relative error
@@ -308,11 +308,10 @@ double get_attenuation_along_path(double pos[2], double pos2[2], double C0,
 		epsrel = 1.e-5;
 		max_epsrel = 1.e-3;
 	}
-	
+
 	int max_badfunc_tries = 5;
 	int num_badfunc_tries = 0;
-	double delta_epsrel = (max_epsrel - epsrel) / max_badfunc_tries; // small initial relative error
-
+	double delta_epsrel = (log10(max_epsrel) - log10(epsrel)) / max_badfunc_tries; // small initial relative error
 	int status;
 
 	/*
@@ -333,8 +332,8 @@ double get_attenuation_along_path(double pos[2], double pos2[2], double C0,
 
 		if (status != GSL_SUCCESS) {
 			status = GSL_CONTINUE;
+			epsrel = pow(10, log10(epsrel) + delta_epsrel); //double the size of the relative error
 			num_badfunc_tries++;
-			epsrel += delta_epsrel; //double the size of the relative error
 		}
 
 	} while (status == GSL_CONTINUE && num_badfunc_tries <= max_badfunc_tries);
@@ -810,8 +809,8 @@ vector <vector <double> > find_solutions(double x1[2], double x2[2], double n_ic
 		else logC0_stop = root_1-0.0001;
 
 		logC0_start = -100.;
-		delta_start = GSL_FN_EVAL(&F,logC0_start);
-		delta_stop = GSL_FN_EVAL(&F,logC0_stop);
+		delta_start = GSL_FN_EVAL(&F, logC0_start);
+		delta_stop = GSL_FN_EVAL(&F, logC0_stop);
 		bool found_root_3 = false;
 		double root_3 = -10000000;
 		if(signbit(delta_start)!=signbit(delta_stop)){
@@ -837,7 +836,7 @@ vector <vector <double> > find_solutions(double x1[2], double x2[2], double n_ic
 					logC0_start = gsl_root_fsolver_x_lower(s);
 					logC0_stop = gsl_root_fsolver_x_upper(s);
 					// printf("[Iter, Xlo, Xhi]: [%d, %.8f, %.8f] \n",iter,logC0_start,logC0_stop);
-					status3 = gsl_root_test_interval(logC0_start,logC0_stop,0,precision_fit);
+					status3 = gsl_root_test_interval(logC0_start, logC0_stop, 0, precision_fit);
 					if(status3==GSL_EBADFUNC) {status3=GSL_CONTINUE; num_badfunc_tries++; continue;}
 					if(status3 == GSL_SUCCESS){
 						// printf("Converged on root 3! Iteration %d\n",iter);


### PR DESCRIPTION
Most significant changes in this PR:

- Changes the integration method and max tolerated error in integration (important for GL3) for attenuation calculation in cpp wrapper
- changes variable names in analytic raytracer + make one function numba compatiable
- Support GL3 attenuation model in python with numba
- Some more cleanup
- Add python script to compare attenuation calculations