### PR TITLE
Hotfix/event deserialization

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -1,6 +1,6 @@
 name: Build and publish
 
-on: 
+on:
   pull_request:
   workflow_dispatch:
   push:
@@ -75,6 +75,9 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token}}
       run: |
+        git config --global user.email "sjoerd.bouma@fau.de"
+        git config --global user.name "Sjoerd Bouma"
+
         export VERSION_NEW="$(poetry version -s)"
         export NEW_TAG=v$VERSION_NEW
         git tag $NEW_TAG -m "$NEW_TAG release"

--- a/NuRadioReco/framework/event.py
+++ b/NuRadioReco/framework/event.py
@@ -688,4 +688,5 @@ class Event(NuRadioReco.framework.parameter_storage.ParameterStorage):
         if "__modules_event" in data:
             self.__modules_event = data['__modules_event']
         if "__modules_station" in data:
-            self.__modules_station = data['__modules_station']
+            for key, value in data['__modules_station'].items():
+                self.__modules_station[key] = value

--- a/NuRadioReco/utilities/geometryUtilities.py
+++ b/NuRadioReco/utilities/geometryUtilities.py
@@ -327,7 +327,7 @@ def fresnel_factors_and_signal_zenith(detector, station, channel_id, zenith):
         t_theta = get_fresnel_t_p(zenith, n_ice, 1)
         t_phi = get_fresnel_t_s(zenith, n_ice, 1)
         logger.debug((
-            "Channel {:d}: electric field is refracted into the firn. "
+            "Channel {}: electric field is refracted into the firn. "
             "theta {:.0f} -> {:.0f}. Transmission coefficient p (eTheta) "
             "{:.2f} s (ePhi) {:.2f}".format(channel_id, zenith / units.deg,
             zenith_antenna / units.deg, t_theta, t_phi)))

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,10 @@ Changelog - to keep track of all relevant changes
 please update the categories "new features" and "bugfixes" before a pull request merge!
 
 
+version 3.0.1
+bugfixes:
+- fixed an issue where applying modules to older .nur files might raise a KeyError due to an internal change in the event module registry
+
 version 3.0.0
 NuRadioMC 3.0 is a complete refactor of the NuRadioMC core (simulation.py), enabling long-awaited features such as:
 - exposing functions to calculate voltage traces from showers for stand-alone use (needed e.g. for Likelihood forward folding reconstruction)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "NuRadioMC"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Christian Glaser et al."]
 homepage = "https://github.com/nu-radio/NuRadioMC"
 documentation = "https://nu-radio.github.io/NuRadioMC/main.html"


### PR DESCRIPTION
Fixes two minor, obscure issues:
- Opening an older .nur file used to result in `self.__modules_station` **not** being a defaultdict, which could raise a KeyError if subsequently running modules on it
- One debug message in `geometryUtilities` explicitly formats the channel id as `:d`, which raises an error if the channel id is not an integer. While it might be a good idea to make sure that channel ids are always integers in the future, this is not currently enforced, and I don't think this is where we would want to raise an error.

I've also co-opted #925, which this PR is based on. This should fix the automatic release to Github (I tested that giving an arbitrary identity works on a private repository), thanks @fschlueter! For v3.0.0 I made the release manually already.