### PR TITLE
Cleanup in Cython wrapper for CPP raytracer

### DIFF
--- a/NuRadioMC/SignalProp/CPPAnalyticRayTracing/setup.py
+++ b/NuRadioMC/SignalProp/CPPAnalyticRayTracing/setup.py
@@ -17,6 +17,7 @@ if __name__ == "__main__":
                 include_dirs=[numpy.get_include(), '../../utilities/', str(os.environ['GSLDIR']) + '/include/'],
                 library_dirs=[str(os.environ['GSLDIR']) + '/lib/'],
                 extra_compile_args=['-O3'],
+                define_macros = [('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')],
                 libraries=['gsl', 'gslcblas'],
                 language='c++'
                 ),

--- a/NuRadioMC/SignalProp/CPPAnalyticRayTracing/wrapper.pyx
+++ b/NuRadioMC/SignalProp/CPPAnalyticRayTracing/wrapper.pyx
@@ -1,14 +1,4 @@
-import numpy as np
-cimport numpy as np
 from operator import itemgetter
-import time
-
-# Numpy must be initialized. When using numpy from C or Cython you must
-# _always_ do that, or you will have segfaults
-np.import_array()
-
-cdef extern from "numpy/arrayobject.h":
-    void PyArray_ENABLEFLAGS(np.ndarray arr, int flags)
 
 cdef extern from "analytic_raytracing.cpp":
     void find_solutions2(double * &, double * &, int * &, int & , double, double, double, double, double, double, double, int, int, double)
@@ -16,7 +6,7 @@ cdef extern from "analytic_raytracing.cpp":
     double get_attenuation_length_wrapper(double, double, int)
 
 cpdef find_solutions(x1, x2, n_ice, delta_n, z_0, reflection, reflection_case, ice_reflection):
-    cdef:
+    cdef: # These will give a warning for not being assigned during compilation, but this is fine (they are assigned in find_solutions2)
         double * C0s
         double * C1s
         int * types

--- a/NuRadioMC/SignalProp/CPPAnalyticRayTracing/wrapper.pyx
+++ b/NuRadioMC/SignalProp/CPPAnalyticRayTracing/wrapper.pyx
@@ -21,29 +21,14 @@ cpdef find_solutions(x1, x2, n_ice, delta_n, z_0, reflection, reflection_case, i
         double * C1s
         int * types
         int size
-        np.npy_intp shape[1]
 
     find_solutions2(C0s, C1s, types, size, x1[0], x1[1], x2[0], x2[1], n_ice, delta_n, z_0, reflection, reflection_case, ice_reflection)
 
-    # 1. Make sure that you have called np.import_array()
-    # http://gael-varoquaux.info/programming/
-    # cython-example-of-exposing-c-computed-arrays-in-python-without-data-copies.html
-    # 2. OWNDATA flag is important. It tells the NumPy to free data when the python object is deleted.
-    # https://stackoverflow.com/questions/23872946/force-numpy-ndarray-to-take-ownership-of-its-memory-in-cython/
-    # You can verify that the memory gets freed when Python object is deleted by using tools such as pmap.
-    shape[0] = < np.npy_intp > size
-    cdef np.ndarray[double, ndim = 1] C0ss = np.PyArray_SimpleNewFromData(1, shape, np.NPY_DOUBLE, C0s)
-    PyArray_ENABLEFLAGS(C0ss, np.NPY_OWNDATA)
-    cdef np.ndarray[double, ndim = 1] C1ss = np.PyArray_SimpleNewFromData(1, shape, np.NPY_DOUBLE, C1s)
-    PyArray_ENABLEFLAGS(C1ss, np.NPY_OWNDATA)
-    cdef np.ndarray[int, ndim = 1] typess = np.PyArray_SimpleNewFromData(1, shape, np.NPY_INT, types)
-    PyArray_ENABLEFLAGS(typess, np.NPY_OWNDATA)
-
     solutions = []
-    for i in range(len(C0ss)):
-        solutions.append({'type': typess[i],
-                          'C0': C0ss[i],
-                          'C1': C1ss[i],
+    for i in range(size):
+        solutions.append({'type': types[i],
+                          'C0': C0s[i],
+                          'C1': C1s[i],
                           'reflection': reflection,
                           'reflection_case': reflection_case})
 

--- a/NuRadioMC/SignalProp/install.sh
+++ b/NuRadioMC/SignalProp/install.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 cd "$(dirname "$0")"
 cd CPPAnalyticRayTracing
-rm wrapper.so  # first delete already existing module
-rm wrapper.*.so #also the versions on mac
+
+# check if old versions exist, and delete them
+if [ -f wrapper.so ]; then
+	rm wrapper.so  # first delete already existing module
+fi
+oldfiles=$(find . -maxdepth 1 -name "wrapper.*.so")
+if [ -n "$oldfiles" ]; then
+	rm wrapper.*.so #also the versions on mac
+fi
+
+# try to set $GSLDIR if it isn't already defined
 if [[ -z "${GSLDIR}" ]]; then
 	echo "GSLDIR environment variable undefined"
 	echo "setting GSLDIR to " $(gsl-config --prefix)


### PR DESCRIPTION
Numpy 2.3 has finally removed the deprecated `NPY_OWNDATA` flag ([link to release notes](https://numpy.org/doc/2.3/release/2.3.0-notes.html#expired-deprecations)) , which it turns out we were using in a slightly hacky fashion in the CPP wrapper. 

We could replace the `NPY_OWNDATA` flag with the `NPY_ARRAY_OWNDATA` flag. But as far as I can tell, there is actually no reason to create numpy arrays in the code at this point, so I've instead just cut out the array creation altogether. This seems to work fine locally, but let's see what the CI does : )