### PR TITLE
Fix outputWriterHDF5 trying to get the event from an empty station buffer

### DIFF
--- a/NuRadioMC/simulation/output_writer_hdf5.py
+++ b/NuRadioMC/simulation/output_writer_hdf5.py
@@ -384,7 +384,8 @@ class outputWriterHDF5:
             # we also want to save the first interaction even if it didn't contribute to any trigger
             # this is important to know the initial neutrino properties (only relevant for the simulation of
             # secondary interactions)
-            stn_buffer = event_buffer[self._station_ids[0]]
+            # We will get this from the first non-empty station in event_buffer
+            stn_buffer = [b for b in event_buffer.values() if b][0] # `if b` ensures we don't get a non-triggered station (with no buffer)
             evt = stn_buffer[list(stn_buffer.keys())[0]]
             particle = evt.get_primary()
             if(particle[pap.shower_id] not in shower_ids):


### PR DESCRIPTION
In order to get the properties of the primary particle, `outputWriterHDF5` tries to obtain the event from the first station_buffer in `event_buffer`. If the first station has not triggered, its buffer will be empty, leading to a KeyError. This hotfix fixes this by taking the first non-empty station buffer instead.

Kudos to @SuedIsProgramming for finding this issue and already extensively debugging it in #938!

Closes #938. I will make a separate hotfix release for `master` and update the changelog accordingly once this gets merged.