### PR TITLE
Change hardware db signal chain structure + enable gain calibration

### DIFF
--- a/NuRadioReco/detector/RNO_G/db_mongo_write.py
+++ b/NuRadioReco/detector/RNO_G/db_mongo_write.py
@@ -634,7 +634,7 @@ class Database(NuRadioReco.detector.RNO_G.db_mongo_read.Database):
             logger.error(f'No active station {station_id} in the database')
         else:
             # filter to get all active stations with the correct id
-            time = self.__current_time
+            time = decomm_time
             time_filter = [{"$match": {
                 'commission_time': {"$lte": time},
                 'decommission_time': {"$gte": time},
@@ -702,7 +702,7 @@ class Database(NuRadioReco.detector.RNO_G.db_mongo_read.Database):
             logger.error(f'No active station {station_id} in the database')
         else:
             # filter to get all active stations with the correct id
-            time = self.__current_time
+            time = decomm_time
             time_filter = [{"$match": {
                 'commission_time': {"$lte": time},
                 'decommission_time': {"$gte": time},

--- a/NuRadioReco/detector/RNO_G/db_mongo_write.py
+++ b/NuRadioReco/detector/RNO_G/db_mongo_write.py
@@ -644,7 +644,7 @@ class Database(NuRadioReco.detector.RNO_G.db_mongo_read.Database):
         # checks if the arguments are valid
         if not re.fullmatch(r"(station|channel|device)", object_name):
             raise RuntimeError("The given object name is not valid. Please only use 'station' or 'channel' or 'device'.")
-        if not re.fullmatch(r"(channel|device)", object_name) and object_id is None:
+        if re.fullmatch(r"(channel|device)", object_name) and object_id is None:
             raise RuntimeError("Object id is missing. You try to decommission a channel or device without specifying the id.")
         
         # get the entry of the aktive station

--- a/NuRadioReco/detector/RNO_G/db_mongo_write.py
+++ b/NuRadioReco/detector/RNO_G/db_mongo_write.py
@@ -96,7 +96,7 @@ class Database(NuRadioReco.detector.RNO_G.db_mongo_read.Database):
                                          'primary_measurement': primary_measurement_times
                                      }}}, upsert=True)
 
-    def add_entry_to_database(self, collection, identification_key, identification_value, primary_measurement, data_dict, primary_measurement_start=None):
+    def add_entry_to_database(self, collection, identification_key, identification_value, primary_measurement, data_dict, primary_measurement_start=None, add_main_dict_info=None):
         """
         inserts a entry into the database.
         If the measurement dosn't exist yet, it will be created.
@@ -116,6 +116,8 @@ class Database(NuRadioReco.detector.RNO_G.db_mongo_read.Database):
             dictionary with all the information that should be saved for this entry
         primary_measurement_start: datetime.datetime
             If this quantity is given, the start time of the primary measurement is set to this value. Otherwise, the primary start time will be set to the current time
+        add_main_dict_info: dict
+            Allows to give more information to the general part of the document (Be careful, these informations are not backed up by a primary time).
         """
 
         self.set_database_time(datetime.datetime.utcnow())
@@ -136,7 +138,13 @@ class Database(NuRadioReco.detector.RNO_G.db_mongo_read.Database):
         # update the entry with the measurement (if the entry doesn't exist it will be created)
         data_dict.update({'id_measurement': ObjectId(
         ), 'primary_measurement': primary_measurement_times, 'last_updated': datetime.datetime.utcnow()})
-        self.db[collection].update_one({identification_key: identification_value},
+
+        main_dict = {identification_key: identification_value}
+
+        if add_main_dict_info is not None:
+            main_dict.update(add_main_dict_info)
+            
+        self.db[collection].update_one(main_dict,
                                        {'$push': {'measurements': data_dict}}, upsert=True)
 
     def add_general_station_info(self, station_id, station_name, station_comment, signal_digitizer_config_id, trigger_digitizer_config_id, commission_time, decommission_time=datetime.datetime(2080, 1, 1)):

--- a/NuRadioReco/detector/RNO_G/rnog_detector.py
+++ b/NuRadioReco/detector/RNO_G/rnog_detector.py
@@ -893,14 +893,9 @@ class Detector():
             components = [entry["collection"] for entry in measurement_components_list]
             is_equal = False
             if "drab_board" in components and "iglu_board" in components:
-                iglu_drab_mag = [entry['mag'] for entry in measurement_components_list if re.search(r'(drab_board|iglu_board)', entry['collection'])]
-                
-                if len(iglu_drab_mag) != 2:
-                    raise ValueError("More than a IGLU-DRAB pair found in the signal chain.") 
-                
                 is_equal = np.allclose(
-                    iglu_drab_mag[0],
-                    iglu_drab_mag[1])
+                    measurement_components_list[components.index("drab_board")]["mag"],
+                    measurement_components_list[components.index("iglu_board")]["mag"])
 
                 if is_equal:
                     self.logger.warn(


### PR DESCRIPTION
This PR modifies the RNO-G hardware database read and write code such that it will work with a new and better database structure. Additionally, the code was adjusted to allow for gain calibration factors in the signal chain. The latter will allow to have the impulse response with a gain calibration in the database. 

The database needs to be slightly restructured before this PR can be merged (the code is tested on a test database with a new structure).

Also, before merging the response or detector class needs to be adjusted in order to allow an application of the gain calibration value.