### PR TITLE
Fix order such that kwargs override the defaults

### DIFF
--- a/NuRadioReco/modules/io/coreas/coreasInterpolator.py
+++ b/NuRadioReco/modules/io/coreas/coreasInterpolator.py
@@ -298,7 +298,7 @@ class coreasInterpolator:
             "ignore_cutoff_freq_in_timing" : False,
             "verbose" : False
         }
-        interp_options = {**kwargs, **interp_options_default}  # merge the dicts, making sure kwargs overwrite defaults
+        interp_options = {**interp_options_default, **kwargs}  # merge the dicts, making sure kwargs overwrite defaults
 
         geomagnetic_angle = coreas.get_geomagnetic_angle(self.zenith, self.azimuth, self.magnetic_field_vector)
 
@@ -372,7 +372,7 @@ class coreasInterpolator:
             "fill_value" : None,
             "recover_concentric_rings" : False,
         }
-        interp_options = {**kwargs, **interp_options_default}
+        interp_options = {**interp_options_default, **kwargs}  # merge the dicts, making sure kwargs overwrite defaults
 
         fluence_per_position = [
             np.sum(efield[quantity]) for efield in self.sim_station.get_electric_fields()

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ new features:
 - energy-dependent inelasticity distribution (only BGR18 model) and cc / nc fraction (all models)
 
 bugfixes:
+- Fixed a bug which caused interpolator options explicitly passed to the coreasInterpolator to be overwritten 
 
 version 3.0.2
 bugfixes:


### PR DESCRIPTION
**Issue being addressed** 
The order of the interpolation options merging was wrong, which meant that the defaults were always executed. This fix ensures that the options can be overridden via the function call. 

I did not edit the changelog.txt file because it seems to minor to document, but if you want me to change this then I can add it.