### PR TITLE
New feature channel galactic noise adder

### DIFF
--- a/NuRadioReco/modules/channelGalacticNoiseAdder.py
+++ b/NuRadioReco/modules/channelGalacticNoiseAdder.py
@@ -424,7 +424,7 @@ class channelGalacticNoiseAdder:
 
             polarisation = self.__random_generator.uniform(0, 2. * np.pi, len(efield_amplitude))
 
-            spectrum[window] += spectrum_pixel * np.cos(polarisation)
+            spectrum[window] += spectrum_pixel# * np.cos(polarisation)
 
         return np.std(fft.freq2time(spectrum, sampling_rate))
 
@@ -469,6 +469,7 @@ def get_local_coordinates(coordinates, time, n_side):
 if __name__ == "__main__":
 
     from astropy.time import Time
+    from NuRadioReco.utilities import fft
     location = (42.93, 79.999099)
 
     dh = np.arange(-12, 12, 0.5)


### PR DESCRIPTION
This PR add a new function to the channelGalacticNoiseAdder `get_electric_field_strength` and implements some caching for the sky noise temperature. 

The function `get_electric_field_strength` could also be put in the daugther module `efieldGalacticNoiseAdder`. In fact it probably fits better there. I chose it to but it here such that both modules have it.