### PR TITLE
Make efield unique identifier hashable

### DIFF
--- a/NuRadioReco/framework/electric_field.py
+++ b/NuRadioReco/framework/electric_field.py
@@ -51,7 +51,7 @@ class ElectricField(NuRadioReco.framework.base_trace.BaseTrace,
         """
         returns a unique identifier consisting of the tuple channel_ids, shower_id and ray_tracing_id
         """
-        return (self._channel_ids, self._shower_id, self._ray_tracing_id)
+        return (tuple(self._channel_ids), self._shower_id, self._ray_tracing_id)
 
     def set_channel_ids(self, channel_ids):
         self._channel_ids = channel_ids

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ new features:
 
 bugfixes:
 - Fixed the core parameter in Events created by the readCoREASDetector module not being 3-dimensional
+- Convert list of channel ids to tuple in efield.get_unique_identifier() to make it hashable
 
 version 3.0.3
 bugfixes:


### PR DESCRIPTION
When working with the `efieldChannelGalacticNoiseAdder` I found an issue where the first item of the tuple returned by `efield.get_unique_identifier()` is a list. This is not a hashable type, which causes issues when trying to use the unique identifier as an key in the dictionary that is constructed in the module. Therefore I included a conversion to a tuple in the `get_unique_identifier()` function.