### PR TITLE
Read git hash on import

### DIFF
--- a/NuRadioReco/utilities/version.py
+++ b/NuRadioReco/utilities/version.py
@@ -1,3 +1,6 @@
+import NuRadioMC
+import NuRadioReco
+
 from subprocess import Popen, PIPE
 import os
 import re
@@ -18,20 +21,21 @@ def get_git_commit_hash(path):
         return "none"
     return h
 
+path = os.path.dirname(NuRadioMC.__file__)
+NuRadioMC_hash = get_git_commit_hash(path)
+
 
 def get_NuRadioMC_commit_hash():
     """
     returns the hash of the current commit of the NuRadioMC git repository
     """
-    import NuRadioMC
-    path = os.path.dirname(NuRadioMC.__file__)
-    return get_git_commit_hash(path)
+    return NuRadioMC_hash
 
+path = os.path.dirname(NuRadioReco.__file__)
+NuRadioReco_hash = get_git_commit_hash(path)
 
 def get_NuRadioReco_commit_hash():
     """
     returns the hash of the current commit of the NuRadioReco git repository
     """
-    import NuRadioReco
-    path = os.path.dirname(NuRadioReco.__file__)
-    return get_git_commit_hash(path)
+    return NuRadioReco_hash


### PR DESCRIPTION
Currently, when you start a bunch of simulations on a batch system, they are start running, some are already finished others are not and you - without thinking about anything evil - change the branch, you create yourself a problem when you want to merge them because the git hash for the files differ. 

This solution has the problem that at import it might make the code slower... 

Not sure if I am happy with that, feel free to comment.