### PR TITLE
Ensure core is 3D in readCoREASDetector

### DIFF
--- a/NuRadioReco/modules/io/coreas/readCoREASDetector.py
+++ b/NuRadioReco/modules/io/coreas/readCoREASDetector.py
@@ -252,7 +252,9 @@ class readCoREASDetector:
             evt = NuRadioReco.framework.event.Event(self.__corsika_evt.get_run_number(), iCore)
             corsika_sim_stn = self.__corsika_evt.get_station(0).get_sim_station()
             sim_shower = copy.deepcopy(self.__corsika_evt.get_first_sim_shower())  # Don't modify the original shower
-            sim_shower.set_parameter(shp.core, core)
+            new_core = sim_shower.get_parameter(shp.core)
+            new_core[:len(core)] = core  # If no z coordinate is given, keep the original one
+            sim_shower.set_parameter(shp.core, new_core)
             evt.add_sim_shower(sim_shower)
 
             # Loop over all selected stations

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,7 +8,8 @@ new features:
 - rice distribution method for estimating electric field energy fluences as proposed in S. Martinelli et al.: https://arxiv.org/pdf/2407.18654
 
 bugfixes:
-- Fixed a bug which caused interpolator options explicitly passed to the coreasInterpolator to be overwritten 
+- Fixed a bug which caused interpolator options explicitly passed to the coreasInterpolator to be overwritten
+- Fixed the core parameter in Events created by the readCoREASDetector module not being 3-dimensional
 
 version 3.0.2
 bugfixes:


### PR DESCRIPTION
The core added to the SimShower in the readCoREASDetector module was not guaranteed to be three-dimensional. This is now fixed.