### PR TITLE
Minor fixes to docstrings and efield fluence estimator

### DIFF
--- a/NuRadioMC/utilities/birefringence_models/model_description.txt
+++ b/NuRadioMC/utilities/birefringence_models/model_description.txt
@@ -4,22 +4,24 @@ In order to use the data, spline interpolated functions were fitted to the data 
 
 The previously used models are presented here:
 
-southpole A     -   assumes a constant index of refraction at shallow and deep depths
+    southpole A     -   assumes a constant index of refraction at shallow and deep depths
 
-southpole B     -   assumes a converging index of refraction at shallow depths
+    southpole B     -   assumes a converging index of refraction at shallow depths
 
-southpole C     -   no birefringence as nx = ny = nz
+    southpole C     -   no birefringence as nx = ny = nz
 
-southpole D     -   assumes a constant average over all depths
+    southpole D     -   assumes a constant average over all depths
 
-southpole E     -   assumes ny and nz to be the same value at the average of the two
+    southpole E     -   assumes ny and nz to be the same value at the average of the two
 
 The models A, B, D, E were presented in the paper: N. Heyer and C. Glaser, First-principle calculation of birefringence effects for in-ice
 radio detection of neutrinos, eprint: 2205.06169.
 
 
-greenland A     -   most reasonable interpolation
+The Greenland ice models are based on the data in Aguilar, J. A. and others, Radiofrequency Ice Dielectric Measurements at Summit Station, Greenland, eprint: 2212.10285
 
-greenland B     -   assumes ny and nx to be the same value at the average of the two
+    greenland A     -   most reasonable interpolation
 
-greenland C     -   assumes ny and nx to diverge more than the data indicates
+    greenland B     -   assumes ny and nx to be the same value at the average of the two
+
+    greenland C     -   assumes ny and nx to diverge more than the data indicates

--- a/NuRadioReco/examples/Interactive/read_lofar_data.ipynb
+++ b/NuRadioReco/examples/Interactive/read_lofar_data.ipynb
@@ -66,8 +66,9 @@
     "from NuRadioReco.utilities.dataservers import download_from_dataserver\n",
     "\n",
     "data_path = './data' # where to store the data - this will drop the data in `./data`\n",
-    "target_path = f'{data_path}/sample-data.tar.gz' \n",
-    "download_from_dataserver(remote_path='lofar_share/lofar-sample-event.tar.gz', target_path=target_path)"
+    "target_path = f'{data_path}/sample-data.tar.gz'\n",
+    "if not Path('./data/tbb/').exists(): # do not download again if the data has already been downloaded\n",
+    "    download_from_dataserver(remote_path='lofar_share/lofar-sample-event.tar.gz', target_path=target_path)"
    ]
   },
   {
@@ -187,8 +188,7 @@
     "- **Event type identifyer**: since we know that LOFAR events are cosmic rays, we force set the event type via the eventTypeIdentifyer. This is necessary to set certain shower parameters internally. Sets the type of event. If you save the event after this, you will see raw, uncalibrated and unfiltered data.\n",
     "- **RFI filtering**: filters out narrowband RFI noise, using the phase stability method.\n",
     "- **Bandpass filter**: First applies a Gaussian bandpass filter to the data in the frequency domain, then also tapers off the edges in time using a half-Hann window. The `self.begin()` is called in init function, and does not have to be explicitly called. If you save the event after this, you will get uncalibrated, filtered traces.\n",
-    "- **Galactic calibrator**: converts ADC counts to voltages based on the Galactic calibration. If you save after this, you will get calibrated traces *without timing calibration*.\n",
-    "- **Applying calibration delays**: adds timing calibration. If you save after this, you will get fully calibrated traces, without selection on good traces.\n",
+    "- **Galactic calibrator**: converts ADC counts to voltages based on the Galactic calibration. If you save after this, you will get calibrated traces.\n",
     "- **Station pulse finder**: Finds stations and channels with a good signal, flags bad channels.\n",
     "- **Planewave fit**: Performs a timing fit based on a simple plane wave assumption per station and saves the direction reconstruction parameters in the stationParameters.\n",
     "- **Voltage to Efield converter**: converts the voltages to E-Fields using the antenna response and reconstructed directions. Saves the Electric fields separately in the event. The converter runs per channel group (even/odd antenna) since two polarizations are needed to reconstruct the E-Field.\n",
@@ -550,6 +550,18 @@
     "    ax.set_ylabel('Direction along $v \\\\times (v \\\\times B)$ [m]')   \n",
     "\n",
     "    plt.show(fig_pol)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for event in reader.run():\n",
+    "    for station in event.get_stations():\n",
+    "        for channel in station.iter_channels():\n",
+    "            pass"
    ]
   },
   {

--- a/NuRadioReco/modules/LOFAR/stationPulseFinder.py
+++ b/NuRadioReco/modules/LOFAR/stationPulseFinder.py
@@ -15,7 +15,7 @@ def find_snr_of_timeseries(timeseries, sampling_rate=None, window_start=0, windo
     r"""
     Return the signal-to-noise ratio (SNR) of a given time trace, defined as
 
-    ..math ::
+    .. math::
         \frac{max( | Hilbert(timeseries[window]) | )}{ STD( Hilbert(timeseries[noise]) ) }
 
     The signal window and noise window are controlled through the extra parameters to the function.
@@ -80,7 +80,9 @@ def find_snr_of_timeseries(timeseries, sampling_rate=None, window_start=0, windo
 
 class stationPulseFinder:
     """
-    Look for significant pulses in every station. The module uses beamforming to enhance the sensitivity in
+    Look for significant pulses in every station.
+
+    The module uses beamforming to enhance the sensitivity in
     direction estimated from the LORA particle data. It also identifies the channels which have an SNR good
     enough to use for direction fitting later.
     """
@@ -97,6 +99,8 @@ class stationPulseFinder:
 
     def begin(self, window=256, noise_window=10000, cr_snr=6.5, good_channels=6, logger_level=logging.NOTSET):
         """
+        Set parameters for pulse finding
+
         Sets the window size to use for pulse finding, as well as the number of samples away from the pulse
         to use for noise measurements. The function also defines what an acceptable SNR is to consider a
         cosmic-ray signal to be in the trace, as well as the number of good channels a station should have


### PR DESCRIPTION
- Fixes a misspelled check for `method == rice_disttribution` in `trace_utilities.get_electric_field_energy_fluence`; just use `rice` instead and raise an error if a non-supported method is provided instead
- Assortment of smaller docstring fixes which I was too lazy to put in a separate PR, but shouldn't affect anything.