### PR TITLE
Raise `ValueError` if if new arguments to Singleton `__init__` would be ignored

### DIFF
--- a/NuRadioReco/detector/detector_base.py
+++ b/NuRadioReco/detector/detector_base.py
@@ -243,7 +243,7 @@ class DetectorBase(object):
         the value to the attribute.
         """
         if isinstance(value, bool):
-            self.__assume_inf = value
+            self._antenna_by_depth = value
         else:
             raise ValueError(f"Value for antenna_by_depth should be boolean, not {type(value)}")
 

--- a/NuRadioReco/utilities/metaclasses.py
+++ b/NuRadioReco/utilities/metaclasses.py
@@ -31,10 +31,11 @@ class Singleton(type):
             Singleton._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
             Singleton._args_kwargs[cls] = (args, kwargs)
         elif (args, kwargs) != Singleton._args_kwargs[cls]:
-            logger.warning(
-                f'{cls} is a Singleton, returning existing instance and ignoring '
-                'arguments passed to __init__. To create a new instance instead, include '
+            msg = (
+                f'Singleton class {cls} was already initialized with different arguments. '
+                'To create a new instance with different initial values, include '
                 '`create_new=True` in the class initialization call.'
                 )
+            raise ValueError(msg)
 
         return Singleton._instances[cls]

--- a/NuRadioReco/utilities/metaclasses.py
+++ b/NuRadioReco/utilities/metaclasses.py
@@ -1,3 +1,6 @@
+import logging
+logger = logging.getLogger('NuRadioReco.metaclasses')
+
 class Singleton(type):
     """
     Can be assigned to classes as a metaclass.
@@ -7,6 +10,7 @@ class Singleton(type):
     return the existing instance if one exists.
     """
     _instances = {}
+    _args_kwargs = {}
 
     def __call__(cls, *args, **kwargs):
         """
@@ -25,5 +29,14 @@ class Singleton(type):
 
         if Singleton._instances.get(cls, None) is None or create_new:
             Singleton._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        elif (args, kwargs) != Singleton._args_kwargs[cls]:
+            logger.warning(
+                f'{cls} is a Singleton, returning existing instance and ignoring '
+                'arguments passed to __init__. To create a new instance instead, include '
+                '`create_new=True` in the class initialization call.'
+                )
+
+        Singleton._args_kwargs[cls] = (args, kwargs)
+
 
         return Singleton._instances[cls]

--- a/NuRadioReco/utilities/metaclasses.py
+++ b/NuRadioReco/utilities/metaclasses.py
@@ -29,14 +29,12 @@ class Singleton(type):
 
         if Singleton._instances.get(cls, None) is None or create_new:
             Singleton._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+            Singleton._args_kwargs[cls] = (args, kwargs)
         elif (args, kwargs) != Singleton._args_kwargs[cls]:
             logger.warning(
                 f'{cls} is a Singleton, returning existing instance and ignoring '
                 'arguments passed to __init__. To create a new instance instead, include '
                 '`create_new=True` in the class initialization call.'
                 )
-
-        Singleton._args_kwargs[cls] = (args, kwargs)
-
 
         return Singleton._instances[cls]


### PR DESCRIPTION
Something I semi-regularly run into - our Singleton implementation always returns the existing instance of a class, but this means that if I call a class with different arguments, these arguments are silently ignored. E.g.
```
from NuRadioReco.detector.detector import Detector

det = Detector(RNO_G/RNO_single_station.json, antenna_by_depth=True)
(...)
new_det = Detector(RNO_G/RNO_single_station.json, antenna_by_depth=False)
```
results in `new_det` ignoring the new value for `antenna_by_depth` (similarly, if I think I load a completely different detector description, I will silently get the old one instead).

This PR keeps track of the arguments passed to `__init__`, and emits a warning if a user tries to create a new class instance with different arguments. The alternative would be to always reinitialize the class in this case (i.e. essentially the default becomes `create_new=True` if different arguments are passed to `__init__ `). I could probably live with this too.