### PR TITLE
NuRadioReco.detector.response: fix bug in get()

### DIFF
--- a/NuRadioReco/detector/response.py
+++ b/NuRadioReco/detector/response.py
@@ -299,8 +299,8 @@ class Response:
 
         idx = self.__names.index(name)
         single_response = copy.deepcopy(self)
-        single_response.__gains = [self.__names[idx]]
-        single_response.__names = [self.__gains[idx]]
+        single_response.__names = [self.__names[idx]]
+        single_response.__gains = [self.__gains[idx]]
         single_response.__phases = [self.__phases[idx]]
         single_response.__weights = [self.__weights[idx]]
         single_response.__time_delays = [self.__time_delays[idx]]


### PR DESCRIPTION
There is a small bug in the get() function of the response class, making the function unusable. 
This PR fixes the small bug and makes the function usable.
