### PR TITLE
add option to set pre trigger times

### DIFF
--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -1442,6 +1442,8 @@ class simulation:
         logger.status("Starting NuRadioMC simulation")
         self.__time_logger.reset_times()
 
+        i_triggered_events = 0 # counter for triggered events
+
         particle_mode = "simulation_mode" not in self._fin_attrs or self._fin_attrs['simulation_mode'] != "emitter"
         event_group_ids = np.array(self._fin['event_group_ids'])
         unique_event_group_ids = np.unique(event_group_ids)
@@ -1687,6 +1689,8 @@ class simulation:
                     channelSignalReconstructor.run(evt, station, self._det)
                     self._set_event_station_parameters(evt)
 
+                    i_triggered_events += 1 # count the number of triggered events
+
                     if self._outputfilenameNuRadioReco is not None:
                         # downsample traces to detector sampling rate to save file size
                         sampling_rate_detector = self._det.get_sampling_frequency(
@@ -1730,6 +1734,8 @@ class simulation:
         if not self._output_writer_hdf5.write_output_file():
             logger.warning("No events were triggered. Writing empty HDF5 output file.")
             self._output_writer_hdf5.write_empty_output_file(self._fin_attrs)
+
+        return i_triggered_events
 
     def add_filtered_noise_to_channels(self, evt, station, channel_ids):
         """

--- a/NuRadioReco/modules/phasedarray/triggerSimulator.py
+++ b/NuRadioReco/modules/phasedarray/triggerSimulator.py
@@ -34,8 +34,7 @@ class triggerSimulator:
         logger.setLevel(log_level)
         self.begin()
 
-    def begin(self, debug=False, pre_trigger_time=100 * units.ns):
-        self.__pre_trigger_time = pre_trigger_time
+    def begin(self, debug=False):
         self.__debug = debug
 
     def get_antenna_positions(self, station, det, triggered_channels=None, component=2):
@@ -468,6 +467,7 @@ class triggerSimulator:
             window=32,
             step=16,
             apply_digitization=True,
+            pre_trigger_time=None
             ):
 
         """
@@ -530,6 +530,10 @@ class triggerSimulator:
         apply_digitization: bool (default True)
             Perform the quantization of the ADC. If set to true, should also set options
             `trigger_adc`, `adc_output`, `clock_offset`
+        pre_trigger_time: float
+            Defines the amount of trace recorded before the trigger time. This module does not cut the traces,
+            but this trigger property is later used to trim traces accordingly.
+            If none, the default value of the HighLowTrigger class is used, which is currently 55ns.
 
         Returns
         -------
@@ -571,6 +575,9 @@ class triggerSimulator:
                 apply_digitization=apply_digitization,
             )
 
+        kwargs = {}
+        if pre_trigger_time is not None:
+            kwargs['pre_trigger_times'] = pre_trigger_time
         # Create a trigger object to be returned to the station
         trigger = SimplePhasedTrigger(
             trigger_name,
@@ -581,6 +588,7 @@ class triggerSimulator:
             window_size=window,
             step_size=step,
             maximum_amps=maximum_amps,
+            **kwargs
         )
 
         trigger.set_triggered(is_triggered)

--- a/NuRadioReco/modules/trigger/highLowThreshold.py
+++ b/NuRadioReco/modules/trigger/highLowThreshold.py
@@ -172,7 +172,8 @@ class triggerSimulator:
             clock_offset=0,
             adc_output='voltage',
             step=1,
-            align_strides_to_start=False):
+            align_strides_to_start=False,
+            pre_trigger_time=None):
         """
         simulate ARIANNA trigger logic
 
@@ -222,6 +223,10 @@ class triggerSimulator:
             to start at the beginning of the trace without padding. If false, the traces
             will be zero-padded at the beginning of the trace. This allows a trigger at 
             beginning of the trace to be associated with the correct trigger time.
+        pre_trigger_time: float
+            Defines the amount of trace recorded before the trigger time. This module does not cut the traces,
+            but this trigger property is later used to trim traces accordingly.
+            If none, the default value of the HighLowTrigger class is used, which is currently 55ns.
         """
         t = time.time()
 
@@ -295,8 +300,12 @@ class triggerSimulator:
             logger.info("set_not_triggered flag True, setting triggered to False.")
             has_triggered = False
 
+        kwargs = {}
+        if pre_trigger_time is not None:
+            kwargs['pre_trigger_times'] = pre_trigger_time
         trigger = HighLowTrigger(trigger_name, threshold_high, threshold_low, high_low_window,
-                                 coinc_window, channels=triggered_channels, number_of_coincidences=number_concidences)
+                                 coinc_window, channels=triggered_channels, number_of_coincidences=number_concidences,
+                                 **kwargs)
         trigger.set_triggered_channels(channels_that_passed_trigger)
 
         if not has_triggered:


### PR DESCRIPTION
This PR fixes two things:

- adds option to the high/low and PA trigger modules to configure the pre_trigger_times. The new logic is that the pre_trigger_time is a property of the trigger itself. This property is used by the windowCutter module. However, we forgot to make this configurable. This PR introduces an optional kward to the run methods of the trigger module to make this configurable. 

- Return the number of triggered events in the run method of simulation.py. We forgot to do this during the refactoring. Therefore, the runner.py utility broke. It is useful to know how many event trigger, e.g., to keep simulating until a fixed number of events were triggered. 