### PR TITLE
Use custom numpy pickling only inside NuRadioReco.framework

### DIFF
--- a/NuRadioReco/__init__.py
+++ b/NuRadioReco/__init__.py
@@ -1,7 +1,4 @@
 import os
-import copyreg
-import numpy as np
-from .utilities.io_utilities import _pickle_numpy_array, _pickle_numpy_scalar
 import logging
 
 from NuRadioReco.utilities.logging import NuRadioLogger, _setup_logger
@@ -31,17 +28,3 @@ if os.path.isfile(toml_file):
 # If not available, we're probably using the pip installed package
 if __version__ == None:
     __version__ = importlib_metadata.version("NuRadioMC")
-
-# Overwrite the pickling mechanism of numpy arrays for better IO compatibility.
-#
-# The __reduce__ methods are overwritten by the global dispatch_table.
-# We modify this by using copyreg.pickle.
-# see https://docs.python.org/3/library/pickle.html#dispatch-tables
-
-copyreg.pickle(np.ndarray, _pickle_numpy_array)
-# there are multiple numpy scalar types (float64, float32 etc.)
-# we overwrite the pickling __reduce__ for all of them
-# note that this might upcast in some cases
-for dtype in np.ScalarType:
-    if dtype.__module__ == 'numpy':
-        copyreg.pickle(dtype, _pickle_numpy_scalar)

--- a/NuRadioReco/framework/base_shower.py
+++ b/NuRadioReco/framework/base_shower.py
@@ -3,6 +3,7 @@ from NuRadioReco.framework.parameters import showerParameters
 import NuRadioReco.framework.parameter_storage
 from radiotools import helper as hp, coordinatesystems
 import pickle
+from NuRadioReco.utilities.io_utilities import _dumps
 
 import logging
 logger = logging.getLogger('NuRadioReco.Shower')
@@ -70,7 +71,7 @@ class BaseShower(NuRadioReco.framework.parameter_storage.ParameterStorage):
     def serialize(self):
         data = NuRadioReco.framework.parameter_storage.ParameterStorage.serialize(self)
         data['_id'] = self._id
-        return pickle.dumps(data, protocol=4)
+        return _dumps(data, protocol=4)
 
     def deserialize(self, data_pkl):
         data = pickle.loads(data_pkl)

--- a/NuRadioReco/framework/base_station.py
+++ b/NuRadioReco/framework/base_station.py
@@ -11,6 +11,7 @@ import astropy.time
 import logging
 import collections
 import pickle
+from NuRadioReco.utilities.io_utilities import _dumps
 
 logger = logging.getLogger('NuRadioReco.BaseStation')
 
@@ -288,7 +289,7 @@ class BaseStation(NuRadioReco.framework.parameter_storage.ParameterStorage):
             'electric_fields': efield_pkls
         })
 
-        return pickle.dumps(data, protocol=4)
+        return _dumps(data, protocol=4)
 
     def deserialize(self, data_pkl):
         data = pickle.loads(data_pkl)

--- a/NuRadioReco/framework/base_trace.py
+++ b/NuRadioReco/framework/base_trace.py
@@ -9,6 +9,7 @@ import logging
 import numbers
 import copy
 import pickle
+from NuRadioReco.utilities.io_utilities import _dumps
 logger = logging.getLogger("NuRadioReco.BaseTrace")
 
 
@@ -296,7 +297,7 @@ class BaseTrace:
         data = {'sampling_rate': self.get_sampling_rate(),
                 'time_trace': time_trace,
                 'trace_start_time': self.get_trace_start_time()}
-        return pickle.dumps(data, protocol=4)
+        return _dumps(data, protocol=4)
 
     def deserialize(self, data_pkl):
         data = pickle.loads(data_pkl)

--- a/NuRadioReco/framework/channel.py
+++ b/NuRadioReco/framework/channel.py
@@ -4,6 +4,7 @@ import NuRadioReco.framework.parameters as parameters
 import NuRadioReco.framework.parameter_storage
 
 import pickle
+from NuRadioReco.utilities.io_utilities import _dumps
 import logging
 logger = logging.getLogger('NuRadioReco.Channel')
 
@@ -91,7 +92,7 @@ class Channel(NuRadioReco.framework.base_trace.BaseTrace,
             'trigger_channel_pkl': trigger_channel_pkl,
         })
 
-        return pickle.dumps(data, protocol=4)
+        return _dumps(data, protocol=4)
 
     def deserialize(self, data_pkl):
         data = pickle.loads(data_pkl)

--- a/NuRadioReco/framework/electric_field.py
+++ b/NuRadioReco/framework/electric_field.py
@@ -6,6 +6,7 @@ import radiotools.coordinatesystems
 from NuRadioReco.utilities.trace_utilities import get_stokes
 
 import pickle
+from NuRadioReco.utilities.io_utilities import _dumps
 import logging
 logger = logging.getLogger('NuRadioReco.ElectricField')
 
@@ -167,7 +168,7 @@ class ElectricField(NuRadioReco.framework.base_trace.BaseTrace,
             'base_trace': base_trace_pkl
         })
 
-        return pickle.dumps(data, protocol=4)
+        return _dumps(data, protocol=4)
 
     def deserialize(self, data_pkl):
         data = pickle.loads(data_pkl)

--- a/NuRadioReco/framework/emitter.py
+++ b/NuRadioReco/framework/emitter.py
@@ -1,6 +1,7 @@
 import NuRadioReco.framework.parameters as parameters
 import NuRadioReco.framework.parameter_storage
 import pickle
+from NuRadioReco.utilities.io_utilities import _dumps
 
 import logging
 logger = logging.getLogger('NuRadioReco.Emitter')
@@ -33,7 +34,7 @@ class Emitter(NuRadioReco.framework.parameter_storage.ParameterStorage):
             '_id': self._id
         })
 
-        return pickle.dumps(data, protocol=4)
+        return _dumps(data, protocol=4)
 
     def deserialize(self, data_pkl):
         data = pickle.loads(data_pkl)

--- a/NuRadioReco/framework/event.py
+++ b/NuRadioReco/framework/event.py
@@ -19,6 +19,7 @@ from six import itervalues
 import numpy as np
 import collections
 import pickle
+from NuRadioReco.utilities.io_utilities import _dumps
 
 import logging
 logger = logging.getLogger('NuRadioReco.Event')
@@ -640,7 +641,7 @@ class Event(NuRadioReco.framework.parameter_storage.ParameterStorage):
             '__modules_station': modules_out_station
         })
 
-        return pickle.dumps(data, protocol=4)
+        return _dumps(data, protocol=4)
 
     def deserialize(self, data_pkl):
         data = pickle.loads(data_pkl)

--- a/NuRadioReco/framework/hybrid_information.py
+++ b/NuRadioReco/framework/hybrid_information.py
@@ -1,4 +1,5 @@
 import pickle
+from NuRadioReco.utilities.io_utilities import _dumps
 import NuRadioReco.framework.hybrid_shower
 
 
@@ -29,7 +30,7 @@ class HybridInformation():
         data = {
             'shower_pickles': shower_pickles
         }
-        return pickle.dumps(data, protocol=4)
+        return _dumps(data, protocol=4)
 
     def deserialize(self, data_pkl):
         for shower_pkl in pickle.loads(data_pkl)['shower_pickles']:

--- a/NuRadioReco/framework/hybrid_shower.py
+++ b/NuRadioReco/framework/hybrid_shower.py
@@ -1,5 +1,6 @@
 import NuRadioReco.framework.base_shower
 import pickle
+from NuRadioReco.utilities.io_utilities import _dumps
 
 
 class HybridShower(NuRadioReco.framework.base_shower.BaseShower):
@@ -33,7 +34,7 @@ class HybridShower(NuRadioReco.framework.base_shower.BaseShower):
             'name': self.__name,
             'detector': detector_info
         }
-        return pickle.dumps(data, protocol=4)
+        return _dumps(data, protocol=4)
 
     def deserialize(self, data_pkl):
         data = pickle.loads(data_pkl)

--- a/NuRadioReco/framework/particle.py
+++ b/NuRadioReco/framework/particle.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 from NuRadioReco.framework.parameters import particleParameters as partp
 import NuRadioReco.framework.parameter_storage
 import pickle
+from NuRadioReco.utilities.io_utilities import _dumps
 import collections
 import math
 import logging
@@ -52,7 +53,7 @@ class Particle(NuRadioReco.framework.parameter_storage.ParameterStorage):
     def serialize(self):
         data = NuRadioReco.framework.parameter_storage.ParameterStorage.serialize(self)
         data['_id'] = self._id
-        return pickle.dumps(data, protocol=4)
+        return _dumps(data, protocol=4)
 
     def deserialize(self, data_pkl):
         data = pickle.loads(data_pkl)

--- a/NuRadioReco/framework/radio_shower.py
+++ b/NuRadioReco/framework/radio_shower.py
@@ -1,5 +1,6 @@
 import NuRadioReco.framework.base_shower
 import pickle
+from NuRadioReco.utilities.io_utilities import _dumps
 
 
 class RadioShower(NuRadioReco.framework.base_shower.BaseShower):
@@ -23,7 +24,7 @@ class RadioShower(NuRadioReco.framework.base_shower.BaseShower):
             'station_ids': self.__station_ids,
             'base_shower': base_shower_pickle
         }
-        return pickle.dumps(data, protocol=4)
+        return _dumps(data, protocol=4)
 
     def deserialize(self, data_pkl):
         data = pickle.loads(data_pkl)

--- a/NuRadioReco/framework/sim_channel.py
+++ b/NuRadioReco/framework/sim_channel.py
@@ -3,6 +3,7 @@ import NuRadioReco.framework.base_trace
 import NuRadioReco.framework.channel
 
 import pickle
+from NuRadioReco.utilities.io_utilities import _dumps
 import logging
 logger = logging.getLogger('NuRadioReco.SimChannel')
 
@@ -55,7 +56,7 @@ class SimChannel(NuRadioReco.framework.channel.Channel):
             'channel': channel_pkl
         }
 
-        return pickle.dumps(data, protocol=4)
+        return _dumps(data, protocol=4)
 
     def deserialize(self, data_pkl):
         data = pickle.loads(data_pkl)

--- a/NuRadioReco/framework/sim_station.py
+++ b/NuRadioReco/framework/sim_station.py
@@ -4,6 +4,7 @@ import NuRadioReco.framework.channel
 import NuRadioReco.framework.sim_channel
 import collections
 import pickle
+from NuRadioReco.utilities.io_utilities import _dumps
 import logging
 logger = logging.getLogger('NuRadioReco.SimStation')
 
@@ -156,7 +157,7 @@ class SimStation(NuRadioReco.framework.base_station.BaseStation):
                 '__simulation_weight': self.__simulation_weight,
                 'channels': channels_pkl,
                 'base_station': base_station_pkl}
-        return pickle.dumps(data, protocol=4)
+        return _dumps(data, protocol=4)
 
     def deserialize(self, data_pkl):
         data = pickle.loads(data_pkl)

--- a/NuRadioReco/framework/station.py
+++ b/NuRadioReco/framework/station.py
@@ -5,6 +5,7 @@ import NuRadioReco.framework.channel
 import NuRadioReco.framework.parameters
 from six import iteritems
 import pickle
+from NuRadioReco.utilities.io_utilities import _dumps
 import logging
 import collections
 logger = logging.getLogger('NuRadioReco.Station')
@@ -282,7 +283,7 @@ class Station(NuRadioReco.framework.base_station.BaseStation):
                 'base_station': base_station_pkl,
                 'sim_station': sim_station_pkl}
 
-        return pickle.dumps(data, protocol=4)
+        return _dumps(data, protocol=4)
 
     def deserialize(self, data_pkl):
         data = pickle.loads(data_pkl)

--- a/NuRadioReco/framework/trigger.py
+++ b/NuRadioReco/framework/trigger.py
@@ -1,5 +1,6 @@
 from six import iteritems
 import pickle
+from NuRadioReco.utilities.io_utilities import _dumps
 import numpy as np
 from NuRadioReco.utilities import units
 
@@ -218,7 +219,7 @@ class Trigger:
         return self._pre_trigger_times
 
     def serialize(self):
-        return pickle.dumps(self.__dict__, protocol=4)
+        return _dumps(self.__dict__, protocol=4)
 
     def deserialize(self, data_pkl):
         for key, value in iteritems(pickle.loads(data_pkl)):

--- a/NuRadioReco/utilities/io_utilities.py
+++ b/NuRadioReco/utilities/io_utilities.py
@@ -8,7 +8,9 @@ for faster, numpy 2 cross-compatible pickled numpy arrays. This mostly happens
 """
 
 import pickle
+import copyreg
 import numpy as np
+import io
 from ._fastnumpyio import pack, unpack # these are essentially faster alternatives for np.load/save
 import logging
 import datetime
@@ -17,7 +19,7 @@ import astropy.time
 logger = logging.getLogger('NuRadioReco.utilities.io_utilities')
 
 # we overwrite the default pickling mechanism for numpy arrays
-# and scalars. We store arrays using np.save / np.load,
+# and scalars. We store arrays using custom, faster versions of np.save/np.load,
 # and scalars by explicit casting to built-in Python types
 # (note that this upcasts some types, e.g. np.float32 to float)
 # This allows to maintain compatibility across numpy 2.0
@@ -44,6 +46,42 @@ def _pickle_numpy_scalar(i):
         return bytes, (bytes(i),)
     else:
         raise TypeError(f"Unsupported type of numpy scalar {i} (type {type(i)})")
+
+class _NurPickler(pickle.Pickler):
+    """
+    Custom pickler class that overwrites the pickling of numpy objects
+
+    This class is used to overwrite the pickling mechanism
+    of numpy arrays and scalars for better IO compatibility,
+    as directly pickled numpy arrays are not read-compatible
+    between numpy versions ``<2`` ``>=2``.
+    """
+    dispatch_table = copyreg.dispatch_table.copy()
+    # the __reduce__ methods are overwritten by pickle.dispatch_table
+    # see https://docs.python.org/3/library/pickle.html#pickle.Pickler.dispatch_table
+    dispatch_table[np.ndarray] =  _pickle_numpy_array
+
+    # there are multiple numpy scalar types (float64, float32 etc.)
+    # we overwrite the pickling __reduce__ for all of them
+    # note that this might upcast in some cases
+    for dtype in np.ScalarType:
+        if dtype.__module__ == 'numpy':
+            copyreg.pickle(dtype, _pickle_numpy_scalar)
+
+def _dumps(obj, protocol=None, *, fix_imports=True, buffer_callback=None):
+    """
+    Return the pickled representation of the object as a bytes object.
+
+    This is a copy of the standard `pickle.dumps` implementation,
+    but uses the custom `_NurPickler` class for pickling instead of the
+    global pickling mechanism. Currently, this affects only the pickling
+    of numpy objects.
+    """
+    f = io.BytesIO()
+    _NurPickler(f, protocol, fix_imports=fix_imports,
+             buffer_callback=buffer_callback).dump(obj)
+    res = f.getvalue()
+    return res
 
 
 def read_pickle(filename, encoding='latin1'):


### PR DESCRIPTION
Restricts the custom pickling of numpy objects to use within `NuRadioReco.framework` only. As highlighted by @MartinRavn in #919, currently we overwrite the pickling of all numpy objects globally upon importing NuRadioReco, also affecting other user code. This PR introduces a custom version of `pickle.dumps` that is explicitly imported and used instead of the global `pickle.dumps` inside all modules in `NuRadioReco.framework`. Any other pickling code remains unaffected (notably, we also unfortunately use pickle to store numpy arrays in some other places, e.g. for antenna models, ARZ profiles, etc - this may cause issues in the future, though my recommendation would probably be to replace pickle in those instances altogether with something more stable, e.g. np.savez or hdf5. But this is for a future PR).

Note that the unpickling mechanism is not affected by this change, and therefore in particular `.nur` files created with any previous version of NuRadioMC should remain readable.

Fixes #919 

