### PR TITLE
Fix get_index_of_refraction() at z_air_boundary

### DIFF
--- a/NuRadioMC/utilities/medium_base.py
+++ b/NuRadioMC/utilities/medium_base.py
@@ -268,7 +268,7 @@ class IceModelSimple(IceModel):
                 return 1
         else:
             ior = self.n_ice - self.delta_n * np.exp((position[:, 2] - self.z_shift) / self.z_0)
-            ior[position[:, 2] >= 0] = 1.
+            ior[position[:, 2] - self.z_air_boundary > 0] = 1.
             return ior
 
     def get_average_index_of_refraction(self, position1, position2):
@@ -337,7 +337,7 @@ class IceModelSimple(IceModel):
                 gradient[2] = gradient_z(position[2])
         else:
             gradient = gradient_z(position[:,2])
-            gradient[position[:, 2] >= 0] = 0
+            gradient[position[:, 2] - self.z_air_boundary > 0] = 0
             gradient = np.stack((np.zeros_like(gradient),np.zeros_like(gradient),gradient),axis=1)
 
         return gradient
@@ -490,7 +490,7 @@ class IceModelExponentialPolynomial(IceModel):
                 return 1.
         else:
             ior = ior(position[:,2])
-            ior[position[:, 2] > 0] = 1.
+            ior[position[:, 2] - self.z_air_boundary > 0] = 1.
             return ior
 
     def get_average_index_of_refraction(self, position1, position2):
@@ -571,7 +571,7 @@ class IceModelExponentialPolynomial(IceModel):
                 return np.array([0, 0, 0])
         else:
             dior = dior_dz(position[:,2])
-            dior[position[:, 2] > 0] = 0
+            dior[position[:, 2] - self.z_air_boundary > 0] = 0
             return np.stack((np.zeros_like(dior),np.zeros_like(dior),dior),axis=1)
 
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ new features:
 bugfixes:
 - Fixed the core parameter in Events created by the readCoREASDetector module not being 3-dimensional
 - Convert list of channel ids to tuple in efield.get_unique_identifier() to make it hashable
+- Fixed discrepancy in index of refraction (NuRadioMC.utilities.medium_base.IceModel.get_index_of_refraction) when calling with 1D vs. 2D array
 
 version 3.0.3
 bugfixes:


### PR DESCRIPTION
`get_index_of_refraction()` and `get_gradient_of_index_of_refraction()` functions for `IceModelSimple` and `IceModelExponentialPolynomial` both hard-code `self.z_air_boundary = 0` when querying with a 2D array of coordinates instead of allowing surface depth to vary.

Additionally, calling `IceModelSimple.get_index_of_refraction()` at surface depth returned the ice ior for a 1D array and the air ior (1.0) for a 2D array due to a misplaced >=.