### PR TITLE
Hotfix release v3.0.3

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -86,6 +86,10 @@ jobs:
         # we want to include the changelog since the last release
         # First, we use gh release and some regex to get the latest tag
         export LATEST_TAG=$(gh release list | sed -rn 's/.*Latest\s*(\S+).*/\1/p')
+        # the checkout action does not by default fetch the entire remote,
+        # so to compare to the previous tag we first need to fetch it
+        git fetch --depth=1 origin refs/tags/$LATEST_TAG:refs/tags/$LATEST_TAG
+
         # Next, we use some more regex to select
         # the section of the changelog between the new and latest versions:
         git diff --output-indicator-new=\| $LATEST_TAG $NEW_TAG changelog.txt | sed -rn "/^\|.*$VERSION_NEW/,/^[^|]/{s/\|//p}" | sed -n "2,\$p" > /tmp/changelog_$NEW_TAG.md

--- a/NuRadioMC/simulation/output_writer_hdf5.py
+++ b/NuRadioMC/simulation/output_writer_hdf5.py
@@ -384,7 +384,8 @@ class outputWriterHDF5:
             # we also want to save the first interaction even if it didn't contribute to any trigger
             # this is important to know the initial neutrino properties (only relevant for the simulation of
             # secondary interactions)
-            stn_buffer = event_buffer[self._station_ids[0]]
+            # We will get this from the first non-empty station in event_buffer
+            stn_buffer = [b for b in event_buffer.values() if b][0] # `if b` ensures we don't get a non-triggered station (with no buffer)
             evt = stn_buffer[list(stn_buffer.keys())[0]]
             particle = evt.get_primary()
             if(particle[pap.shower_id] not in shower_ids):

--- a/NuRadioReco/detector/detector_base.py
+++ b/NuRadioReco/detector/detector_base.py
@@ -175,10 +175,10 @@ class DetectorBase(object):
             self._db.truncate()
             stations_table = self._db.table('stations', cache_size=1000)
             for station in dictionary['stations'].values():
-                stations_table.insert(station)
+                stations_table.insert({**station})
             channels_table = self._db.table('channels', cache_size=1000)
             for channel in dictionary['channels'].values():
-                channels_table.insert(channel)
+                channels_table.insert({**channel})
         else:
             self._db = TinyDB(
                 json_filename,

--- a/NuRadioReco/modules/io/coreas/coreasInterpolator.py
+++ b/NuRadioReco/modules/io/coreas/coreasInterpolator.py
@@ -298,7 +298,7 @@ class coreasInterpolator:
             "ignore_cutoff_freq_in_timing" : False,
             "verbose" : False
         }
-        interp_options = {**kwargs, **interp_options_default}  # merge the dicts, making sure kwargs overwrite defaults
+        interp_options = {**interp_options_default, **kwargs}  # merge the dicts, making sure kwargs overwrite defaults
 
         geomagnetic_angle = coreas.get_geomagnetic_angle(self.zenith, self.azimuth, self.magnetic_field_vector)
 
@@ -372,7 +372,7 @@ class coreasInterpolator:
             "fill_value" : None,
             "recover_concentric_rings" : False,
         }
-        interp_options = {**kwargs, **interp_options_default}
+        interp_options = {**interp_options_default, **kwargs}  # merge the dicts, making sure kwargs overwrite defaults
 
         fluence_per_position = [
             np.sum(efield[quantity]) for efield in self.sim_station.get_electric_fields()

--- a/NuRadioReco/modules/io/eventWriter.py
+++ b/NuRadioReco/modules/io/eventWriter.py
@@ -212,7 +212,7 @@ class eventWriter:
                     self.__stored_stations.append({
                         'station_id': station.get_id()
                     })
-                det_dict['stations'][str(i_station)] = station_description
+                det_dict['stations'][str(i_station)] = {**station_description}
                 i_station += 1
             for channel in station.iter_channels():
                 if not self.__is_channel_already_in_file(
@@ -234,7 +234,7 @@ class eventWriter:
                           'station_id': station.get_id(),
                           'channel_id': channel.get_id()
                         })
-                    det_dict['channels'][str(i_channel)] = channel_description
+                    det_dict['channels'][str(i_channel)] = {**channel_description}
                     i_channel += 1
             # If we have a genericDetector, the default station may not be in the event.
             # In that case, we have to add it manually to make sure it ends up in the file
@@ -245,12 +245,12 @@ class eventWriter:
                         self.__stored_stations.append({
                             'station_id': reference_station_id
                         })
-                        det_dict['stations'][str(i_station)] = station_description
+                        det_dict['stations'][str(i_station)] = {**station_description}
                         i_station += 1
                         for channel_id in det.get_channel_ids(reference_station_id):
                             if not self.__is_channel_already_in_file(reference_station_id, channel_id, None):
                                 channel_description = det.get_raw_channel(reference_station_id, channel_id)
-                                det_dict['channels'][str(i_channel)] = channel_description
+                                det_dict['channels'][str(i_channel)] = {**channel_description}
                                 self.__stored_channels.append({
                                     'station_id': reference_station_id,
                                     'channel_id': channel_id

--- a/NuRadioReco/utilities/io_utilities.py
+++ b/NuRadioReco/utilities/io_utilities.py
@@ -71,7 +71,7 @@ class _NurPickler(pickle.Pickler):
         if dtype.__module__ == 'numpy':
             dispatch_table[dtype] = _pickle_numpy_scalar
 
-def _dumps(obj, protocol=None, *, fix_imports=True, buffer_callback=None):
+def _dumps(obj, protocol=None, *, fix_imports=True, **kwargs):
     """
     Return the pickled representation of the object as a bytes object.
 
@@ -81,9 +81,7 @@ def _dumps(obj, protocol=None, *, fix_imports=True, buffer_callback=None):
     of numpy objects.
     """
     f = io.BytesIO()
-    _NurPickler(
-        f, protocol, fix_imports=fix_imports,
-        buffer_callback=buffer_callback).dump(obj)
+    _NurPickler(f, protocol, fix_imports=fix_imports, **kwargs).dump(obj)
     res = f.getvalue()
     return res
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,13 @@ Changelog - to keep track of all relevant changes
 
 please update the categories "new features" and "bugfixes" before a pull request merge!
 
+version 3.0.3
+bugfixes:
+- Fixed a bug which caused interpolator options explicitly passed to the coreasInterpolator to be overwritten
+- Removed one unused optional argument introduced in 3.0.2 which broke Event storage on python version <3.8
+- Fixed a bug where untriggered stations in a multiple-station event would attempt to access primary particle
+  information from an empty buffer.
+
 version 3.0.2
 bugfixes:
 - Restricted custom pickling of numpy objects to NuRadioReco.framework.

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ bugfixes:
 - Removed one unused optional argument introduced in 3.0.2 which broke Event storage on python version <3.8
 - Fixed a bug where untriggered stations in a multiple-station event would attempt to access primary particle
   information from an empty buffer.
+- Fixed a bug where loading a GenericDetector from a .nur file raised an error in some cases.
 
 version 3.0.2
 bugfixes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "NuRadioMC"
-version = "3.0.2"
+version = "3.0.3"
 authors = ["Christian Glaser et al."]
 homepage = "https://github.com/nu-radio/NuRadioMC"
 documentation = "https://nu-radio.github.io/NuRadioMC/main.html"


### PR DESCRIPTION
Unfortunately, time for our next hotfix release:
1. Fixed a bug that would crash simulation.py for multiple station events where only some of the stations triggered (#942)
2. Removed an unused optional kwarg in our custom pickler that doesn't work with python versions below 3.8 (thanks @MijnheerD for alerting me!)
3. Ported #945 as this was a single-line change that fixes a bug present in 3.0.2
4. Fixed #950 by explicitly converting detector channel and station descriptions to `dict` (instead of the custom tinydb `Document` type which has a `docid` property) on read-in and writing. Performance impact should be minimal. Thanks @fschlueter for suggesting this fix.

 (1.) and (3.) have already been fixed on `develop`, 2. and 4. will be merged afterwards.