### PR TITLE
Pin pygdsm<=1.6.0 for older python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ sphinx-rtd-theme = {version = "*", optional = true}
 numpydoc = {version = "*", optional = true}
 proposal = {version = "7.6.2", optional = true}
 pylfmap = {version = "*", optional = true}
+pygdsm = {version = "<=1.6.0", python = "<3.10", optional = true}
 healpy = {version = "*", optional = true}
 MCEq = {version = "*", optional = true}
 crflux = {version = "*", optional = true}
@@ -59,7 +60,7 @@ pre-commit = "*"
 [tool.poetry.extras]
 dev = ["pre-commit", "Sphinx", "sphinx-rtd-theme", "numpydoc"]
 proposal = ["proposal"]
-galacticnoise = ['pylfmap', 'healpy']
+galacticnoise = ['pylfmap', 'pygdsm', 'healpy']
 muon-flux = ['MCEq', 'crflux']
 cr_interpolator = ["cr-pulse-interpolator"]
 ALL = ["proposal", "pylfmap", "healpy", "MCEq", "crflux", "cr-pulse-interpolator"]


### PR DESCRIPTION
Pins `pygdsm<=1.6.0` on Python versions older than 3.10, because newer pygdsm versions use typing formats incompatible with those Python versions (without updating the minimum Python version in their package requirements).

This fixes the `channelGalacticNoiseadder` test failing on Python >=3.7, <3.10 in the CI.

Closes #973 