### PR TITLE
Hotfix: correct specification of pygdsm / galacticnoise version requirements.

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -215,5 +215,5 @@ jobs:
         jupyter execute NuRadioMC/examples/Interactive/W01-simulate-neutrino-detector.ipynb
         jupyter execute NuRadioMC/examples/Interactive/W02-reading-nur-files.ipynb
         jupyter execute NuRadioReco/examples/Interactive/read_lofar_data.ipynb
-        jupyter execute NuRadioReco/examples/Interactive/processing-RNOG-files.ipynb
+        jupyter execute NuRadioReco/examples/Interactive/read_RNOG_data.ipynb
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ numpydoc = {version = "*", optional = true}
 proposal = {version = "7.6.2", optional = true}
 pylfmap = {version = "*", optional = true}
 pygdsm = {version = "<=1.6.0", python = "<3.10", optional = true}
+pygdsm = {version = "*", python = ">=3.10", optional = true}
 healpy = {version = "*", optional = true}
 MCEq = {version = "*", optional = true}
 crflux = {version = "*", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,10 @@ sphinx-rtd-theme = {version = "*", optional = true}
 numpydoc = {version = "*", optional = true}
 proposal = {version = "7.6.2", optional = true}
 pylfmap = {version = "*", optional = true}
-pygdsm = {version = "<=1.6.0", python = "<3.10", optional = true}
-pygdsm = {version = "*", python = ">=3.10", optional = true}
+pygdsm = [
+    {version = "<=1.6.0", python = "<3.10", optional = true},
+    {version = "*", python = ">=3.10", optional = true}
+]
 healpy = {version = "*", optional = true}
 MCEq = {version = "*", optional = true}
 crflux = {version = "*", optional = true}


### PR DESCRIPTION
Turns out @fschlueter was right and I did not specify the `pygdsm` optional dependency correctly (it would not be installed on python >= 3.10 previously).

Should be fixed now.