### PR TITLE
Change default `Singleton` behaviour

### DIFF
--- a/NuRadioMC/EvtGen/NuRadioProposal.py
+++ b/NuRadioMC/EvtGen/NuRadioProposal.py
@@ -244,8 +244,8 @@ class ProposalFunctions(object):
             upper_energy_limit of tables that will be created by PROPOSAL, in NuRadioMC units (eV).
             There will be an error if primaries with energies above this energy will be injected.
             Note that PROPOSAL will have to regenerate tables for a new values of upper_energy_limit
-        create_new: bool (default:False)
-            Can be used to force the creation of a new ProposalFunctions object.
+        create_new: bool (default: None)
+            Set to ``True`` to force the creation of a new ProposalFunctions object.
             By default, the __init__ will only create a new object if none already exists.
             For more details, check the documentation for the
             :class:`Singleton metaclass <NuRadioReco.utilities.metaclasses.Singleton>`.

--- a/NuRadioMC/SignalGen/askaryan.py
+++ b/NuRadioMC/SignalGen/askaryan.py
@@ -3,6 +3,7 @@ import numpy as np
 from NuRadioReco.utilities import units, fft
 from NuRadioMC.SignalGen import parametrizations as par
 import logging
+
 logger = logging.getLogger("NuRadioMC.SignalGen.askaryan")
 
 

--- a/NuRadioMC/test/SignalGen/test_build.sh
+++ b/NuRadioMC/test/SignalGen/test_build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-set -e
+# set -e
 NuRadioMC/test/SignalGen/U01unit_test.py NuRadioMC/test/SignalGen/reference_v1.pkl

--- a/NuRadioReco/detector/RNO_G/rnog_detector.py
+++ b/NuRadioReco/detector/RNO_G/rnog_detector.py
@@ -100,9 +100,10 @@ class Detector():
             This is useful for example in simulations when one wants to simulate only one station. The default None
             means to descibe all commissioned stations.
 
-        create_new : bool (Default: False)
-            If False, and a database already exists, the existing database will be used rather than initializing a
-            new connection. Set to True to create a new database connection.
+        create_new : bool (Default: None)
+            If ``False``, the existing database connection (if there is one) will be used rather than initializing a
+            new connection. Set to ``True`` to always create a new database connection.
+            The default is to create a new database only if the ``database_connection`` argument has changed.
 
         Notes
         -----

--- a/NuRadioReco/detector/detector_base.py
+++ b/NuRadioReco/detector/detector_base.py
@@ -139,6 +139,7 @@ class DetectorBase(object):
                  dictionary=None, assume_inf=True, antenna_by_depth=True):
         """
         Initialize the stations detector properties.
+
         By default, a new detector instance is only created of none exists yet, otherwise the existing instance
         is returned. To force the creation of a new detector instance, pass the additional keyword parameter
         `create_new=True` to this function. For more details, check the documentation for the
@@ -162,8 +163,8 @@ class DetectorBase(object):
             if True the antenna model is determined automatically depending on the depth of the antenna. This is done by
             appending e.g. '_InfFirn' to the antenna model name.
             if False, the antenna model as specified in the database is used.
-        create_new: bool (default:False)
-            Can be used to force the creation of a new detector object. By default, the __init__ will only create a new
+        create_new: bool (default: None)
+            Set to ``True`` to force the creation of a new detector object. By default, the __init__ will only create a new
             object if none already exists.
         """
         self._serialization = SerializationMiddleware()

--- a/NuRadioReco/utilities/metaclasses.py
+++ b/NuRadioReco/utilities/metaclasses.py
@@ -22,17 +22,34 @@ class Singleton(type):
 
         Parameters
         ----------
-        create_new: bool (default: False)
-            If set to true, a new instance will always be created, even if one already exists.
-        """
-        create_new = kwargs.pop('create_new', False)
+        create_new: bool (default: None)
+            * If ``False``, this will always attempt to return an existing instance of the class.
+              If the existing instance was created with different initial arguments, this raises an error.
+            * If ``True``, a new instance will always be created, even if one already exists.
+            * If ``None`` (default), try to return an existing instance only if the provided arguments match,
+              otherwise return a new instance (implies ``create_new=True``).
 
-        if Singleton._instances.get(cls, None) is None or create_new:
+        Notes
+        -----
+        The `Singleton` metaclass is intended for classes that are expensive to initialize
+        (e.g. because of a large amount of I/O, such as loading an antenna model from disk).
+        """
+        create_new = kwargs.pop('create_new', None)
+
+
+        create_new = (
+            create_new
+            or cls not in Singleton._instances
+            or create_new is None and (args, kwargs) != Singleton._args_kwargs[cls]
+        )
+
+        if create_new:
+            logger.debug(f'Creating new instance of {cls}...')
             Singleton._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
             Singleton._args_kwargs[cls] = (args, kwargs)
         elif (args, kwargs) != Singleton._args_kwargs[cls]:
             msg = (
-                f'Singleton class {cls} was already initialized with different arguments. '
+                f'Singleton {cls} was already initialized with different arguments. '
                 'To create a new instance with different initial values, include '
                 '`create_new=True` in the class initialization call.'
                 )

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,11 @@ new features:
 - added rno-g cal_pulser waveform model at different temperatures in NuRadioMC/data 
 - energy-dependent inelasticity distribution (only BGR18 model) and cc / nc fraction (all models)
 - rice distribution method for estimating electric field energy fluences as proposed in S. Martinelli et al.: https://arxiv.org/pdf/2407.18654
+- Change to default behaviour of Singleton (NuRadioReco.utilities.metaclasses.Singleton) classes.
+  Previously, any arguments passed to `__init__` would be silently ignored.
+  Now, instead a new instance of the class is generated
+  with the correct arguments if ``create_new==None`` (the new default), or an error is raised if
+  ``create_new==False``.
 
 bugfixes:
 - Fixed the core parameter in Events created by the readCoREASDetector module not being 3-dimensional

--- a/documentation/source/NuRadioReco/pages/utilities.rst
+++ b/documentation/source/NuRadioReco/pages/utilities.rst
@@ -40,7 +40,7 @@ independent of the sampling rate.
 .. Important:: Always use these helper functions when doing Fourier transformations.
 
 Metaclasses
-------------------------
+-----------
 
 Singleton
 ^^^^^^^^^
@@ -52,3 +52,9 @@ already exists and return that instance instead of creating a new one.
 
 If you want to enforce the creation of a new class instance, you can overwrite this behavior
 by passing ``create_new=True`` as a parameter to the __call__ method.
+
+.. Note::
+  Prior to version 3.1.0, any arguments passed to the ``__init__()`` of a Singleton class
+  would be silently ignored. As of version 3.1.0, instead a new instance of the class is generated
+  with the correct arguments if ``create_new==None`` (the new default), or an error is raised if
+  ``create_new==False``.


### PR DESCRIPTION
This is essentially an extension of / fix for #977. 

# Description of the problem 
As a recap, the previous default of `Singleton` was to always returns the existing instance of a class, but silently ignore any new arguments passed to `__init__`. E.g.
```
from NuRadioReco.detector.detector import Detector

det = Detector(RNO_G/RNO_single_station.json, antenna_by_depth=True)
(...)
new_det = Detector(RNO_G/RNO_single_station.json, antenna_by_depth=False)
```
results in `new_det` ignoring the new value for `antenna_by_depth` (similarly, if I think I load a completely different detector description, I will silently get the old one instead).

#977 attempted to 'fix' this by raising an error if this was the case. However, we have at least one instance where this leads to very unintuitive behaviour: `askaryan.get_time_trace` contains a wrapper for ARZ, which was definitely not doing the right thing before, but with the behaviour introduced in #977 would have to either always call create_new internally (which would degrade performance), or implement some additional caching (which works, but is ugly). In either case, code like
```
from NuRadioMC.SignalGen import askaryan, ARZ

askaryan.get_time_trace(..., model='ARZ2019')

(...)
arz = ARZ.ARZ()
```
would raise the Singleton error because the ARZ class was already initialized internally in the askaryan module with non-default arguments. I find this not very intuitive.

# Suggested fix
The new suggested implementation of the Singleton sets `create_new=None` by default, and automatically creates a new class instance if the arguments to `__init__` have changed (i.e. implies `create_new=True` in this case). One can still recover the behaviour from #977 by explicitly setting `create_new=False`, ensuring no new instances are created.