### PR TITLE
Add set_id() method to BaseStation.

### DIFF
--- a/NuRadioReco/framework/base_station.py
+++ b/NuRadioReco/framework/base_station.py
@@ -81,6 +81,9 @@ class BaseStation(NuRadioReco.framework.parameter_storage.ParameterStorage):
     def get_id(self):
         return self._station_id
 
+    def set_id(self, station_id):
+        self._station_id = station_id
+
     def remove_triggers(self):
         """
         removes all triggers from the station


### PR DESCRIPTION
Useful for reading event information from RNO-G stations that have not yet been assigned a stationID.

Example case: calibration pulser drop data returns 0 for station.get_id(), which causes issues later when using the Detector class. I didn’t find a quick workaround other than explicitly setting the station ID.
