### PR TITLE
Refactor antennapattern class

### DIFF
--- a/NuRadioMC/test/Veff/1e18eV/T03check_output.py
+++ b/NuRadioMC/test/Veff/1e18eV/T03check_output.py
@@ -20,7 +20,7 @@ trigger_per_file = {
 
 Veff_mean_per_file = {
     "output.hdf5": 5.35558,
-    "output_noise.hdf5": 8.23497
+    "output_noise.hdf5": 8.25448
 }
 Veff_sigma = 0.0001
 

--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -1740,7 +1740,7 @@ class AntennaPatternAnalytic(AntennaPatternBase):
         logger.error("phase type {} not implemented".format(phase_type))
         raise NotImplementedError("phase type {} not implemented".format(phase_type))
 
-    def _gain_to_vel(self, freq, gain, low_frequency_cutoff=True):
+    def _gain_to_vel(self, freq, gain):
         """
         Convert a gain into a vector effective length, apply the low frequency cutoff
         and normalize to the maximum VEL of the model
@@ -1751,8 +1751,6 @@ class AntennaPatternAnalytic(AntennaPatternBase):
             frequencies at which to evaluate the response
         gain: array of floats
             the gain at those frequencies
-        low_frequency_cutoff: bool
-            if True, suppress the response below ``cutoff_freq`` with a half Hann window
 
         Returns
         -------
@@ -1763,9 +1761,8 @@ class AntennaPatternAnalytic(AntennaPatternBase):
         VEL = np.zeros_like(freq)
         VEL[in_band] = np.sqrt(gain[in_band]) / freq[in_band]
 
-        if low_frequency_cutoff:
-            i_cutoff = np.argmax(freq > self._cutoff_freq)
-            VEL[:i_cutoff] *= hann(2 * i_cutoff)[:i_cutoff]
+        i_cutoff = np.argmax(freq > self._cutoff_freq)
+        VEL[:i_cutoff] *= hann(2 * i_cutoff)[:i_cutoff]
 
         VEL[in_band] *= self._max_VEL / np.max(VEL[in_band])
         return VEL

--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -1565,24 +1565,23 @@ class AntennaPattern(AntennaPatternBase):
             logger.debug("phi bounds {}, {}, {}".format(self.phi_lower_bound, phi, self.phi_upper_bound))
             return np.zeros((2, len(freq)), dtype=complex)
 
+        in_band = ((freq >= self.frequency_lower_bound) & (freq <= self.frequency_upper_bound))
+        if not np.any(in_band):
+            return np.zeros((2, len(freq)), dtype=complex)
+
         # the grids are not necessarily equally spaced (e.g. the theta grid of
         # RNOG_vpol_4inch_center_n1.73), hence look up the bracketing nodes instead of
         # calculating their indices from the grid boundaries
-        i_freq = np.array(get_bracketing_indices(freq, self.frequencies, self._equidistant_freqs))
         i_theta = np.array(get_bracketing_indices(theta, self.theta_angles, self._equidistant_theta))
         i_phi = np.array(get_bracketing_indices(phi, self.phi_angles, self._equidistant_phi))
 
-        # out of band frequencies are interpolated across the whole band and zeroed below
-        out_of_band = (freq < self.frequency_lower_bound) | (freq > self.frequency_upper_bound)
-        i_freq[0, out_of_band] = 0
-        i_freq[1, out_of_band] = self.n_freqs - 1
+        # Collapse the two angular axes first, over the frequency nodes that the request
+        # spans: theta and phi have a single bracket while every requested frequency has its
+        # own, so this interpolates a few hundred grid points instead of 8 per frequency bin.
+        first = max(int(np.searchsorted(self.frequencies, freq[in_band].min(), "right")) - 1, 0)
+        last = min(int(np.searchsorted(self.frequencies, freq[in_band].max(), "left")) + 1, self.n_freqs)
 
         method = self._interpolation_method
-
-        # Collapse the two angular axes first, over the frequency nodes that are actually
-        # needed: theta and phi have a single bracket while every requested frequency has its
-        # own, so this interpolates a few hundred grid points instead of 8 per frequency bin.
-        first, last = int(i_freq.min()), int(i_freq.max()) + 1
         VEL = self.VEL[:, first:last][:, :, i_phi[:, None], i_theta[None, :]]
         VEL = interpolate_linear(
             phi, *self.phi_angles[i_phi], VEL[..., 0, :], VEL[..., 1, :], method)
@@ -1590,12 +1589,36 @@ class AntennaPattern(AntennaPatternBase):
             theta, *self.theta_angles[i_theta], VEL[..., 0], VEL[..., 1], method)
 
         # ... and only then interpolate along the frequency axis, shape (component, n_freq)
-        i_freq -= first
-        VEL = interpolate_linear(
-            freq, *self.frequencies[i_freq + first], VEL[:, i_freq[0]], VEL[:, i_freq[1]], method)
+        VEL = self._interpolate_frequency(freq, self.frequencies[first:last], VEL)
 
-        VEL[:, out_of_band] = 0
+        VEL[:, ~in_band] = 0
         return VEL[0], VEL[1]
+
+    def _interpolate_frequency(self, freq, nodes, VEL):
+        """
+        Interpolate the vector effective length at the frequency nodes onto ``freq``
+
+        Parameters
+        ----------
+        freq: array of floats
+            the requested frequencies
+        nodes: array of floats
+            the frequency nodes VEL is given at
+        VEL: array of complex floats
+            the vector effective length, shape (component, len(nodes))
+
+        Returns
+        -------
+        VEL: array of complex floats
+            the interpolated vector effective length, shape (component, len(freq))
+        """
+        if self._interpolation_method == 'complex':
+            # np.interp does the bracketing internally, in C and for the whole vector at once
+            return np.array([np.interp(freq, nodes, VEL[0]), np.interp(freq, nodes, VEL[1])])
+
+        i_freq = np.array(get_bracketing_indices(freq, nodes, is_equidistant(nodes)))
+        return interpolate_linear(
+            freq, *nodes[i_freq], VEL[:, i_freq[0]], VEL[:, i_freq[1]], self._interpolation_method)
 
 
 class AntennaPatternAnalytic(AntennaPatternBase):

--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -1450,9 +1450,9 @@ class AntennaPatternBase:
 
         This function does three things:
 
-        * `_get_theta_and_phi`: transform the requested signal direction into the coordinate system
+        * ``_get_theta_and_phi``: transform the requested signal direction into the coordinate system
           of the antenna simulation, taking the orientation and rotation of the antenna into account
-        * `_get_antenna_response_vectorized_raw`: interpolate the stored antenna pattern at that
+        * ``_get_antenna_response_vectorized_raw``: interpolate the stored antenna pattern at that
           requested direction (properly transformed) and frequencies (in the native simulated coordinate system)
         * rotate the interpolated vector effective length, so that its two components refer to the
           on-sky unit vectors of the NuRadio coordinate system

--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -1215,7 +1215,7 @@ def get_onsky_rotation(zenith, azimuth):
     """
     Rotation matrix from the ground (x, y, z) into the on-sky (eR, eTheta, ePhi) system
 
-    Equivalent to `radiotools.coordinatesystems.cstrafo` but constructs only the
+    Equivalent to ``radiotools.coordinatesystems.cstrafo`` but constructs only the
     transformation needed here. The matrix is orthonormal, i.e. its transpose describes
     the inverse transformation.
 

--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -1,5 +1,5 @@
 from NuRadioReco.utilities import units, io_utilities
-from radiotools import helper as hp, coordinatesystems as cs
+from radiotools import helper as hp
 
 from scipy import constants
 from scipy.signal.windows import hann
@@ -19,15 +19,18 @@ path_to_antennamodels = os.path.join(os.path.dirname(os.path.abspath(__file__)),
 
 def interpolate_linear(x, x0, x1, y0, y1, interpolation_method='complex'):
     """
-    helper function to linearly interpolate between two complex numbers
+    Linearly interpolate between two (arrays of) complex numbers
+
+    All arguments may be scalars or arrays as long as they broadcast against each other.
+    Where the two data points coincide (``x0 == x1``) ``y0`` is returned.
 
     Parameters
     ----------
-    x: float
-        the requested position
-    x0, y0: float, complex float
+    x: float or array of floats
+        the requested position(s)
+    x0, y0: float or complex float (or arrays thereof)
         the first data point
-    x1, y1: float, complex float
+    x1, y1: float or complex float (or arrays thereof)
         the second data point
     interpolation_method: string
         specifies if interpolation is in
@@ -37,53 +40,29 @@ def interpolate_linear(x, x0, x1, y0, y1, interpolation_method='complex'):
 
     Returns
     -------
-    y: complex float
-        the interpolated value
+    y: complex float or array of complex floats
+        the interpolated value(s)
     """
-    if x0 == x1:
-        return y0
+    delta = np.asarray(x1) - np.asarray(x0)
+    coincident = delta == 0
+    weight = np.where(coincident, 0., (np.asarray(x) - np.asarray(x0)) / np.where(coincident, 1., delta))
+
     if interpolation_method == 'complex':
-        return y0 + (y1 - y0) * (x - x0) / (x1 - x0)
-    elif interpolation_method == 'magphase':  # interpolate magnitude and phase
-        mag0 = np.abs(y0)
-        mag1 = np.abs(y1)
-        phase0 = np.angle(y0)
-        phase1 = np.angle(y1)
-        phase0, phase1 = np.unwrap([phase0, phase1])
-        mag = mag0 + (mag1 - mag0) * (x - x0) / (x1 - x0)
-        phase = phase0 + (phase1 - phase0) * (x - x0) / (x1 - x0)
-        y = mag * np.exp(1j * phase)
-        return y
-    else:
-        logger.error("interpolation mode {} not implemented".format(interpolation_method))
-        raise NotImplementedError
+        return y0 + (y1 - y0) * weight
+
+    if interpolation_method == 'magphase':  # interpolate magnitude and phase
+        # unwrap along the axis connecting the two data points, i.e. do not confuse
+        # a phase wrap between y0 and y1 with the phase evolution within either of them
+        phase0, phase1 = np.unwrap([np.angle(y0), np.angle(y1)], axis=0)
+        mag = np.abs(y0) + (np.abs(y1) - np.abs(y0)) * weight
+        return mag * np.exp(1j * (phase0 + (phase1 - phase0) * weight))
+
+    logger.error("interpolation mode {} not implemented".format(interpolation_method))
+    raise NotImplementedError("interpolation mode {} not implemented".format(interpolation_method))
 
 
-def interpolate_linear_vectorized(x, x0, x1, y0, y1, interpolation_method='complex'):
-    """
-    Same as `interpolate_linear` but all parameters can be vectors
-
-    """
-    x = np.array(x)
-    mask = x0 != x1
-    result = np.zeros_like(x, dtype=complex)
-    denominator = x1 - x0
-    if interpolation_method == 'complex':
-        result[mask] = y0[mask] + (y1[mask] - y0[mask]) * (x[mask] - x0[mask]) / denominator[mask]
-    elif interpolation_method == 'magphase':  # interpolate magnitude and phase
-        mag0 = np.abs(y0[mask])
-        mag1 = np.abs(y1[mask])
-        phase0 = np.angle(y0[mask])
-        phase1 = np.angle(y1[mask])
-        phase0, phase1 = np.unwrap([phase0, phase1])
-        mag = mag0 + (mag1 - mag0) * (x[mask] - x0[mask]) / denominator[mask]
-        phase = phase0 + (phase1 - phase0) * (x[mask] - x0[mask]) / denominator[mask]
-        result[mask] = mag * np.exp(1j * phase)
-    else:
-        logger.error("interpolation mode {} not implemented".format(interpolation_method))
-        raise NotImplementedError
-    result[~mask] = y0[~mask]
-    return result
+# `interpolate_linear` handles arrays, the two functions used to be separate
+interpolate_linear_vectorized = interpolate_linear
 
 
 def is_equidistant(nodes, rtol=1e-4):
@@ -1232,6 +1211,62 @@ def preprocess_FEKO_mat(path, polarization='X', downscale_freq=1, downscale_zeni
                      freq, theta, phi, vel_phi, vel_theta],
                     fout, protocol=4)
 
+def get_onsky_rotation(zenith, azimuth):
+    """
+    Rotation matrix from the ground (x, y, z) into the on-sky (eR, eTheta, ePhi) system
+
+    Equivalent to `radiotools.coordinatesystems.cstrafo` but constructs only the
+    transformation needed here. The matrix is orthonormal, i.e. its transpose describes
+    the inverse transformation.
+
+    Parameters
+    ----------
+    zenith, azimuth: float
+        direction defining the on-sky coordinate system
+
+    Returns
+    -------
+    rotation: array of floats
+        the 3x3 rotation matrix
+    """
+    ct, st = np.cos(zenith), np.sin(zenith)
+    cp, sp = np.cos(azimuth), np.sin(azimuth)
+    return np.array([
+        [st * cp, st * sp, ct],
+        [ct * cp, ct * sp, -st],
+        [-sp, cp, 0.]])
+
+
+def get_orthonormal_basis(theta1, phi1, theta2, phi2, description):
+    """
+    Basis spanned by two (almost) perpendicular directions and their cross product
+
+    Parameters
+    ----------
+    theta1, phi1: float
+        zenith and azimuth angle of the first direction (for antennas: the boresight)
+    theta2, phi2: float
+        zenith and azimuth angle of the second direction (for antennas: perpendicular
+        to the boresight, e.g. the normal of the plane containing the tines of an LPDA)
+    description: string
+        what is being defined, used for the error message
+
+    Returns
+    -------
+    basis: array of floats
+        the 3x3 matrix of the three basis vectors
+    """
+    e1 = hp.spherical_to_cartesian(theta1, phi1)
+    e2 = hp.spherical_to_cartesian(theta2, phi2)
+    e3 = np.cross(e1, e2)
+
+    if np.linalg.norm(e3) < 0.9:  # the two directions are not perpendicular enough
+        logger.error("orientation of antenna not properly defined in {}".format(description))
+        raise AssertionError("orientation of antenna not properly defined in {}".format(description))
+
+    return np.array([e1, e2, e3])
+
+
 class AntennaPatternBase:
     """
     base class of utility class that handles access and buffering to antenna pattern
@@ -1239,58 +1274,67 @@ class AntennaPatternBase:
 
     def _get_antenna_rotation(self, orientation_theta, orientation_phi, rotation_theta, rotation_phi):
         """
+        Rotation from the coordinate system of the antenna simulation into the one of
+        the antenna as deployed in the field, and its inverse
+
+        The result only depends on the requested orientation, of which a detector has very
+        few, so it is buffered.
 
         Parameters
         ----------
+        orientation_theta, orientation_phi: float
+            orientation (boresight) of the antenna in the field, see
+            `AntennaPatternBase.get_antenna_response_vectorized`
+        rotation_theta, rotation_phi: float
+            rotation of the antenna in the field, see
+            `AntennaPatternBase.get_antenna_response_vectorized`
 
+        Returns
+        -------
+        rotation, inverse_rotation: array of floats
+            the 3x3 rotation matrix and its inverse
         """
-        # define orientation of WIPL-D antenna simulation in NuRadio coordinate system
-        e1 = hp.spherical_to_cartesian(self._orientation_theta, self._orientation_phi)  # boresight direction
-        e2 = hp.spherical_to_cartesian(self._rotation_theta, self._rotation_phi)  # vector perpendicular to tine plane
-        e3 = np.cross(e1, e2)
-        E = np.array([e1, e2, e3])
-        if np.linalg.norm(e3) < 0.9:
-            logger.error("orientation of antenna not properly defined in WIPL-D orientation file")
-            raise AssertionError("orientation of antenna not properly defined in WIPL-D orientation file")
+        orientation = (orientation_theta, orientation_phi, rotation_theta, rotation_phi)
+        if orientation not in self._antenna_rotations:
+            simulated = get_orthonormal_basis(
+                self._orientation_theta, self._orientation_phi,
+                self._rotation_theta, self._rotation_phi, "the antenna model")
+            deployed = get_orthonormal_basis(*orientation, "the detector description")
 
-        # get normal vectors for antenne orientation in field in NuRadio coordinate system
-        a1 = hp.spherical_to_cartesian(orientation_theta, orientation_phi)
-        a2 = hp.spherical_to_cartesian(rotation_theta, rotation_phi)
-        a3 = np.cross(a1, a2)
-        A = np.array([a1, a2, a3])
-        if np.linalg.norm(a3) < 0.9:
-            logger.error("orientation of antenna not properly defined detector description")
-            raise AssertionError("orientation of antenna not properly defined detector description")
-        from numpy.linalg import inv
+            rotation = np.matmul(np.linalg.inv(simulated), deployed)
+            self._antenna_rotations[orientation] = (rotation, np.linalg.inv(rotation))
 
-        return np.matmul(inv(E), A)
+        return self._antenna_rotations[orientation]
 
-    def _get_theta_and_phi(self, zenith, azimuth, orientation_theta, orientation_phi, rotation_theta, rotation_phi):
+    def _get_theta_and_phi(self, zenith, azimuth, orientation_theta, orientation_phi,
+                           rotation_theta, rotation_phi):
         """
-        transform zenith and azimuth angle in NuRadio coordinate system to the WIPLD coordinate system.
-        In addition the orientation of the antenna as deployed in the field is taken into account.
+        Transform an incoming signal direction from the NuRadio into the antenna
+        simulation coordinate system, taking the orientation of the antenna as deployed
+        in the field into account
 
         Parameters
         ----------
-        """
+        zenith, azimuth: float
+            incoming signal direction in the NuRadio coordinate system
+        orientation_theta, orientation_phi, rotation_theta, rotation_phi: float
+            orientation of the antenna in the field, see
+            `AntennaPatternBase.get_antenna_response_vectorized`
 
-        rot = self._get_antenna_rotation(orientation_theta, orientation_phi, rotation_theta, rotation_phi)
+        Returns
+        -------
+        theta, phi: float
+            the same direction in the coordinate system of the antenna simulation
+        """
+        rotation, _ = self._get_antenna_rotation(
+            orientation_theta, orientation_phi, rotation_theta, rotation_phi)
 
         incoming_direction = hp.spherical_to_cartesian(zenith, azimuth)
-        incoming_direction_WIPLD = np.dot(rot, incoming_direction.T).T
-        theta, phi = hp.cartesian_to_spherical(*incoming_direction_WIPLD)
-        if zenith == 180 * units.deg:
-            logger.debug(incoming_direction)
-            logger.debug(rot)
-            logger.debug(incoming_direction_WIPLD)
-        #         theta = 0.5 * np.pi - theta  # in wipl D the elevation is defined with 0deg being in the x-y plane
-        #         theta = hp.get_normalized_angle(theta)
-        #         phi = hp.get_normalized_angle(phi)
+        theta, phi = hp.cartesian_to_spherical(*np.dot(rotation, incoming_direction.T).T)
 
-        logger.debug("zen/az {:.0f} {:.0f} transform to {:.0f} {:.0f}".format(zenith / units.deg,
-                                                                              azimuth / units.deg,
-                                                                              theta / units.deg,
-                                                                              phi / units.deg))
+        logger.debug("zen/az {:.0f} {:.0f} transform to {:.0f} {:.0f}".format(
+            zenith / units.deg, azimuth / units.deg, theta / units.deg, phi / units.deg))
+
         return theta, phi
 
     def get_antenna_response_vectorized(self, freq, zenith, azimuth, orientation_theta, orientation_phi, rotation_theta,
@@ -1324,37 +1368,30 @@ class AntennaPatternBase:
             are complex floats or arrays of complex floats
             of the same length as the frequency input
         """
+        freq = np.atleast_1d(freq)
         if self._notfound:
-            VEL = {'theta': np.ones(len(freq), dtype=complex),
-                   'phi': np.ones(len(freq), dtype=complex)}
-            return VEL
-
-        if isinstance(freq, (float, int)):
-            freq = np.array([freq])
+            return {'theta': np.ones(len(freq), dtype=complex),
+                    'phi': np.ones(len(freq), dtype=complex)}
 
         theta, phi = self._get_theta_and_phi(
-            zenith, azimuth, orientation_theta, orientation_phi,
-            rotation_theta, rotation_phi)
+            zenith, azimuth, orientation_theta, orientation_phi, rotation_theta, rotation_phi)
 
-        Vtheta_raw, Vphi_raw = self._get_antenna_response_vectorized_raw(freq, theta, phi)
+        VEL_theta_raw, VEL_phi_raw = self._get_antenna_response_vectorized_raw(freq, theta, phi)
 
-        # now rotate the raw theta and phi component of the VEL into the NuRadio coordinate system.
-        # As the theta and phi angles are differently defined in WIPLD and NuRadio, also the orientation of the
-        # eTheta and ePhi unit vectors are different.
-        cstrans = cs.cstrafo(zenith=theta, azimuth=phi)
-        V_xyz_raw = cstrans.transform_from_onsky_to_ground(
-            np.array([np.zeros(Vtheta_raw.shape[0]), Vtheta_raw, Vphi_raw]))
-
-        rot = self._get_antenna_rotation(
+        # The eTheta and ePhi unit vectors of the antenna simulation and of NuRadio point in
+        # different directions, so rotate the VEL from the one on-sky system into the other
+        # by going through the (cartesian) ground coordinate system.
+        _, inverse_antenna_rotation = self._get_antenna_rotation(
             orientation_theta, orientation_phi, rotation_theta, rotation_phi)
-        V_xyz = np.dot(np.linalg.inv(rot), V_xyz_raw)
+        rotation = (get_onsky_rotation(zenith, azimuth)
+                    @ inverse_antenna_rotation
+                    @ get_onsky_rotation(theta, phi).T)
 
-        cstrans2 = cs.cstrafo(zenith=zenith, azimuth=azimuth)
-        V_onsky = cstrans2.transform_from_ground_to_onsky(V_xyz)
-        VEL = {'theta': V_onsky[1],
-               'phi': V_onsky[2]}
+        # the eR component of the VEL is zero and the one of the result is not needed,
+        # hence only the eTheta/ePhi block of the rotation contributes
+        VEL = np.matmul(rotation[1:, 1:], np.array([VEL_theta_raw, VEL_phi_raw]))
 
-        return VEL
+        return {'theta': VEL[0], 'phi': VEL[1]}
 
 
 class AntennaPattern(AntennaPatternBase):
@@ -1383,6 +1420,8 @@ class AntennaPattern(AntennaPatternBase):
     H_theta: array of floats
         the complex realized vector effective length of the eTheta polarization component
 
+    The three angular/spectral axes are sampled on a regular (but not necessarily equally
+    spaced) grid, i.e. the VEL is stored as a ``(n_freqs, n_phi, n_theta)`` cube.
     """
 
     def __init__(self, antenna_model, path=path_to_antennamodels,
@@ -1408,6 +1447,7 @@ class AntennaPattern(AntennaPatternBase):
 
         self._name = antenna_model
         self._interpolation_method = interpolation_method
+        self._antenna_rotations = {}
 
         t0 = time()
         filename = os.path.join(path, antenna_model, "{}.pkl".format(antenna_model))
@@ -1422,204 +1462,130 @@ class AntennaPattern(AntennaPatternBase):
             raise FileNotFoundError("antenna response for {} not found".format(antenna_model))
 
         self.frequencies = np.unique(ff)
-        self.frequency_lower_bound = self.frequencies[0]
-        self.frequency_upper_bound = self.frequencies[-1]
-
         self.theta_angles = np.unique(thetas)
-        self.theta_lower_bound = self.theta_angles[0]
-        self.theta_upper_bound = self.theta_angles[-1]
-        logger.debug(
-            "{} thetas from {} to {}".format(len(self.theta_angles), self.theta_lower_bound, self.theta_upper_bound))
-
         self.phi_angles = np.unique(phis)
-        self.phi_lower_bound = self.phi_angles[0]
-        self.phi_upper_bound = self.phi_angles[-1]
-        logger.debug("{} phis from {} to {}".format(len(self.phi_angles), self.phi_lower_bound, self.phi_upper_bound))
 
         self.n_freqs = len(self.frequencies)
         self.n_theta = len(self.theta_angles)
         self.n_phi = len(self.phi_angles)
+
+        self.frequency_lower_bound, self.frequency_upper_bound = self.frequencies[[0, -1]]
+        self.theta_lower_bound, self.theta_upper_bound = self.theta_angles[[0, -1]]
+        self.phi_lower_bound, self.phi_upper_bound = self.phi_angles[[0, -1]]
+        logger.debug("{} thetas from {} to {}".format(
+            self.n_theta, self.theta_lower_bound, self.theta_upper_bound))
+        logger.debug("{} phis from {} to {}".format(
+            self.n_phi, self.phi_lower_bound, self.phi_upper_bound))
 
         # allows the faster index calculation in `get_bracketing_indices`
         self._equidistant_freqs = is_equidistant(self.frequencies)
         self._equidistant_theta = is_equidistant(self.theta_angles)
         self._equidistant_phi = is_equidistant(self.phi_angles)
 
-        self.VEL_phi = H_phi
-        self.VEL_theta = H_theta
-
         if do_consistency_check and not verified:
             logger.status("Performing consistency check on antenna response ...")
-            # additional consistency check
-            for iFreq, freq in enumerate(self.frequencies):
-                for iPhi, phi in enumerate(self.phi_angles):
-                    for iTheta, theta in enumerate(self.theta_angles):
-                        index = self._get_index(iFreq, iTheta, iPhi)
+            self._check_grid_ordering(ff, thetas, phis)
 
-                        if phi != phis[index]:
-                            logger.error("phi angle has changed during theta loop {0}, {1}".format(
-                                phi / units.deg, phis[index] / units.deg))
-                            raise Exception("phi angle has changed during theta loop")
-
-                        if theta != thetas[index]:
-                            logger.error("theta angle has changed during theta loop {0}, {1}".format(
-                                theta / units.deg, thetas[index] / units.deg))
-                            raise Exception("theta angle has changed during theta loop")
-
-                        if freq != ff[index]:
-                            logger.error("frequency has changed {0}, {1}".format(
-                                freq, ff[index]))
-                            raise Exception("frequency has changed")
+        grid_shape = (self.n_freqs, self.n_phi, self.n_theta)
+        self.VEL_theta = H_theta.reshape(grid_shape)
+        self.VEL_phi = H_phi.reshape(grid_shape)
 
         logger.status('Loading antenna file {} took {:.1f} seconds'.format(antenna_model, time() - t0))
 
-    def _get_index(self, iFreq, iTheta, iPhi):
+    def _check_grid_ordering(self, ff, thetas, phis):
         """
+        Check that the flat arrays of the antenna file iterate over theta first, then phi,
+        then frequency, which is what reshaping them into the VEL cube assumes
         """
-        return iFreq * self.n_theta * self.n_phi + iPhi * self.n_theta + iTheta
+        expected = {
+            "frequency": (ff, np.repeat(self.frequencies, self.n_phi * self.n_theta)),
+            "phi angle": (phis, np.tile(np.repeat(self.phi_angles, self.n_theta), self.n_freqs)),
+            "theta angle": (thetas, np.tile(self.theta_angles, self.n_freqs * self.n_phi)),
+        }
+
+        for name, (stored, ordered) in expected.items():
+            if not np.array_equal(stored, ordered):
+                logger.error("{} is not ordered as expected in {}".format(name, self._name))
+                raise Exception("{} is not ordered as expected in {}".format(name, self._name))
 
     def _get_antenna_response_vectorized_raw(self, freq, theta, phi):
         """
-        get vector effective length in (WIPLD) coordinate system
-        """
-        while phi < self.phi_lower_bound:
-            phi += 2 * np.pi
-        while phi > self.phi_upper_bound:
-            phi -= 2 * np.pi
+        Get the vector effective length in the coordinate system of the antenna simulation
 
+        Trilinearly interpolates the VEL cube at the requested position. Frequencies
+        outside of the simulated band return 0, directions outside of the simulated
+        solid angle return 0 for all frequencies.
+
+        Parameters
+        ----------
+        freq: array of floats
+            frequencies at which to evaluate the response
+        theta, phi: float
+            direction in the coordinate system of the antenna simulation
+
+        Returns
+        -------
+        VEL_theta, VEL_phi: arrays of complex floats
+            the two components of the vector effective length
+        """
+        freq = np.atleast_1d(freq)
+        phi = self.phi_lower_bound + (phi - self.phi_lower_bound) % (2 * np.pi)
+
+        # avoid that rounding pushes a request at exactly 0 or 180 deg out of the grid
         if hp.is_equal(theta, self.theta_upper_bound, rel_precision=1e-5):
             theta = self.theta_upper_bound
         if hp.is_equal(theta, self.theta_lower_bound, rel_precision=1e-5):
             theta = self.theta_lower_bound
-        if (((phi < self.phi_lower_bound) or (phi > self.phi_upper_bound))
-                or ((theta < self.theta_lower_bound) or (theta > self.theta_upper_bound))):
-            logger.debug(self._name)
-            logger.debug("theta bounds {0} ,{1}, {2}".format(self.theta_lower_bound, theta, self.theta_upper_bound))
-            logger.debug("phi bounds {0} ,{1}, {2}".format(self.phi_lower_bound, phi, self.phi_upper_bound))
-            logger.warning("theta, phi or frequency out of range, returning (0,0j)")
-            logger.debug("{0},{1},{2}".format(freq, self.frequency_lower_bound, self.frequency_upper_bound))
-            return np.zeros(shape=(2,1), dtype=complex)
 
-        # the angular and frequency grids are not necessarily equally spaced (e.g. the
-        # theta grid of RNOG_vpol_4inch_center_n1.73), hence look up the bracketing
-        # nodes instead of calculating their indices from the grid boundaries
-        iTheta_lower, iTheta_upper = get_bracketing_indices(
-            theta, self.theta_angles, self._equidistant_theta)
-        theta_lower = self.theta_angles[iTheta_lower]
-        theta_upper = self.theta_angles[iTheta_upper]
+        if not (self.phi_lower_bound <= phi <= self.phi_upper_bound
+                and self.theta_lower_bound <= theta <= self.theta_upper_bound):
+            logger.warning("theta or phi out of range for {}, returning (0, 0j)".format(self._name))
+            logger.debug("theta bounds {}, {}, {}".format(self.theta_lower_bound, theta, self.theta_upper_bound))
+            logger.debug("phi bounds {}, {}, {}".format(self.phi_lower_bound, phi, self.phi_upper_bound))
+            return np.zeros((2, len(freq)), dtype=complex)
 
-        iPhi_lower, iPhi_upper = get_bracketing_indices(
-            phi, self.phi_angles, self._equidistant_phi)
-        phi_lower = self.phi_angles[iPhi_lower]
-        phi_upper = self.phi_angles[iPhi_upper]
+        # the grids are not necessarily equally spaced (e.g. the theta grid of
+        # RNOG_vpol_4inch_center_n1.73), hence look up the bracketing nodes instead of
+        # calculating their indices from the grid boundaries
+        i_freq = np.array(get_bracketing_indices(freq, self.frequencies, self._equidistant_freqs))
+        i_theta = np.array(get_bracketing_indices(theta, self.theta_angles, self._equidistant_theta))
+        i_phi = np.array(get_bracketing_indices(phi, self.phi_angles, self._equidistant_phi))
 
-        iFrequency_lower, iFrequency_upper = get_bracketing_indices(
-            freq, self.frequencies, self._equidistant_freqs)
-        # handling frequency out of bound cases properly
-        out_of_bound_freqs_low = freq < self.frequency_lower_bound
-        out_of_bound_freqs_high = freq > self.frequency_upper_bound
-        iFrequency_lower[
-            out_of_bound_freqs_low] = 0  # set all out of bound frequencies to its minimum/maximum possible value
-        iFrequency_lower[
-            out_of_bound_freqs_high] = 0  # set all out of bound frequencies to its minimum/maximum possible value
-        iFrequency_upper[out_of_bound_freqs_low] = self.n_freqs - 1
-        iFrequency_upper[out_of_bound_freqs_high] = self.n_freqs - 1
-        frequency_lower = self.frequencies[iFrequency_lower]
-        frequency_upper = self.frequencies[iFrequency_upper]
+        # out of band frequencies are interpolated across the whole band and zeroed below
+        out_of_band = (freq < self.frequency_lower_bound) | (freq > self.frequency_upper_bound)
+        i_freq[0, out_of_band] = 0
+        i_freq[1, out_of_band] = self.n_freqs - 1
 
-        # lower frequency bound
-        # theta low
-        VELt_freq_low_theta_low = interpolate_linear(
-            phi, phi_lower, phi_upper,
-            self.VEL_theta[self._get_index(iFrequency_lower, iTheta_lower, iPhi_lower)],
-            self.VEL_theta[self._get_index(iFrequency_lower, iTheta_lower, iPhi_upper)],
-            self._interpolation_method)
-        VELp_freq_low_theta_low = interpolate_linear(
-            phi, phi_lower, phi_upper,
-            self.VEL_phi[self._get_index(iFrequency_lower, iTheta_lower, iPhi_lower)],
-            self.VEL_phi[self._get_index(iFrequency_lower, iTheta_lower, iPhi_upper)],
-            self._interpolation_method)
+        # the 8 grid points surrounding the request, shape (component, freq, phi, theta, n_freq)
+        cell = (i_freq[:, None, None, :], i_phi[None, :, None, None], i_theta[None, None, :, None])
+        VEL = np.array([self.VEL_theta[cell], self.VEL_phi[cell]])
 
-        # theta up
-        VELt_freq_low_theta_up = interpolate_linear(
-            phi, phi_lower, phi_upper,
-            self.VEL_theta[self._get_index(iFrequency_lower, iTheta_upper, iPhi_lower)],
-            self.VEL_theta[self._get_index(iFrequency_lower, iTheta_upper, iPhi_upper)],
-            self._interpolation_method)
-        VELp_freq_low_theta_up = interpolate_linear(
-            phi, phi_lower, phi_upper,
-            self.VEL_phi[self._get_index(iFrequency_lower, iTheta_upper, iPhi_lower)],
-            self.VEL_phi[self._get_index(iFrequency_lower, iTheta_upper, iPhi_upper)],
-            self._interpolation_method)
+        # collapse the three grid axes one by one, each time the axis is at position 2 (phi,
+        # then theta) resp. 1 (frequency)
+        method = self._interpolation_method
+        VEL = interpolate_linear(
+            phi, *self.phi_angles[i_phi], VEL[:, :, 0], VEL[:, :, 1], method)
+        VEL = interpolate_linear(
+            theta, *self.theta_angles[i_theta], VEL[:, :, 0], VEL[:, :, 1], method)
+        VEL = interpolate_linear(
+            freq, *self.frequencies[i_freq], VEL[:, 0], VEL[:, 1], method)
 
-        VELt_freq_low = interpolate_linear(theta, theta_lower,
-                                           theta_upper,
-                                           VELt_freq_low_theta_low,
-                                           VELt_freq_low_theta_up,
-                                           self._interpolation_method)
-        VELp_freq_low = interpolate_linear(theta, theta_lower,
-                                           theta_upper,
-                                           VELp_freq_low_theta_low,
-                                           VELp_freq_low_theta_up,
-                                           self._interpolation_method)
-
-        # upper frequency bound
-        # theta low
-        VELt_freq_up_theta_low = interpolate_linear(
-            phi, phi_lower, phi_upper,
-            self.VEL_theta[self._get_index(iFrequency_upper, iTheta_lower, iPhi_lower)],
-            self.VEL_theta[self._get_index(iFrequency_upper, iTheta_lower, iPhi_upper)],
-            self._interpolation_method)
-        VELp_freq_up_theta_low = interpolate_linear(
-            phi, phi_lower, phi_upper,
-            self.VEL_phi[self._get_index(iFrequency_upper, iTheta_lower, iPhi_lower)],
-            self.VEL_phi[self._get_index(iFrequency_upper, iTheta_lower, iPhi_upper)],
-            self._interpolation_method)
-
-        # theta up
-        VELt_freq_up_theta_up = interpolate_linear(
-            phi, phi_lower, phi_upper,
-            self.VEL_theta[self._get_index(iFrequency_upper, iTheta_upper, iPhi_lower)],
-            self.VEL_theta[self._get_index(iFrequency_upper, iTheta_upper, iPhi_upper)],
-            self._interpolation_method)
-        VELp_freq_up_theta_up = interpolate_linear(
-            phi, phi_lower, phi_upper,
-            self.VEL_phi[self._get_index(iFrequency_upper, iTheta_upper, iPhi_lower)],
-            self.VEL_phi[self._get_index(iFrequency_upper, iTheta_upper, iPhi_upper)],
-            self._interpolation_method)
-
-        VELt_freq_up = interpolate_linear(theta, theta_lower, theta_upper,
-                                          VELt_freq_up_theta_low,
-                                          VELt_freq_up_theta_up,
-                                          self._interpolation_method)
-        VELp_freq_up = interpolate_linear(theta, theta_lower, theta_upper,
-                                          VELp_freq_up_theta_low,
-                                          VELp_freq_up_theta_up,
-                                          self._interpolation_method)
-
-        interpolated_VELt = interpolate_linear_vectorized(freq, frequency_lower,
-                                                          frequency_upper,
-                                                          VELt_freq_low,
-                                                          VELt_freq_up,
-                                                          self._interpolation_method)
-        interpolated_VELp = interpolate_linear_vectorized(freq, frequency_lower,
-                                                          frequency_upper,
-                                                          VELp_freq_low,
-                                                          VELp_freq_up,
-                                                          self._interpolation_method)
-
-        # set all out of bound frequencies to zero
-        interpolated_VELt[out_of_bound_freqs_low] = 0 + 0 * 1j
-        interpolated_VELt[out_of_bound_freqs_high] = 0 + 0 * 1j
-        interpolated_VELp[out_of_bound_freqs_low] = 0 + 0 * 1j
-        interpolated_VELp[out_of_bound_freqs_high] = 0 + 0 * 1j
-        return interpolated_VELt, interpolated_VELp
+        VEL[:, out_of_band] = 0
+        return VEL[0], VEL[1]
 
 
 class AntennaPatternAnalytic(AntennaPatternBase):
     """
     utility class that handles access and buffering to analytic antenna pattern
     """
+
+    # default low frequency cutoff (peak frequency for the HPol) and maximum VEL, chosen
+    # such that the model approximates the corresponding simulated antenna model
+    _defaults = {
+        'analytic_LPDA': (110 * units.MHz, 0.55 * units.m),   # createLPDA_100MHz_InfFirn_n1.4
+        'analytic_VPol': (220 * units.MHz, 0.18 * units.m),   # RNOG_vpol_v3_5inch_center_n1.74
+        'analytic_HPol': (500 * units.MHz, 0.055 * units.m),  # RNOG_hpol_v4_8inch_center_n1.74
+    }
 
     def __init__(self, antenna_model, cutoff_freq=None, max_VEL=None):
         """
@@ -1645,169 +1611,161 @@ class AntennaPatternAnalytic(AntennaPatternBase):
             'analytic_VPol': 0.18 m,
             'analytic_HPol': 0.055 m.
         """
+        if antenna_model not in self._defaults:
+            logger.error("analytic antenna model {} is not implemented".format(antenna_model))
+            raise ValueError("analytic antenna model {} is not implemented".format(antenna_model))
+
         self._notfound = False
         self._model = antenna_model
+        self._antenna_rotations = {}
 
-        if self._model == 'analytic_LPDA':
-            # LPDA dummy model points towards z direction and has its tines in the y-z plane
-            self._orientation_theta = 0 * units.deg
-            self._orientation_phi = 0 * units.deg
-            self._rotation_theta = 90 * units.deg
-            self._rotation_phi = 0 * units.deg
-            self._cutoff_freq = 110 * units.MHz if cutoff_freq is None else cutoff_freq
-            self._max_VEL = 0.55 * units.m if max_VEL is None else max_VEL
+        default_cutoff_freq, default_max_VEL = self._defaults[antenna_model]
+        self._cutoff_freq = default_cutoff_freq if cutoff_freq is None else cutoff_freq
+        self._max_VEL = default_max_VEL if max_VEL is None else max_VEL
 
-        if self._model == 'analytic_VPol':
-            # VPol dummy model points towards z direction
-            self._orientation_theta = 0 * units.deg
-            self._orientation_phi = 0 * units.deg
-            self._rotation_theta = 90 * units.deg
-            self._rotation_phi = 0 * units.deg
-            self._cutoff_freq = 220 * units.MHz if cutoff_freq is None else cutoff_freq
-            self._max_VEL = 0.18 * units.m if max_VEL is None else max_VEL
-
-        if self._model == 'analytic_HPol':
-            # HPol dummy model points towards z direction
-            self._orientation_theta = 0 * units.deg
-            self._orientation_phi = 0 * units.deg
-            self._rotation_theta = 90 * units.deg
-            self._rotation_phi = 0 * units.deg
-            self._cutoff_freq = 500 * units.MHz if cutoff_freq is None else cutoff_freq
-            self._max_VEL = 0.055 * units.m if max_VEL is None else max_VEL
+        # all dummy models point towards z, the LPDA has its tines in the y-z plane
+        self._orientation_theta = 0 * units.deg
+        self._orientation_phi = 0 * units.deg
+        self._rotation_theta = 90 * units.deg
+        self._rotation_phi = 0 * units.deg
 
     def parametric_phase(self, freq, phase_type='theoretical'):
         """
+        Phase of the analytic antenna models as a function of frequency
 
+        Parameters
+        ----------
+        freq: array of floats
+            frequencies at which to evaluate the phase
+        phase_type: string
+            one of 'theoretical', 'frontlobe_lpda', 'side_lpda', 'back_lpda',
+            'VPol_third_order' or 'HPol_third_order'
+
+        Returns
+        -------
+        phase: array of floats
+            the phase in radians
         """
-        if phase_type == 'frontlobe_lpda':
-            a = 100 * (freq - 400 * units.MHz) ** 2 - 20
-            a[np.where(freq > 400 * units.MHz)] -= 0.00007 * (
-                freq[np.where(freq > 400 * units.MHz)] - 400 * units.MHz) ** 2
+        # The third order parametrizations: the 1st, 2nd, and 3rd order parameters are obtained
+        # from a 2nd order polynomial fit to the slope of the unwrapped complex phase of the
+        # corresponding simulated antenna pattern. The constant term is obtained by fitting the
+        # resulting analytic antenna pattern (with the offset set to 0) in the time domain to
+        # the simulated antenna pattern in the time domain.
+        if phase_type == 'theoretical':
+            tau = 0.75             # ratio of two elements
+            f = 1000. * units.MHz  # maximum frequency
+            return np.pi / np.log(tau) * np.log(freq / f) - 60
+        elif phase_type == 'frontlobe_lpda':
+            phase = 100 * (freq - 400 * units.MHz) ** 2 - 20
+            above = freq > 400 * units.MHz
+            phase[above] -= 0.00007 * (freq[above] - 400 * units.MHz) ** 2
+            return phase
         elif phase_type == 'side_lpda':
-            a = 40 * (freq - 950 * units.MHz) ** 2 - 40
+            return 40 * (freq - 950 * units.MHz) ** 2 - 40
         elif phase_type == 'back_lpda':
-            a = 50 * (freq - 950 * units.MHz) ** 2 - 50
-        elif phase_type == "theoretical":
-            # ratio of two elements
-            tau = 0.75
-            # maximum frequency
-            f = 1000. * units.MHz
-            a = np.pi / np.log(tau) * np.log(freq / f) - 60
-        if phase_type == 'VPol_third_order':
-            # The 1st, 2nd, and 3rd order parameters are obtained from a 2nd order polynomial fit to the slope of the
-            # unwrapped complex phase of the RNOG_vpol_v3_5inch_center_n1.74 antenna pattern. The constant term is obtained
-            # by fitting the resulting analytic antenna pattern (with the offset set to 0) in the time domain to the
-            # simulated antenna pattern in the time domain.
-            a = 2.086 - 117.917 * freq + 74.567/2 * freq**2 - 64.343/3 * freq**3
-        if phase_type == 'HPol_third_order':
-            # The 1st, 2nd, and 3rd order parameters are obtained from a 2nd order polynomial fit to the slope of the
-            # unwrapped complex phase of the RNOG_hpol_v4_8inch_center_n1.74 antenna pattern. The constant term is obtained
-            # by fitting the resulting analytic antenna pattern (with the offset set to 0) in the time domain to the
-            # simulated antenna pattern in the time domain.
-            a = 0.321 - 11.400 * freq + 39.590/2 * freq**2 -38.181/3 * freq**3
+            return 50 * (freq - 950 * units.MHz) ** 2 - 50
+        elif phase_type == 'VPol_third_order':
+            return 2.086 - 117.917 * freq + 74.567 / 2 * freq ** 2 - 64.343 / 3 * freq ** 3
+        elif phase_type == 'HPol_third_order':
+            return 0.321 - 11.400 * freq + 39.590 / 2 * freq ** 2 - 38.181 / 3 * freq ** 3
 
-        return a
+        logger.error("phase type {} not implemented".format(phase_type))
+        raise NotImplementedError("phase type {} not implemented".format(phase_type))
+
+    def _gain_to_vel(self, freq, gain, low_frequency_cutoff=True):
+        """
+        Convert a gain into a vector effective length, apply the low frequency cutoff
+        and normalize to the maximum VEL of the model
+
+        Parameters
+        ----------
+        freq: array of floats
+            frequencies at which to evaluate the response
+        gain: array of floats
+            the gain at those frequencies
+        low_frequency_cutoff: bool
+            if True, suppress the response below ``cutoff_freq`` with a half Hann window
+
+        Returns
+        -------
+        VEL: array of floats
+            the vector effective length
+        """
+        in_band = freq > 0
+        VEL = np.zeros_like(freq)
+        VEL[in_band] = np.sqrt(gain[in_band]) / freq[in_band]
+
+        if low_frequency_cutoff:
+            i_cutoff = np.argmax(freq > self._cutoff_freq)
+            VEL[:i_cutoff] *= hann(2 * i_cutoff)[:i_cutoff]
+
+        VEL[in_band] *= self._max_VEL / np.max(VEL[in_band])
+        return VEL
 
     def _get_antenna_response_vectorized_raw(self, freq, theta, phi, group_delay=True):
         """
+        Get the vector effective length in the coordinate system of the antenna model
 
+        Parameters
+        ----------
+        freq: array of floats
+            frequencies at which to evaluate the response
+        theta, phi: float
+            direction in the coordinate system of the antenna model
+        group_delay: bool
+            if True, apply the parametrized phase of the model
+
+        Returns
+        -------
+        VEL_theta, VEL_phi: arrays of floats or complex floats
+            the two components of the vector effective length
         """
+        in_band = freq > 0
+
         if self._model == 'analytic_LPDA':
-            """
-            Dummy LPDA model. Approximates createLPDA_100MHz_InfFirn_n1.4 with the default values of cutoff_freq and max_VEL.
-            Flat gain as function of frequency.
-            """
-            fmask = freq > 0
-            index = np.argmax(freq > self._cutoff_freq)
-            gain_filter = hann(2 * index)
-            gain = np.ones_like(freq)
+            # Flat gain as function of frequency
+            VEL = self._gain_to_vel(freq, np.ones_like(freq))
+            VEL_theta = VEL * np.cos(theta) * np.sin(phi) * np.cos(theta / 2)
+            VEL_phi = VEL * np.cos(theta / 2) * np.cos(phi)
 
-            # Theta component:
-            VEL_theta          = np.zeros_like(gain)
-            VEL_theta[fmask]   = np.sqrt(gain[fmask]) / freq[fmask]            # Gain to VEL conversion
-            VEL_theta[:index] *= gain_filter[:index]                           # Low frequency cutoff
-            VEL_theta[fmask]  *= self._max_VEL / max(VEL_theta[fmask])         # Normalize to requested max VEL
-            VEL_theta         *= np.cos(theta) * np.sin(phi) * np.cos(theta/2) # Directional dependency of response
-
-            # Phi component:
-            VEL_phi          = np.zeros_like(gain)
-            VEL_phi[fmask]   = np.sqrt(gain[fmask]) / freq[fmask]
-            VEL_phi[:index] *= gain_filter[:index]
-            VEL_phi[fmask]  *= self._max_VEL / max(VEL_phi[fmask])
-            VEL_phi         *= np.cos(theta/2) * np.cos(phi)
-
-            if group_delay:
-                if theta <= 45 * units.deg:
-                    phase_type = "frontlobe_lpda"
-                elif theta > 45 * units.deg and theta <= 90 * units.deg:
-                    phase_type = "side_lpda"
-                elif theta > 90 * units.deg:
-                    phase_type = "back_lpda"
-                phase = self.parametric_phase(freq, phase_type=phase_type)
-
-                VEL_phi = VEL_phi.astype(complex)
-                VEL_theta = VEL_theta.astype(complex)
-
-                VEL_phi *= np.exp(1j * phase)
-                VEL_theta *= np.exp(1j * phase)
+            if theta <= 45 * units.deg:
+                phase_type = "frontlobe_lpda"
+            elif theta <= 90 * units.deg:
+                phase_type = "side_lpda"
+            else:
+                phase_type = "back_lpda"
 
         elif self._model == 'analytic_VPol':
-            """
-            Dummy VPol model. Approximates RNOG_vpol_v3_5inch_center_n1.74 with the default values of cutoff_freq and max_VEL.
-            """
-            fmask = freq > 0
-            index = np.argmax(freq > self._cutoff_freq)
-            gain_filter = hann(2 * index)
             gain = np.ones_like(freq)
-            gain[fmask] /= np.sqrt(freq[fmask])  # frequency dependent gain fall-off
+            gain[in_band] /= np.sqrt(freq[in_band])  # frequency dependent gain fall-off
+            VEL_theta = self._gain_to_vel(freq, gain) * np.sin(theta)
+            VEL_phi = np.zeros_like(freq)
+            phase_type = "VPol_third_order"
 
-            # Theta component:
-            VEL_theta         = np.zeros_like(gain)
-            VEL_theta[fmask]  = np.sqrt(gain[fmask]) / freq[fmask]       # Gain to VEL conversion
-            VEL_theta[:index] *= gain_filter[:index]                     # Low frequency cutoff
-            VEL_theta[fmask]  *= self._max_VEL / max(VEL_theta[fmask])   # Normalize to requested max VEL
-            VEL_theta         *= np.sin(theta)                           # Directional dependency of response
-
-            # Phi component:
-            VEL_phi = np.zeros_like(gain)
-
-            if group_delay:
-                phase = self.parametric_phase(freq, phase_type = "VPol_third_order")
-
-                VEL_theta = VEL_theta.astype(complex)
-
-                VEL_theta *= np.exp(1j * phase)
-            
         elif self._model == 'analytic_HPol':
-            """
-            Dummy HPol model. Approximates RNOG_hpol_v4_8inch_center_n1.74 with the default values of cutoff_freq and max_VEL.
-            In this model, cutoff_freq controls where the gain peaks.
-            """
-            fmask = freq > 0
-            peak_freq = np.copy(self._cutoff_freq)
-            gain = np.ones_like(freq)
+            # cos^2 frequency dependency (peaking at cutoff_freq) and sin^2(theta) directivity
+            VEL_phi = np.zeros_like(freq)
+            VEL_phi[in_band] = np.sin(freq[in_band] / self._cutoff_freq * np.pi / 2) ** 2
+            VEL_phi[freq > 2 * self._cutoff_freq] = 0
+            VEL_phi[in_band] *= self._max_VEL / np.max(VEL_phi[in_band])
+            VEL_phi *= np.sin(theta) ** 2
+            VEL_theta = np.zeros_like(freq)
+            phase_type = "HPol_third_order"
 
-            # Theta component:
-            VEL_theta = np.zeros_like(gain)
+        if group_delay:
+            phase = np.exp(1j * self.parametric_phase(freq, phase_type))
+            VEL_theta = VEL_theta * phase
+            VEL_phi = VEL_phi * phase
 
-            # Phi component: Assuming cos^2 squared frequency dependency and sin^2(theta) direction dependency
-            VEL_phi                        = np.zeros_like(gain)
-            VEL_phi[fmask]                 = np.sqrt(gain[fmask]) * np.sin(freq[fmask] / peak_freq * np.pi/2)**2
-            VEL_phi[freq > peak_freq * 2]  = 0
-            VEL_phi[fmask]                *= self._max_VEL / max(VEL_phi[fmask])
-            VEL_phi                       *= np.sin(theta)**2
-
-            if group_delay:
-                phase = self.parametric_phase(freq, phase_type = "HPol_third_order")
-
-                VEL_phi = VEL_phi.astype(complex)
-
-                VEL_phi *= np.exp(1j * phase)
-        
         return VEL_theta, VEL_phi
 
 
 class AntennaPatternProvider(object):
+    """
+    Provider class for antenna pattern. The usage of antenna pattern through this class ensures
+    that an antenna pattern is loaded only once into memory which takes a significant time and
+    occupies a significant amount of memory.
+    """
     __instance = None
 
     def __new__(cls, *args, **kwargs):
@@ -1817,11 +1775,18 @@ class AntennaPatternProvider(object):
 
     def __init__(self, log_level=logging.NOTSET):
         """
-        Provider class for antenna pattern. The usage of antenna pattern through this class ensures
-        that an antenna pattern is loaded only once into memory which takes a significant time and occupies a
-        significant amount of memory.
+        Parameters
+        ----------
+        log_level: int
+            the log level of the antenna pattern logger
         """
         logger.setLevel(log_level)
+
+        # the class is a singleton, only set up the buffer on the very first instantiation
+        # (otherwise every `AntennaPatternProvider()` would discard the loaded patterns)
+        if hasattr(self, "_open_antenna_patterns"):
+            return
+
         self._open_antenna_patterns = {}
         self._antenna_model_replacements = {}
 

--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -1,4 +1,5 @@
 from NuRadioReco.utilities import units, io_utilities
+from NuRadioReco.utilities.logging import deprecated
 from radiotools import helper as hp
 
 from scipy import constants
@@ -737,8 +738,8 @@ def preprocess_AERA(path):
     def P2R(magnitude, phase):
         return magnitude * np.exp(1j * phase)
 
-    VEL_thetas = P2R(theta_amps, theta_phases)
-    VEL_phis = P2R(phi_amps, phi_phases)
+    vel_thetas = P2R(theta_amps, theta_phases)
+    vel_phis = P2R(phi_amps, phi_phases)
 
     # (angle) -> (freq * angle)
     thetas = np.tile(thetas, n_freqs)
@@ -749,8 +750,8 @@ def preprocess_AERA(path):
 
     # sort with increasing frequency, increasing phi, and increasing theta
     index = np.lexsort((thetas, phis, ff))
-    VEL_thetas = VEL_thetas.flatten()[index]
-    VEL_phis = VEL_phis.flatten()[index]
+    vel_thetas = vel_thetas.flatten()[index]
+    vel_phis = vel_phis.flatten()[index]
 
     # (angle) -> (freq * angle)
     theta = np.tile(thetas, n_freqs)[index]
@@ -758,8 +759,8 @@ def preprocess_AERA(path):
 
     # to avoid issues when deviding throw H (H=0 is ignored)
     # |H| < 0.1 should not happen between 30 - 80 MHz
-    H_phi = np.where(np.abs(VEL_phis) > 0.01, VEL_phis, 0)
-    H_theta = np.where(np.abs(VEL_thetas) > 0.01, VEL_thetas, 0)
+    H_phi = np.where(np.abs(vel_phis) > 0.01, vel_phis, 0)
+    H_theta = np.where(np.abs(vel_thetas) > 0.01, vel_thetas, 0)
 
     # values for a upwards pointing LPDA with the arm aligned to the magnetic field
     orientation_theta, orientation_phi, rotation_theta, rotation_phi = 0 * units.deg, 0 * units.deg, 90 * units.deg, 90 * units.deg
@@ -1085,21 +1086,21 @@ def preprocess_LOFAR_txt(directory, ant='LBA', orientation=None):
         for ar in [theta_real, theta_imag, phi_real, phi_imag]:
             ar *= -1
 
-    VEL_thetas = theta_real + 1j * theta_imag
-    VEL_phis = phi_real + 1j * phi_imag
+    vel_thetas = theta_real + 1j * theta_imag
+    vel_phis = phi_real + 1j * phi_imag
 
     # sort with increasing frequency, increasing phi, and increasing theta
     index = np.lexsort((thetas, phis, frequencies))
-    VEL_thetas = VEL_thetas.flatten()[index]
-    VEL_phis = VEL_phis.flatten()[index]
+    vel_thetas = vel_thetas.flatten()[index]
+    vel_phis = vel_phis.flatten()[index]
 
     # (angle) -> (freq * angle)
     theta = thetas[index]
     phi = phis[index]
 
     # TODO: is the correct calculation of VEL? Felix wrote that for AERA, |H| < 0.1 should not happen...
-    H_phi = VEL_phis
-    H_theta = VEL_thetas
+    H_phi = vel_phis
+    H_theta = vel_thetas
 
     # values for an upright LBA antenna aligned along E-W
     orientation_theta, orientation_phi, rotation_theta, rotation_phi = \
@@ -1385,7 +1386,7 @@ class AntennaPatternBase:
 
         Returns
         -------
-        VEL: dictonary of complex arrays
+        vel: dictonary of complex arrays
             theta and phi component of the vector effective length, both components
             are complex floats or arrays of complex floats
             of the same length as the frequency input
@@ -1398,7 +1399,7 @@ class AntennaPatternBase:
         theta, phi = self._get_theta_and_phi(
             zenith, azimuth, orientation_theta, orientation_phi, rotation_theta, rotation_phi)
 
-        VEL_theta_raw, VEL_phi_raw = self._get_antenna_response_vectorized_raw(freq, theta, phi)
+        vel_theta_raw, vel_phi_raw = self._get_antenna_response_vectorized_raw(freq, theta, phi)
 
         _, inverse_antenna_rotation, polar_roll = self._get_antenna_rotation(
             orientation_theta, orientation_phi, rotation_theta, rotation_phi)
@@ -1407,7 +1408,7 @@ class AntennaPatternBase:
         # unit vectors at the shifted azimuth are rolled by exactly the same angle. Both
         # cancel for every direction, i.e. the two on-sky systems already coincide.
         if polar_roll:
-            return {'theta': VEL_theta_raw, 'phi': VEL_phi_raw}
+            return {'theta': vel_theta_raw, 'phi': vel_phi_raw}
 
         # The eTheta and ePhi unit vectors of the antenna simulation and of NuRadio point in
         # different directions, so rotate the VEL from the one on-sky system into the other
@@ -1418,9 +1419,9 @@ class AntennaPatternBase:
 
         # the eR component of the VEL is zero and the one of the result is not needed,
         # hence only the eTheta/ePhi block of the rotation contributes
-        VEL = np.matmul(rotation[1:, 1:], np.array([VEL_theta_raw, VEL_phi_raw]))
+        vel = np.matmul(rotation[1:, 1:], np.array([vel_theta_raw, vel_phi_raw]))
 
-        return {'theta': VEL[0], 'phi': VEL[1]}
+        return {'theta': vel[0], 'phi': vel[1]}
 
 
 class AntennaPattern(AntennaPatternBase):
@@ -1515,13 +1516,29 @@ class AntennaPattern(AntennaPatternBase):
             logger.status("Performing consistency check on antenna response ...")
             self._check_grid_ordering(ff, thetas, phis)
 
-        # both components in one array so that a single gather serves both, VEL_theta and
-        # VEL_phi are views into it
+        # both components in one array so that a single gather serves both
         grid_shape = (self.n_freqs, self.n_phi, self.n_theta)
-        self.VEL = np.array([H_theta.reshape(grid_shape), H_phi.reshape(grid_shape)])
-        self.VEL_theta, self.VEL_phi = self.VEL
+        self._vel = np.array([H_theta.reshape(grid_shape), H_phi.reshape(grid_shape)])
 
         logger.status('Loading antenna file {} took {:.1f} seconds'.format(antenna_model, time() - t0))
+
+    @property
+    @deprecated("`AntennaPattern.VEL` is deprecated. You should not use it. "
+        "If you know what you are doing you can use it with `_vel` instead.", stacklevel=2)
+    def VEL(self):
+        return self._vel
+
+    @property
+    @deprecated("`AntennaPattern.VEL_theta` is deprecated. You should not use it. "
+        "If you know what you are doing you can use it with `_vel[0]` instead.", stacklevel=2)
+    def VEL_theta(self):
+        return self._vel[0]
+
+    @property
+    @deprecated("`AntennaPattern.VEL_phi` is deprecated. You should not use it. "
+        "If you know what you are doing you can use it with `_vel[1]` instead.", stacklevel=2)
+    def VEL_phi(self):
+        return self._vel[1]
 
     def _check_grid_ordering(self, ff, thetas, phis):
         """
@@ -1556,7 +1573,7 @@ class AntennaPattern(AntennaPatternBase):
 
         Returns
         -------
-        VEL_theta, VEL_phi: arrays of complex floats
+        vel_theta, vel_phi: arrays of complex floats
             the two components of the vector effective length
         """
         freq = np.atleast_1d(freq)
@@ -1592,30 +1609,30 @@ class AntennaPattern(AntennaPatternBase):
         last = min(int(np.searchsorted(self.frequencies, freq[in_band].max(), "left")) + 1, self.n_freqs)
 
         method = self._interpolation_method
-        VEL = self.VEL[:, first:last][:, :, i_phi[:, None], i_theta[None, :]]
+        vel = self._vel[:, first:last][:, :, i_phi[:, None], i_theta[None, :]]
 
         if method == 'complex':
             # the bilinear interpolation written as a single weighted sum of the four
             # corners, which is ~2x faster than interpolating one axis after the other
             w_phi = get_interpolation_weight(phi, *self.phi_angles[i_phi])
             w_theta = get_interpolation_weight(theta, *self.theta_angles[i_theta])
-            VEL = (VEL[..., 0, 0] * ((1 - w_phi) * (1 - w_theta))
-                   + VEL[..., 0, 1] * ((1 - w_phi) * w_theta)
-                   + VEL[..., 1, 0] * (w_phi * (1 - w_theta))
-                   + VEL[..., 1, 1] * (w_phi * w_theta))
+            vel = (vel[..., 0, 0] * ((1 - w_phi) * (1 - w_theta))
+                   + vel[..., 0, 1] * ((1 - w_phi) * w_theta)
+                   + vel[..., 1, 0] * (w_phi * (1 - w_theta))
+                   + vel[..., 1, 1] * (w_phi * w_theta))
         else:
-            VEL = interpolate_linear(
-                phi, *self.phi_angles[i_phi], VEL[..., 0, :], VEL[..., 1, :], method)
-            VEL = interpolate_linear(
-                theta, *self.theta_angles[i_theta], VEL[..., 0], VEL[..., 1], method)
+            vel = interpolate_linear(
+                phi, *self.phi_angles[i_phi], vel[..., 0, :], vel[..., 1, :], method)
+            vel = interpolate_linear(
+                theta, *self.theta_angles[i_theta], vel[..., 0], vel[..., 1], method)
 
         # ... and only then interpolate along the frequency axis, shape (component, n_freq)
-        VEL = self._interpolate_frequency(freq, self.frequencies[first:last], VEL)
+        vel = self._interpolate_frequency(freq, self.frequencies[first:last], vel)
 
-        VEL[:, ~in_band] = 0
-        return VEL[0], VEL[1]
+        vel[:, ~in_band] = 0
+        return vel[0], vel[1]
 
-    def _interpolate_frequency(self, freq, nodes, VEL):
+    def _interpolate_frequency(self, freq, nodes, vel):
         """
         Interpolate the vector effective length at the frequency nodes onto ``freq``
 
@@ -1624,22 +1641,22 @@ class AntennaPattern(AntennaPatternBase):
         freq: array of floats
             the requested frequencies
         nodes: array of floats
-            the frequency nodes VEL is given at
-        VEL: array of complex floats
+            the frequency nodes vel is given at
+        vel: array of complex floats
             the vector effective length, shape (component, len(nodes))
 
         Returns
         -------
-        VEL: array of complex floats
+        vel: array of complex floats
             the interpolated vector effective length, shape (component, len(freq))
         """
         if self._interpolation_method == 'complex':
             # np.interp does the bracketing internally, in C and for the whole vector at once
-            return np.array([np.interp(freq, nodes, VEL[0]), np.interp(freq, nodes, VEL[1])])
+            return np.array([np.interp(freq, nodes, vel[0]), np.interp(freq, nodes, vel[1])])
 
         i_freq = np.array(get_bracketing_indices(freq, nodes, is_equidistant(nodes)))
         return interpolate_linear(
-            freq, *nodes[i_freq], VEL[:, i_freq[0]], VEL[:, i_freq[1]], self._interpolation_method)
+            freq, *nodes[i_freq], vel[:, i_freq[0]], vel[:, i_freq[1]], self._interpolation_method)
 
 
 class AntennaPatternAnalytic(AntennaPatternBase):
@@ -1754,18 +1771,18 @@ class AntennaPatternAnalytic(AntennaPatternBase):
 
         Returns
         -------
-        VEL: array of floats
+        vel: array of floats
             the vector effective length
         """
         in_band = freq > 0
-        VEL = np.zeros_like(freq)
-        VEL[in_band] = np.sqrt(gain[in_band]) / freq[in_band]
+        vel = np.zeros_like(freq)
+        vel[in_band] = np.sqrt(gain[in_band]) / freq[in_band]
 
         i_cutoff = np.argmax(freq > self._cutoff_freq)
-        VEL[:i_cutoff] *= hann(2 * i_cutoff)[:i_cutoff]
+        vel[:i_cutoff] *= hann(2 * i_cutoff)[:i_cutoff]
 
-        VEL[in_band] *= self._max_VEL / np.max(VEL[in_band])
-        return VEL
+        vel[in_band] *= self._max_VEL / np.max(vel[in_band])
+        return vel
 
     def _get_antenna_response_vectorized_raw(self, freq, theta, phi, group_delay=True):
         """
@@ -1782,16 +1799,16 @@ class AntennaPatternAnalytic(AntennaPatternBase):
 
         Returns
         -------
-        VEL_theta, VEL_phi: arrays of floats or complex floats
+        vel_theta, vel_phi: arrays of floats or complex floats
             the two components of the vector effective length
         """
         in_band = freq > 0
 
         if self._model == 'analytic_LPDA':
             # Flat gain as function of frequency
-            VEL = self._gain_to_vel(freq, np.ones_like(freq))
-            VEL_theta = VEL * np.cos(theta) * np.sin(phi) * np.cos(theta / 2)
-            VEL_phi = VEL * np.cos(theta / 2) * np.cos(phi)
+            vel = self._gain_to_vel(freq, np.ones_like(freq))
+            vel_theta = vel * np.cos(theta) * np.sin(phi) * np.cos(theta / 2)
+            vel_phi = vel * np.cos(theta / 2) * np.cos(phi)
 
             if theta <= 45 * units.deg:
                 phase_type = "frontlobe_lpda"
@@ -1803,26 +1820,26 @@ class AntennaPatternAnalytic(AntennaPatternBase):
         elif self._model == 'analytic_VPol':
             gain = np.ones_like(freq)
             gain[in_band] /= np.sqrt(freq[in_band])  # frequency dependent gain fall-off
-            VEL_theta = self._gain_to_vel(freq, gain) * np.sin(theta)
-            VEL_phi = np.zeros_like(freq)
+            vel_theta = self._gain_to_vel(freq, gain) * np.sin(theta)
+            vel_phi = np.zeros_like(freq)
             phase_type = "VPol_third_order"
 
         elif self._model == 'analytic_HPol':
             # cos^2 frequency dependency (peaking at cutoff_freq) and sin^2(theta) directivity
-            VEL_phi = np.zeros_like(freq)
-            VEL_phi[in_band] = np.sin(freq[in_band] / self._cutoff_freq * np.pi / 2) ** 2
-            VEL_phi[freq > 2 * self._cutoff_freq] = 0
-            VEL_phi[in_band] *= self._max_VEL / np.max(VEL_phi[in_band])
-            VEL_phi *= np.sin(theta) ** 2
-            VEL_theta = np.zeros_like(freq)
+            vel_phi = np.zeros_like(freq)
+            vel_phi[in_band] = np.sin(freq[in_band] / self._cutoff_freq * np.pi / 2) ** 2
+            vel_phi[freq > 2 * self._cutoff_freq] = 0
+            vel_phi[in_band] *= self._max_VEL / np.max(vel_phi[in_band])
+            vel_phi *= np.sin(theta) ** 2
+            vel_theta = np.zeros_like(freq)
             phase_type = "HPol_third_order"
 
         if group_delay:
             phase = np.exp(1j * self.parametric_phase(freq, phase_type))
-            VEL_theta = VEL_theta * phase
-            VEL_phi = VEL_phi * phase
+            vel_theta = vel_theta * phase
+            vel_phi = vel_phi * phase
 
-        return VEL_theta, VEL_phi
+        return vel_theta, vel_phi
 
 
 class AntennaPatternProvider(object):
@@ -1872,6 +1889,11 @@ class AntennaPatternProvider(object):
         **kwargs: dict
             key word arguments that are passed to the init function of the `AntennaPattern` class (see
             documentation of this class for further information)
+
+        Returns
+        -------
+        antenna_pattern : AntennaPattern or AntennaPatternAnalytic
+            Return the loaded antenna pattern object.
         """
         if name in self._antenna_model_replacements:
             replacement = self._antenna_model_replacements[name]

--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -65,6 +65,16 @@ def interpolate_linear(x, x0, x1, y0, y1, interpolation_method='complex'):
 interpolate_linear_vectorized = interpolate_linear
 
 
+def get_interpolation_weight(x, x0, x1):
+    """
+    Fraction of the way from ``x0`` to ``x1`` at which ``x`` lies, 0 for x0 == x1
+    """
+    if x0 == x1:
+        return 0.
+
+    return (x - x0) / (x1 - x0)
+
+
 def is_equidistant(nodes, rtol=1e-4):
     """
     Check whether the grid nodes are equally spaced (within ``rtol`` of the spacing)
@@ -1583,10 +1593,21 @@ class AntennaPattern(AntennaPatternBase):
 
         method = self._interpolation_method
         VEL = self.VEL[:, first:last][:, :, i_phi[:, None], i_theta[None, :]]
-        VEL = interpolate_linear(
-            phi, *self.phi_angles[i_phi], VEL[..., 0, :], VEL[..., 1, :], method)
-        VEL = interpolate_linear(
-            theta, *self.theta_angles[i_theta], VEL[..., 0], VEL[..., 1], method)
+
+        if method == 'complex':
+            # the bilinear interpolation written as a single weighted sum of the four
+            # corners, which is ~2x faster than interpolating one axis after the other
+            w_phi = get_interpolation_weight(phi, *self.phi_angles[i_phi])
+            w_theta = get_interpolation_weight(theta, *self.theta_angles[i_theta])
+            VEL = (VEL[..., 0, 0] * ((1 - w_phi) * (1 - w_theta))
+                   + VEL[..., 0, 1] * ((1 - w_phi) * w_theta)
+                   + VEL[..., 1, 0] * (w_phi * (1 - w_theta))
+                   + VEL[..., 1, 1] * (w_phi * w_theta))
+        else:
+            VEL = interpolate_linear(
+                phi, *self.phi_angles[i_phi], VEL[..., 0, :], VEL[..., 1, :], method)
+            VEL = interpolate_linear(
+                theta, *self.theta_angles[i_theta], VEL[..., 0], VEL[..., 1], method)
 
         # ... and only then interpolate along the frequency axis, shape (component, n_freq)
         VEL = self._interpolate_frequency(freq, self.frequencies[first:last], VEL)

--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -1809,17 +1809,33 @@ class AntennaPatternProvider(object):
             documentation of this class for further information)
         """
         if name in self._antenna_model_replacements:
-            if self._antenna_model_replacements[name] not in self._open_antenna_patterns:
+            replacement = self._antenna_model_replacements[name]
+            if not self._is_buffered(replacement):
                 logger.status("local replacement of antenna model requsted: replacing {} with {}".format(
-                    name, self._antenna_model_replacements[name]))
+                    name, replacement))
 
-            name = self._antenna_model_replacements[name]
+            name = replacement
 
-        if name not in self._open_antenna_patterns:
+        # the keyword arguments are part of the identity of a pattern: a model requested
+        # with different arguments is a different antenna and must not be served from the buffer
+        key = (name,) + tuple(sorted((k, repr(v)) for k, v in kwargs.items()))
+
+        if key not in self._open_antenna_patterns:
+            if self._is_buffered(name):
+                logger.warning(
+                    "antenna model {} is already buffered with different arguments, "
+                    "loading a second copy for {}".format(name, kwargs))
+
             if name.startswith("analytic"):
-                self._open_antenna_patterns[name] = AntennaPatternAnalytic(name, **kwargs)
+                self._open_antenna_patterns[key] = AntennaPatternAnalytic(name, **kwargs)
                 logger.info("loading analytic antenna model {}".format(name))
             else:
-                self._open_antenna_patterns[name] = AntennaPattern(name, **kwargs)
+                self._open_antenna_patterns[key] = AntennaPattern(name, **kwargs)
 
-        return self._open_antenna_patterns[name]
+        return self._open_antenna_patterns[key]
+
+    def _is_buffered(self, name):
+        """
+        Check whether any variant of the antenna model ``name`` is already buffered
+        """
+        return any(key[0] == name for key in self._open_antenna_patterns)

--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -1498,7 +1498,8 @@ class AntennaPattern(AntennaPatternBase):
             logger.debug("phi bounds {0} ,{1}, {2}".format(self.phi_lower_bound, phi, self.phi_upper_bound))
             logger.warning("theta, phi or frequency out of range, returning (0,0j)")
             logger.debug("{0},{1},{2}".format(freq, self.frequency_lower_bound, self.frequency_upper_bound))
-            return np.zeros(shape=(2,1), dtype=complex)
+            shape = np.shape(np.atleast_1d(freq))
+            return np.zeros(shape, dtype=complex), np.zeros(shape, dtype=complex)
 
         # the angular and frequency grids are not necessarily equally spaced (e.g. the
         # theta grid of RNOG_vpol_4inch_center_n1.73), hence look up the bracketing
@@ -1822,6 +1823,12 @@ class AntennaPatternProvider(object):
         significant amount of memory.
         """
         logger.setLevel(log_level)
+
+        # this is a singleton, i.e. __init__ runs on every instantiation. Only set up the
+        # buffer once, otherwise the already loaded patterns would be thrown away
+        if hasattr(self, "_open_antenna_patterns"):
+            return
+
         self._open_antenna_patterns = {}
         self._antenna_model_replacements = {}
 
@@ -1850,11 +1857,20 @@ class AntennaPatternProvider(object):
 
             name = self._antenna_model_replacements[name]
 
-        if name not in self._open_antenna_patterns:
+        # the kwargs are part of the identity of a pattern, a model requested with
+        # different kwargs is a different antenna and must not be served from the buffer
+        key = (name,) + tuple(sorted((k, repr(v)) for k, v in kwargs.items()))
+
+        if key not in self._open_antenna_patterns:
+            if any(buffered[0] == name for buffered in self._open_antenna_patterns):
+                logger.warning(
+                    "antenna model {} is already buffered with different arguments, "
+                    "loading a second copy for {}".format(name, kwargs))
+
             if name.startswith("analytic"):
-                self._open_antenna_patterns[name] = AntennaPatternAnalytic(name, **kwargs)
+                self._open_antenna_patterns[key] = AntennaPatternAnalytic(name, **kwargs)
                 logger.info("loading analytic antenna model {}".format(name))
             else:
-                self._open_antenna_patterns[name] = AntennaPattern(name, **kwargs)
+                self._open_antenna_patterns[key] = AntennaPattern(name, **kwargs)
 
-        return self._open_antenna_patterns[name]
+        return self._open_antenna_patterns[key]

--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -1248,9 +1248,12 @@ def get_onsky_rotation(zenith, azimuth):
         [-sp, cp, 0.]])
 
 
-def get_orthonormal_basis(theta1, phi1, theta2, phi2, description):
+def get_antenna_basis(theta1, phi1, theta2, phi2, description):
     """
     Basis spanned by two (almost) perpendicular directions and their cross product
+
+    The two directions are only required to be almost perpendicular, so the basis is
+    not necessarily orthonormal.
 
     Parameters
     ----------
@@ -1275,24 +1278,59 @@ def get_orthonormal_basis(theta1, phi1, theta2, phi2, description):
         logger.error("orientation of antenna not properly defined in {}".format(description))
         raise AssertionError("orientation of antenna not properly defined in {}".format(description))
 
-    # the two directions are only required to be almost perpendicular and the orientation
-    # stored in some antenna models is off by a few 0.01 deg. Without orthonormalising, the
-    # transformation between the two bases is not a rotation and rescales the VEL slightly.
-    e2 = e2 - np.dot(e2, e1) * e1
-    e2 /= np.linalg.norm(e2)
+    return np.array([e1, e2, e3])
 
-    return np.array([e1, e2, np.cross(e1, e2)])
+
+def make_perpendicular(theta1, phi1, theta2, phi2, description, tolerance=0.1 * units.deg):
+    """
+    Rotate the second direction into the plane perpendicular to the first
+
+    Some antenna models store a rounded angle (89.9544 deg instead of 90 deg), which makes the
+    basis spanned by the two directions non-orthogonal. The transformation between two such bases
+    is not a rotation and rescales the vector effective length slightly. A deviation larger than
+    `tolerance` is a genuine geometry and is left untouched.
+
+    Parameters
+    ----------
+    theta1, phi1: float
+        zenith and azimuth angle of the first direction
+    theta2, phi2: float
+        zenith and azimuth angle of the second direction, the one that is corrected
+    description: string
+        what is being corrected, used for the log message
+    tolerance: float (default: 0.1 deg)
+        largest deviation from perpendicular that is corrected
+
+    Returns
+    -------
+    theta2, phi2: float
+        the corrected second direction
+    """
+    e1 = hp.spherical_to_cartesian(theta1, phi1)
+    e2 = hp.spherical_to_cartesian(theta2, phi2)
+
+    deviation = np.arcsin(np.dot(e1, e2))  # zero if the two directions are perpendicular
+    if not 1e-9 < np.abs(deviation) <= tolerance:  # already perpendicular, or genuinely not
+        return theta2, phi2
+
+    e2 = e2 - np.dot(e2, e1) * e1
+    theta2, phi2 = hp.cartesian_to_spherical(*(e2 / np.linalg.norm(e2)))
+
+    logger.warning("the orientation stored in {} is {:.4f} deg off perpendicular, correcting it".format(
+        description, deviation / units.deg))
+
+    return theta2, phi2
 
 
 class AntennaPatternBase:
     """
-    base class of utility class that handles access and buffering to antenna pattern
+    Base class of utility class that handles access and buffering to antenna pattern
     """
 
     def _get_antenna_rotation(self, orientation_theta, orientation_phi, rotation_theta, rotation_phi):
         """
         Rotation from the coordinate system of the antenna simulation into the one of
-        the antenna as deployed in the field, and its inverse
+        the antenna as deployed in the field, and its inverse.
 
         The result only depends on the requested orientation, of which a detector has very
         few, so it is buffered.
@@ -1300,32 +1338,33 @@ class AntennaPatternBase:
         Parameters
         ----------
         orientation_theta, orientation_phi: float
-            orientation (boresight) of the antenna in the field, see
+            Orientation (boresight) of the antenna in the field, see
             `AntennaPatternBase.get_antenna_response_vectorized`
         rotation_theta, rotation_phi: float
-            rotation of the antenna in the field, see
+            Rotation of the antenna in the field, see
             `AntennaPatternBase.get_antenna_response_vectorized`
 
         Returns
         -------
         rotation, inverse_rotation: array of floats
-            the 3x3 rotation matrix and its inverse
+            The 3x3 matrix which transforms the signal arrival direction into the
+            coordinate system of the antenna simulation, and its inverse.
         polar_roll: bool
-            True if the rotation is a pure roll about the polar axis, see
+            True if the rotation is a pure roll around the polar axis (z-axis), see
             `AntennaPatternBase.get_antenna_response_vectorized`
         """
         orientation = (orientation_theta, orientation_phi, rotation_theta, rotation_phi)
         if orientation not in self._antenna_rotations:
-            simulated = get_orthonormal_basis(
+            simulated = get_antenna_basis(
                 self._orientation_theta, self._orientation_phi,
                 self._rotation_theta, self._rotation_phi, "the antenna model")
-            deployed = get_orthonormal_basis(*orientation, "the detector description")
+            deployed = get_antenna_basis(*orientation, "the detector description")
 
-            # both bases are orthonormal, hence the inverse is the transpose
-            rotation = np.matmul(simulated.T, deployed)
+            # neither basis is required to be orthonormal, so invert instead of transpose
+            rotation = np.matmul(np.linalg.inv(simulated), deployed)
             polar_roll = (np.allclose(rotation[2], [0., 0., 1.])
                           and np.allclose(rotation[:, 2], [0., 0., 1.]))
-            self._antenna_rotations[orientation] = (rotation, rotation.T, polar_roll)
+            self._antenna_rotations[orientation] = (rotation, np.linalg.inv(rotation), polar_roll)
 
         return self._antenna_rotations[orientation]
 
@@ -1363,9 +1402,18 @@ class AntennaPatternBase:
     def get_antenna_response_vectorized(self, freq, zenith, azimuth, orientation_theta, orientation_phi, rotation_theta,
                                         rotation_phi):
         """
-        get the antenna response for a specific frequency, zenith and azimuth angle
+        Get the antenna response for a specific frequency, zenith and azimuth angle.
 
-        All angles are specified in the NuRadio coordinate system. All units are in NuRadio default units
+        All angles are specified in the NuRadio coordinate system. All units are in NuRadio default units.
+
+        This function does three things:
+
+        * `_get_theta_and_phi`: transform the requested signal direction into the coordinate system
+          of the antenna simulation, taking the orientation and rotation of the antenna into account
+        * `_get_antenna_response_vectorized_raw`: interpolate the stored antenna pattern at that
+          requested direction (properly transformed) and frequencies (in the native simulated coordinate system)
+        * rotate the interpolated vector effective length, so that its two components refer to the
+          on-sky unit vectors of the NuRadio coordinate system
 
         Parameters
         ----------
@@ -1411,8 +1459,8 @@ class AntennaPatternBase:
             return {'theta': vel_theta_raw, 'phi': vel_phi_raw}
 
         # The eTheta and ePhi unit vectors of the antenna simulation and of NuRadio point in
-        # different directions, so rotate the VEL from the one on-sky system into the other
-        # by going through the (cartesian) ground coordinate system.
+        # different directions, so rotate the VEL from the one on-sky system of the simulated
+        # antenna pattern into the NuRadio system by going through the (cartesian) ground coordinate system.
         rotation = (get_onsky_rotation(zenith, azimuth)
                     @ inverse_antenna_rotation
                     @ get_onsky_rotation(theta, phi).T)
@@ -1490,6 +1538,10 @@ class AntennaPattern(AntennaPatternBase):
             self._notfound = True
             logger.error("antenna response for {} not found".format(antenna_model))
             raise FileNotFoundError("antenna response for {} not found".format(antenna_model))
+
+        self._rotation_theta, self._rotation_phi = make_perpendicular(
+            self._orientation_theta, self._orientation_phi,
+            self._rotation_theta, self._rotation_phi, antenna_model)
 
         self.frequencies = np.unique(ff)
         self.theta_angles = np.unique(thetas)

--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -1505,9 +1505,11 @@ class AntennaPattern(AntennaPatternBase):
             logger.status("Performing consistency check on antenna response ...")
             self._check_grid_ordering(ff, thetas, phis)
 
+        # both components in one array so that a single gather serves both, VEL_theta and
+        # VEL_phi are views into it
         grid_shape = (self.n_freqs, self.n_phi, self.n_theta)
-        self.VEL_theta = H_theta.reshape(grid_shape)
-        self.VEL_phi = H_phi.reshape(grid_shape)
+        self.VEL = np.array([H_theta.reshape(grid_shape), H_phi.reshape(grid_shape)])
+        self.VEL_theta, self.VEL_phi = self.VEL
 
         logger.status('Loading antenna file {} took {:.1f} seconds'.format(antenna_model, time() - t0))
 
@@ -1575,19 +1577,22 @@ class AntennaPattern(AntennaPatternBase):
         i_freq[0, out_of_band] = 0
         i_freq[1, out_of_band] = self.n_freqs - 1
 
-        # the 8 grid points surrounding the request, shape (component, freq, phi, theta, n_freq)
-        cell = (i_freq[:, None, None, :], i_phi[None, :, None, None], i_theta[None, None, :, None])
-        VEL = np.array([self.VEL_theta[cell], self.VEL_phi[cell]])
-
-        # collapse the three grid axes one by one, each time the axis is at position 2 (phi,
-        # then theta) resp. 1 (frequency)
         method = self._interpolation_method
+
+        # Collapse the two angular axes first, over the frequency nodes that are actually
+        # needed: theta and phi have a single bracket while every requested frequency has its
+        # own, so this interpolates a few hundred grid points instead of 8 per frequency bin.
+        first, last = int(i_freq.min()), int(i_freq.max()) + 1
+        VEL = self.VEL[:, first:last][:, :, i_phi[:, None], i_theta[None, :]]
         VEL = interpolate_linear(
-            phi, *self.phi_angles[i_phi], VEL[:, :, 0], VEL[:, :, 1], method)
+            phi, *self.phi_angles[i_phi], VEL[..., 0, :], VEL[..., 1, :], method)
         VEL = interpolate_linear(
-            theta, *self.theta_angles[i_theta], VEL[:, :, 0], VEL[:, :, 1], method)
+            theta, *self.theta_angles[i_theta], VEL[..., 0], VEL[..., 1], method)
+
+        # ... and only then interpolate along the frequency axis, shape (component, n_freq)
+        i_freq -= first
         VEL = interpolate_linear(
-            freq, *self.frequencies[i_freq], VEL[:, 0], VEL[:, 1], method)
+            freq, *self.frequencies[i_freq + first], VEL[:, i_freq[0]], VEL[:, i_freq[1]], method)
 
         VEL[:, out_of_band] = 0
         return VEL[0], VEL[1]

--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -1264,7 +1264,13 @@ def get_orthonormal_basis(theta1, phi1, theta2, phi2, description):
         logger.error("orientation of antenna not properly defined in {}".format(description))
         raise AssertionError("orientation of antenna not properly defined in {}".format(description))
 
-    return np.array([e1, e2, e3])
+    # the two directions are only required to be almost perpendicular and the orientation
+    # stored in some antenna models is off by a few 0.01 deg. Without orthonormalising, the
+    # transformation between the two bases is not a rotation and rescales the VEL slightly.
+    e2 = e2 - np.dot(e2, e1) * e1
+    e2 /= np.linalg.norm(e2)
+
+    return np.array([e1, e2, np.cross(e1, e2)])
 
 
 class AntennaPatternBase:
@@ -1293,6 +1299,9 @@ class AntennaPatternBase:
         -------
         rotation, inverse_rotation: array of floats
             the 3x3 rotation matrix and its inverse
+        polar_roll: bool
+            True if the rotation is a pure roll about the polar axis, see
+            `AntennaPatternBase.get_antenna_response_vectorized`
         """
         orientation = (orientation_theta, orientation_phi, rotation_theta, rotation_phi)
         if orientation not in self._antenna_rotations:
@@ -1301,8 +1310,11 @@ class AntennaPatternBase:
                 self._rotation_theta, self._rotation_phi, "the antenna model")
             deployed = get_orthonormal_basis(*orientation, "the detector description")
 
-            rotation = np.matmul(np.linalg.inv(simulated), deployed)
-            self._antenna_rotations[orientation] = (rotation, np.linalg.inv(rotation))
+            # both bases are orthonormal, hence the inverse is the transpose
+            rotation = np.matmul(simulated.T, deployed)
+            polar_roll = (np.allclose(rotation[2], [0., 0., 1.])
+                          and np.allclose(rotation[:, 2], [0., 0., 1.]))
+            self._antenna_rotations[orientation] = (rotation, rotation.T, polar_roll)
 
         return self._antenna_rotations[orientation]
 
@@ -1326,7 +1338,7 @@ class AntennaPatternBase:
         theta, phi: float
             the same direction in the coordinate system of the antenna simulation
         """
-        rotation, _ = self._get_antenna_rotation(
+        rotation, _, _ = self._get_antenna_rotation(
             orientation_theta, orientation_phi, rotation_theta, rotation_phi)
 
         incoming_direction = hp.spherical_to_cartesian(zenith, azimuth)
@@ -1378,11 +1390,18 @@ class AntennaPatternBase:
 
         VEL_theta_raw, VEL_phi_raw = self._get_antenna_response_vectorized_raw(freq, theta, phi)
 
+        _, inverse_antenna_rotation, polar_roll = self._get_antenna_rotation(
+            orientation_theta, orientation_phi, rotation_theta, rotation_phi)
+
+        # A roll of the antenna about the polar axis only shifts the azimuth, and the on-sky
+        # unit vectors at the shifted azimuth are rolled by exactly the same angle. Both
+        # cancel for every direction, i.e. the two on-sky systems already coincide.
+        if polar_roll:
+            return {'theta': VEL_theta_raw, 'phi': VEL_phi_raw}
+
         # The eTheta and ePhi unit vectors of the antenna simulation and of NuRadio point in
         # different directions, so rotate the VEL from the one on-sky system into the other
         # by going through the (cartesian) ground coordinate system.
-        _, inverse_antenna_rotation = self._get_antenna_rotation(
-            orientation_theta, orientation_phi, rotation_theta, rotation_phi)
         rotation = (get_onsky_rotation(zenith, azimuth)
                     @ inverse_antenna_rotation
                     @ get_onsky_rotation(theta, phi).T)

--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -76,6 +76,48 @@ def get_interpolation_weight(x, x0, x1):
     return (x - x0) / (x1 - x0)
 
 
+def interpolate_bilinear(x, nodes_x, y, nodes_y, corners, interpolation_method='complex'):
+    """
+    Interpolate within a 2-D grid cell from the values at its four corners
+
+    ``corners[..., i, j]`` is the value at ``(nodes_x[i], nodes_y[j])``.
+
+    The 'complex' interpolation is linear in the values, so the cell collapses into a single
+    weighted sum of the four corners, which is ~3x faster than interpolating one axis after
+    the other. The 'magphase' interpolation is not linear in the values and has to go axis
+    by axis.
+
+    Parameters
+    ----------
+    x, y: float
+        the requested position within the cell
+    nodes_x, nodes_y: array of floats
+        the two bracketing nodes of either axis
+    corners: array of complex floats
+        the values at the four corners, shape ``(..., 2, 2)``
+    interpolation_method: string
+        see `interpolate_linear`
+
+    Returns
+    -------
+    values: array of complex floats
+        the interpolated values, shape ``(...)``
+    """
+    if interpolation_method == 'complex':
+        w_x = get_interpolation_weight(x, *nodes_x)
+        w_y = get_interpolation_weight(y, *nodes_y)
+        return (corners[..., 0, 0] * ((1 - w_x) * (1 - w_y))
+                + corners[..., 0, 1] * ((1 - w_x) * w_y)
+                + corners[..., 1, 0] * (w_x * (1 - w_y))
+                + corners[..., 1, 1] * (w_x * w_y))
+
+    values = interpolate_linear(
+        x, *nodes_x, corners[..., 0, :], corners[..., 1, :], interpolation_method)
+
+    return interpolate_linear(
+        y, *nodes_y, values[..., 0], values[..., 1], interpolation_method)
+
+
 def is_equidistant(nodes, rtol=1e-4):
     """
     Check whether the grid nodes are equally spaced (within ``rtol`` of the spacing)
@@ -1660,23 +1702,18 @@ class AntennaPattern(AntennaPatternBase):
         first = max(int(np.searchsorted(self.frequencies, freq[in_band].min(), "right")) - 1, 0)
         last = min(int(np.searchsorted(self.frequencies, freq[in_band].max(), "left")) + 1, self.n_freqs)
 
-        method = self._interpolation_method
+        # Select only the relevant part of the loaded vector effective length:
+        # All frequencies within the requested frequency range (to be used in
+        # _interpolate_frequency). And the two bracketing nodes for the two angles.
+        # self._vel.shape: (n_pol, self.n_freqs, self.n_phi, self.n_theta)
+        # ---> vel.shape: (n_pol, last - first, 2, 2)
         vel = self._vel[:, first:last][:, :, i_phi[:, None], i_theta[None, :]]
 
-        if method == 'complex':
-            # the bilinear interpolation written as a single weighted sum of the four
-            # corners, which is ~2x faster than interpolating one axis after the other
-            w_phi = get_interpolation_weight(phi, *self.phi_angles[i_phi])
-            w_theta = get_interpolation_weight(theta, *self.theta_angles[i_theta])
-            vel = (vel[..., 0, 0] * ((1 - w_phi) * (1 - w_theta))
-                   + vel[..., 0, 1] * ((1 - w_phi) * w_theta)
-                   + vel[..., 1, 0] * (w_phi * (1 - w_theta))
-                   + vel[..., 1, 1] * (w_phi * w_theta))
-        else:
-            vel = interpolate_linear(
-                phi, *self.phi_angles[i_phi], vel[..., 0, :], vel[..., 1, :], method)
-            vel = interpolate_linear(
-                theta, *self.theta_angles[i_theta], vel[..., 0], vel[..., 1], method)
+        # Only interpolate between the 2 angle nodes each
+        # vel.shape: (n_pol, last - first, 2, 2) ---> (n_pol, last - first)
+        vel = interpolate_bilinear(
+            phi, self.phi_angles[i_phi], theta, self.theta_angles[i_theta],
+            vel, self._interpolation_method)
 
         # ... and only then interpolate along the frequency axis, shape (component, n_freq)
         vel = self._interpolate_frequency(freq, self.frequencies[first:last], vel)

--- a/NuRadioReco/detector/test/test_antennapattern.py
+++ b/NuRadioReco/detector/test/test_antennapattern.py
@@ -248,13 +248,12 @@ def test_interpolation_at_nodes():
     for i_freq in [0, 100, antenna.n_freqs - 1]:
         for i_theta in range(antenna.n_theta):
             for i_phi in range(0, antenna.n_phi, 3):
-                index = antenna._get_index(i_freq, i_theta, i_phi)
                 vel = antenna._get_antenna_response_vectorized_raw(
                     np.array([antenna.frequencies[i_freq]]),
                     antenna.theta_angles[i_theta], antenna.phi_angles[i_phi])
 
-                assert np.allclose(vel[0], antenna.VEL_theta[index], atol=1e-15)
-                assert np.allclose(vel[1], antenna.VEL_phi[index], atol=1e-15)
+                assert np.allclose(vel[0], antenna.VEL_theta[i_freq, i_phi, i_theta], atol=1e-15)
+                assert np.allclose(vel[1], antenna.VEL_phi[i_freq, i_phi, i_theta], atol=1e-15)
 
 
 def test_magphase_agrees_at_nodes():

--- a/NuRadioReco/detector/test/test_antennapattern.py
+++ b/NuRadioReco/detector/test/test_antennapattern.py
@@ -3,8 +3,10 @@
 Tests for NuRadioReco.detector.antennapattern
 
 The tests are split into two groups: everything up to `test_provider_buffering` runs
-without any antenna model file, the tests after it need RNOG_vpol_4inch_center_n1.73
-(~10 MB, downloaded on first use).
+without any antenna model file, the tests after it need antenna models which are
+downloaded on first use: RNOG_vpol_4inch_center_n1.73 (~10 MB) and, for the reference
+values, RNOG_vpol_v3_5inch_center_n1.74 and createLPDA_100MHz_v2_InfFirn_n1.4 (~700 MB
+each).
 
 Regression test for the bracketing of non-equidistant grids: the antenna models are
 not required to be sampled on an equally spaced grid (e.g. RNOG_vpol_4inch_center_n1.73
@@ -315,6 +317,121 @@ def test_vel_is_continuous():
                         azimuth / units.deg, freq / units.MHz, np.median(steps))
 
 
+# --------------------------------------------------------------------------------------
+# reference values, these need the RNOG_vpol_v3_5inch_center_n1.74 and
+# createLPDA_100MHz_v2_InfFirn_n1.4 antenna models
+# --------------------------------------------------------------------------------------
+
+VPOL_MODEL = "RNOG_vpol_v3_5inch_center_n1.74"
+LPDA_MODEL = "createLPDA_100MHz_v2_InfFirn_n1.4"
+
+# the frequencies and directions below mix grid nodes with points in between them (the
+# VPol model is sampled every 5 deg and ~2.13 MHz, the LPDA every 1 deg and 5 MHz), so both
+# the tabulated values and the interpolation are covered
+REFERENCE_FREQUENCIES = np.array([100., 250., 437.]) * units.MHz
+
+# (orientation_theta, orientation_phi, rotation_theta, rotation_phi) in deg
+REFERENCE_ORIENTATIONS = {
+    "vpol_upright": (0, 0, 90, 0),
+    "lpda_upward": (0, 0, 90, 0),  # boresight straight up
+    "lpda_downward": (120, 0, 30, 0),  # boresight 30 deg below the horizon, pointing East
+}
+
+# VEL_theta and VEL_phi (in NuRadio units, i.e. m) at REFERENCE_FREQUENCIES, keyed by
+# (model, orientation) and by the incoming direction (zenith, azimuth) in deg. These values
+# are hard-coded on purpose: they pin down the interpolation and the coordinate
+# transformations and only ever have to be regenerated if either is changed intentionally.
+REFERENCE_VEL = {
+    (VPOL_MODEL, "vpol_upright"): {
+        (37.5, 23): ([-2.590587e-02-8.665878e-02j, +2.708036e-03+5.134874e-02j, -1.941625e-02-2.573250e-02j],
+                     [+1.574257e-04-1.189295e-04j, -2.907987e-04+5.417262e-05j, +2.818347e-04-2.685509e-04j]),
+        (60, 90): ([-8.842906e-02-8.594352e-02j, +1.003573e-01+1.761610e-02j, +3.602543e-02+2.405003e-02j],
+                   [+1.221283e-05+2.995946e-06j, -2.656625e-06-1.709783e-06j, -8.886135e-06-5.124142e-06j]),
+        (90, 210.5): ([-1.269029e-01+1.461460e-02j, -5.967338e-02-1.055009e-01j, -5.873987e-02+5.973344e-02j],
+                      [+3.446606e-05+6.002938e-05j, -1.183580e-04+1.175912e-04j, +2.013560e-04+6.132837e-05j]),
+        (123.5, 305): ([-7.918571e-02-8.934022e-02j, +8.702471e-02+3.345755e-02j, +1.331035e-02+3.210945e-02j],
+                       [+3.802856e-05-1.812795e-05j, +4.049001e-06+8.622571e-05j, +2.272781e-05+5.639228e-05j]),
+        (155, 0): ([-5.953972e-03-6.378338e-02j, -1.432429e-02+2.617367e-02j, +6.947442e-03-2.467225e-02j],
+                   [0j, 0j, 0j]),  # phi = 0 deg is a symmetry plane of the VPol
+    },
+    (LPDA_MODEL, "lpda_upward"): {
+        (37.5, 23): ([-1.068917e-01-8.854878e-02j, +6.456348e-02+1.988244e-02j, -2.568530e-02-3.191559e-02j],
+                     [-3.351973e-01-2.703861e-01j, +1.753179e-01+6.223970e-02j, -7.659485e-02-7.037105e-02j]),
+        (60, 90): ([-1.642099e-01-3.257877e-02j, -3.529879e-02-4.871512e-02j, +3.237249e-02+1.902306e-03j],
+                   [+1.447680e-05+2.135807e-03j, +4.390991e-04-5.821575e-03j, -4.613082e-03+4.844393e-03j]),
+        (90, 210.5): ([+3.979433e-03-2.175291e-03j, +4.135918e-03-4.818399e-03j, +2.784129e-03+2.111465e-03j],
+                      [+1.905512e-01-1.162116e-01j, -1.094214e-01-3.755445e-02j, +5.116181e-02+5.014446e-02j]),
+        (123.5, 305): ([+1.268950e-03+7.560181e-02j, +1.419240e-02+2.498945e-02j, +1.103123e-03+4.780411e-03j],
+                       [+5.844797e-03+9.336023e-02j, +1.178195e-02+2.649801e-02j, +4.258309e-03+1.181137e-02j]),
+        (155, 0): ([+3.437651e-03+2.315606e-03j, +4.778114e-03+3.814342e-03j, +3.236993e-03-6.114700e-03j],
+                   [+7.007768e-02+9.615006e-02j, +8.457904e-03-2.404893e-02j, -1.340033e-02+1.534239e-02j]),
+    },
+    (LPDA_MODEL, "lpda_downward"): {
+        (37.5, 23): ([+9.051290e-02-3.526327e-02j, -2.480212e-02-2.824809e-02j, -9.357417e-03+2.250649e-02j],
+                     [+2.488400e-01-1.026628e-01j, -6.743154e-02-8.270836e-02j, -3.591645e-02+4.548868e-02j]),
+        (60, 90): ([+4.836059e-02-9.430870e-02j, -2.321073e-02+2.159825e-02j, -1.994126e-02+4.408564e-03j],
+                   [-2.455919e-03-1.801982e-04j, -2.495429e-03+3.725803e-03j, -3.037365e-03-3.058060e-04j]),
+        (90, 210.5): ([-1.141920e-03+2.875596e-03j, +1.441551e-03+5.620259e-03j, -7.757950e-04+9.037358e-05j],
+                      [+4.375625e-02+1.106481e-01j, +7.138241e-02+1.653943e-02j, -1.986827e-03-2.482480e-02j]),
+        (123.5, 305): ([+1.561782e-01+8.630120e-02j, -5.759123e-02+3.860100e-02j, +4.264417e-02-2.978903e-02j],
+                       [+2.027716e-01+1.103380e-01j, -7.621077e-02+4.369062e-02j, +4.538133e-02-3.746128e-02j]),
+        (155, 0): ([-3.502938e-03-3.873231e-03j, -3.386163e-03+1.696049e-03j, -5.015626e-03+3.593128e-03j],
+                   [+3.596386e-01+3.162327e-01j, -1.835327e-01-1.070991e-01j, +5.119614e-02+9.862683e-02j]),
+    },
+}
+
+
+def test_reference_vel():
+    """The interpolated VEL has to reproduce the hard-coded reference values"""
+    provider = AntennaPatternProvider()
+
+    for (model, orientation_name), reference in REFERENCE_VEL.items():
+        antenna = provider.load_antenna_pattern(model)
+        orientation = np.array(REFERENCE_ORIENTATIONS[orientation_name]) * units.deg
+
+        for (zenith, azimuth), expected in reference.items():
+            vel = antenna.get_antenna_response_vectorized(
+                REFERENCE_FREQUENCIES, zenith * units.deg, azimuth * units.deg, *orientation)
+
+            for component, reference_component in zip(["theta", "phi"], expected):
+                # the atol is only relevant for the components which are ~ 0 by symmetry
+                assert np.allclose(vel[component], reference_component,
+                                   rtol=1e-5, atol=1e-6 * units.m), \
+                    "{} ({}): VEL_{} at zenith = {} deg, azimuth = {} deg is\n{}\ninstead of\n{}".format(
+                        model, orientation_name, component, zenith, azimuth,
+                        np.array(vel[component]), np.array(reference_component))
+
+
+def test_lpda_beam_follows_orientation():
+    """Rotating the LPDA has to rotate its beam, not deform it"""
+    antenna = AntennaPatternProvider().load_antenna_pattern(LPDA_MODEL)
+    freqs = np.array([250.]) * units.MHz
+
+    # scan the plane phi = 0 deg / 180 deg, which contains both boresights. Negative signed
+    # zenith angles stand for azimuth = 180 deg.
+    signed_zeniths = np.arange(-179., 180., 1.)
+
+    peaks = []
+    for orientation_name in ["lpda_upward", "lpda_downward"]:
+        orientation = np.array(REFERENCE_ORIENTATIONS[orientation_name]) * units.deg
+        vel = [antenna.get_antenna_response_vectorized(
+            freqs, np.abs(zenith) * units.deg, np.pi * (zenith < 0), *orientation)
+            for zenith in signed_zeniths]
+        magnitude = np.array(
+            [np.hypot(np.abs(v["theta"]), np.abs(v["phi"])) for v in vel]).flatten()
+
+        # the beam of this model peaks 11 deg off the boresight
+        i_peak = np.argmax(magnitude)
+        boresight = REFERENCE_ORIENTATIONS[orientation_name][0]
+        assert np.abs(signed_zeniths[i_peak] - boresight) < 15, \
+            "{}: the beam peaks at a zenith angle of {:.0f} deg, the boresight is at {} deg".format(
+                orientation_name, signed_zeniths[i_peak], boresight)
+        peaks.append(magnitude[i_peak])
+
+    assert np.isclose(*peaks, rtol=1e-6), \
+        "the peak |VEL| changes with the orientation: {:.6f} vs {:.6f} m".format(*peaks)
+
+
 if __name__ == "__main__":
     without_antenna_file = [
         test_interpolate_linear, test_interpolate_linear_vectorized, test_get_bracketing_indices,
@@ -323,7 +440,8 @@ if __name__ == "__main__":
 
     with_antenna_file = [
         test_interpolation_at_nodes, test_magphase_agrees_at_nodes, test_phi_wrapping,
-        test_out_of_range, test_vel_is_continuous]
+        test_out_of_range, test_vel_is_continuous, test_reference_vel,
+        test_lpda_beam_follows_orientation]
 
     for test in without_antenna_file + with_antenna_file:
         print("{} ...".format(test.__name__))

--- a/NuRadioReco/detector/test/test_antennapattern.py
+++ b/NuRadioReco/detector/test/test_antennapattern.py
@@ -22,23 +22,6 @@ from NuRadioReco.utilities import units
 TEST_MODEL = "RNOG_vpol_4inch_center_n1.73"
 
 
-def expect_known_issue(func, description):
-    """
-    Run a check which documents a known defect, i.e. which is expected to fail
-
-    Raises if the check passes, which is the signal that the defect was fixed and that
-    the check should be turned into a regular assertion.
-    """
-    try:
-        func()
-    except AssertionError:
-        print("  known issue (still present): {}".format(description))
-        return
-
-    raise AssertionError(
-        "'{}' does not reproduce anymore, please turn it into a regular test".format(description))
-
-
 # --------------------------------------------------------------------------------------
 # interpolation helpers
 # --------------------------------------------------------------------------------------
@@ -140,7 +123,21 @@ def test_antenna_rotation():
                        antenna._rotation_theta, antenna._rotation_phi]
 
     # deploying the antenna exactly as it was simulated must not rotate anything
-    assert np.allclose(antenna._get_antenna_rotation(*own_orientation), np.eye(3))
+    rotation, inverse, polar_roll = antenna._get_antenna_rotation(*own_orientation)
+    assert np.allclose(rotation, np.eye(3)) and np.allclose(inverse, np.eye(3))
+    assert polar_roll, "the identity is a (zero) roll about the polar axis"
+
+    # a roll about the polar axis is cancelled by the shift of the azimuth it causes
+    for roll in [30 * units.deg, 90 * units.deg, 200 * units.deg]:
+        rolled = list(own_orientation)
+        rolled[3] += roll
+        _, _, polar_roll = antenna._get_antenna_rotation(*rolled)
+        assert polar_roll, "a roll of {:.0f} deg about the polar axis is not detected".format(
+            roll / units.deg)
+
+    # tilting the antenna is not
+    tilted = [45 * units.deg, 0., 135 * units.deg, 0.]
+    assert not antenna._get_antenna_rotation(*tilted)[2]
 
     for zenith, azimuth in [(30 * units.deg, 40 * units.deg), (120 * units.deg, 200 * units.deg)]:
         theta, phi = antenna._get_theta_and_phi(zenith, azimuth, *own_orientation)
@@ -296,13 +293,14 @@ def test_out_of_range():
     vel = antenna._get_antenna_response_vectorized_raw(freqs, 200 * units.deg, 0.)
     assert np.all(np.array(vel) == 0)
 
-    def shape_matches_frequencies():
-        vel = antenna._get_antenna_response_vectorized_raw(freqs, 200 * units.deg, 0.)
-        assert np.shape(vel)[1] == len(freqs)
+    # zeros still have to be returned per frequency, just like the in-range path
+    assert np.shape(vel) == (2, len(freqs))
 
-    # the in-range path returns one value per frequency, the out-of-range path a single one
-    expect_known_issue(shape_matches_frequencies,
-                       "out-of-range directions return shape (2, 1) instead of (2, n_freqs)")
+    # this model covers the full sphere, so the public method cannot reach the branch above
+    # (a zenith of 200 deg maps to theta = 160 deg, which is tabulated)
+    vel = antenna.get_antenna_response_vectorized(
+        freqs, 200 * units.deg, 0., 0, 0, np.pi / 2, np.pi / 2)
+    assert np.shape(vel["theta"]) == (len(freqs),)
 
 
 def test_vel_is_continuous():

--- a/NuRadioReco/detector/test/test_antennapattern.py
+++ b/NuRadioReco/detector/test/test_antennapattern.py
@@ -240,9 +240,8 @@ def test_provider_buffering():
     # `__init__` resets the buffer on every instantiation, so the pattern is loaded again
     expect_known_issue(buffer_survives_reinstantiation,
                        "AntennaPatternProvider() empties the buffer of the singleton")
-    # kwargs are ignored as soon as the model is buffered
-    expect_known_issue(kwargs_are_honoured,
-                       "load_antenna_pattern ignores kwargs for an already buffered model")
+
+    kwargs_are_honoured()
 
 
 # --------------------------------------------------------------------------------------

--- a/NuRadioReco/detector/test/test_antennapattern.py
+++ b/NuRadioReco/detector/test/test_antennapattern.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 """
-Tests for the antenna pattern interpolation.
+Tests for NuRadioReco.detector.antennapattern
+
+The tests are split into two groups: everything up to `test_provider_buffering` runs
+without any antenna model file, the tests after it need RNOG_vpol_4inch_center_n1.73
+(~10 MB, downloaded on first use).
 
 Regression test for the bracketing of non-equidistant grids: the antenna models are
 not required to be sampled on an equally spaced grid (e.g. RNOG_vpol_4inch_center_n1.73
@@ -11,8 +15,71 @@ discontinuities of up to 70 % in the vector effective length.
 import numpy as np
 
 from NuRadioReco.detector.antennapattern import (
-    AntennaPatternProvider, get_bracketing_indices, is_equidistant)
+    AntennaPattern, AntennaPatternAnalytic, AntennaPatternProvider, get_bracketing_indices,
+    get_group_delay, interpolate_linear, interpolate_linear_vectorized, is_equidistant)
 from NuRadioReco.utilities import units
+
+TEST_MODEL = "RNOG_vpol_4inch_center_n1.73"
+
+
+def expect_known_issue(func, description):
+    """
+    Run a check which documents a known defect, i.e. which is expected to fail
+
+    Raises if the check passes, which is the signal that the defect was fixed and that
+    the check should be turned into a regular assertion.
+    """
+    try:
+        func()
+    except AssertionError:
+        print("  known issue (still present): {}".format(description))
+        return
+
+    raise AssertionError(
+        "'{}' does not reproduce anymore, please turn it into a regular test".format(description))
+
+
+# --------------------------------------------------------------------------------------
+# interpolation helpers
+# --------------------------------------------------------------------------------------
+
+def test_interpolate_linear():
+    y0, y1 = 1 + 1j, 3 - 2j
+
+    for method in ["complex", "magphase"]:
+        # the endpoints have to be reproduced exactly by both methods
+        assert np.isclose(interpolate_linear(0., 0., 1., y0, y1, method), y0)
+        assert np.isclose(interpolate_linear(1., 0., 1., y0, y1, method), y1)
+
+    # complex interpolation is linear in real and imaginary part
+    assert np.isclose(interpolate_linear(0.5, 0., 1., y0, y1), 0.5 * (y0 + y1))
+
+    # magphase interpolation is linear in magnitude
+    mid = interpolate_linear(0.5, 0., 1., y0, y1, "magphase")
+    assert np.isclose(np.abs(mid), 0.5 * (np.abs(y0) + np.abs(y1)))
+
+    # a degenerate interval returns the first value
+    assert interpolate_linear(5., 1., 1., y0, y1) == y0
+
+    try:
+        interpolate_linear(0.5, 0., 1., y0, y1, "does_not_exist")
+    except NotImplementedError:
+        pass
+    else:
+        raise AssertionError("unknown interpolation method has to raise")
+
+
+def test_interpolate_linear_vectorized():
+    """The vectorized variant has to agree with the scalar one, including x0 == x1"""
+    x = np.array([0.5, 1.0, 2.0])
+    x0, x1 = np.array([0., 1., 2.]), np.array([1., 1., 3.])
+    y0 = np.array([1 + 0j, 5 + 0j, 2 + 2j])
+    y1 = np.array([3 + 0j, 9 + 0j, 4 + 4j])
+
+    for method in ["complex", "magphase"]:
+        vectorized = interpolate_linear_vectorized(x, x0, x1, y0, y1, method)
+        scalar = [interpolate_linear(x[i], x0[i], x1[i], y0[i], y1[i], method) for i in range(len(x))]
+        assert np.allclose(vectorized, scalar), "vectorized and scalar disagree for {}".format(method)
 
 
 def test_get_bracketing_indices():
@@ -24,7 +91,7 @@ def test_get_bracketing_indices():
             "wrong bracket for x = {}".format(x)
 
     # values on a node have to be bracketed such that the interpolation returns the node
-    for i, x in enumerate(nodes):
+    for x in nodes:
         i_lower, i_upper = get_bracketing_indices(x, nodes)
         assert nodes[i_lower] <= x <= nodes[i_upper]
         assert i_upper - i_lower <= 1
@@ -53,30 +120,237 @@ def test_equidistant_shortcut():
         assert np.all(grid[i_slow] == grid[i_fast])
 
 
-def test_vel_is_continuous():
-    """The interpolated VEL must not jump between two adjacent zenith angles"""
-    provider = AntennaPatternProvider()
-    antenna = provider.load_antenna_pattern("RNOG_vpol_4inch_center_n1.73")
+def test_get_group_delay():
+    """A pure delay has a constant group delay of exactly that delay"""
+    df = 10 * units.MHz
+    freqs = np.arange(0, 1000) * df
+    delay = 12.3 * units.ns
 
-    zeniths = np.arange(0, 180, 0.1) * units.deg
-    freq = np.array([200]) * units.MHz
+    group_delay = get_group_delay(np.exp(-1j * 2 * np.pi * freqs * delay), df)
+    assert np.allclose(group_delay, delay)
+
+
+# --------------------------------------------------------------------------------------
+# coordinate transformation (AntennaPatternBase)
+# --------------------------------------------------------------------------------------
+
+def test_antenna_rotation():
+    antenna = AntennaPatternAnalytic("analytic_LPDA")
+    own_orientation = [antenna._orientation_theta, antenna._orientation_phi,
+                       antenna._rotation_theta, antenna._rotation_phi]
+
+    # deploying the antenna exactly as it was simulated must not rotate anything
+    assert np.allclose(antenna._get_antenna_rotation(*own_orientation), np.eye(3))
+
+    for zenith, azimuth in [(30 * units.deg, 40 * units.deg), (120 * units.deg, 200 * units.deg)]:
+        theta, phi = antenna._get_theta_and_phi(zenith, azimuth, *own_orientation)
+        assert np.isclose(theta, zenith)
+        assert np.isclose(np.exp(1j * phi), np.exp(1j * azimuth))  # phi is returned in (-180, 180] deg
+
+    # orientation and rotation have to be perpendicular
+    try:
+        antenna._get_antenna_rotation(0., 0., 0., 0.)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("a degenerate antenna orientation has to raise")
+
+
+# --------------------------------------------------------------------------------------
+# analytic antenna models
+# --------------------------------------------------------------------------------------
+
+def test_analytic_patterns():
+    freqs = np.arange(50, 1001, 10) * units.MHz
+    zeniths = np.arange(0, 181, 10) * units.deg
+    azimuths = np.arange(0, 360, 30) * units.deg
+
+    for model, max_VEL in [("analytic_LPDA", 0.55 * units.m),
+                           ("analytic_VPol", 0.18 * units.m),
+                           ("analytic_HPol", 0.055 * units.m)]:
+        antenna = AntennaPatternAnalytic(model)
+        scaled = AntennaPatternAnalytic(model, max_VEL=2 * max_VEL)
+        orientation = [antenna._orientation_theta, antenna._orientation_phi,
+                       antenna._rotation_theta, antenna._rotation_phi]
+
+        peak, peak_scaled = 0, 0
+        for zenith in zeniths:
+            for azimuth in azimuths:
+                vel = antenna.get_antenna_response_vectorized(freqs, zenith, azimuth, *orientation)
+                assert np.all(np.isfinite(vel["theta"])) and np.all(np.isfinite(vel["phi"]))
+                assert len(vel["theta"]) == len(freqs)
+                peak = max(peak, np.abs(vel["theta"]).max(), np.abs(vel["phi"]).max())
+
+                vel = scaled.get_antenna_response_vectorized(freqs, zenith, azimuth, *orientation)
+                peak_scaled = max(peak_scaled, np.abs(vel["theta"]).max(), np.abs(vel["phi"]).max())
+
+        assert np.isclose(peak, max_VEL), \
+            "{}: peak |VEL| {:.4f} != max_VEL {:.4f}".format(model, peak, max_VEL)
+        assert np.isclose(peak_scaled, 2 * max_VEL), "{}: max_VEL is not applied".format(model)
+
+    # the cutoff frequency has to be picked up as well
+    default = AntennaPatternAnalytic("analytic_VPol")
+    shifted = AntennaPatternAnalytic("analytic_VPol", cutoff_freq=400 * units.MHz)
+    assert shifted._cutoff_freq == 400 * units.MHz
+    orientation = [default._orientation_theta, default._orientation_phi,
+                   default._rotation_theta, default._rotation_phi]
+    assert not np.allclose(
+        default.get_antenna_response_vectorized(freqs, 90 * units.deg, 0., *orientation)["theta"],
+        shifted.get_antenna_response_vectorized(freqs, 90 * units.deg, 0., *orientation)["theta"])
+
+
+def test_parametric_phase():
+    antenna = AntennaPatternAnalytic("analytic_LPDA")
+    freqs = np.linspace(50, 1000, 100) * units.MHz
+
+    for phase_type in ["frontlobe_lpda", "side_lpda", "back_lpda", "theoretical",
+                       "VPol_third_order", "HPol_third_order"]:
+        phase = antenna.parametric_phase(freqs, phase_type)
+        assert np.shape(phase) == np.shape(freqs)
+        assert np.all(np.isfinite(phase)), "{} returns non-finite values".format(phase_type)
+
+
+# --------------------------------------------------------------------------------------
+# AntennaPatternProvider
+# --------------------------------------------------------------------------------------
+
+def test_provider_buffering():
+    provider = AntennaPatternProvider()
+
+    # the provider is a singleton and buffers the (expensive to load) patterns
+    assert AntennaPatternProvider() is provider
+    antenna = provider.load_antenna_pattern("analytic_LPDA")
+    assert provider.load_antenna_pattern("analytic_LPDA") is antenna
+
+    # names starting with "analytic" are dispatched to the analytic implementation
+    assert isinstance(antenna, AntennaPatternAnalytic)
+
+    def buffer_survives_reinstantiation():
+        provider = AntennaPatternProvider()
+        antenna = provider.load_antenna_pattern("analytic_LPDA")
+        AntennaPatternProvider()  # __init__ runs again on the singleton
+        assert provider.load_antenna_pattern("analytic_LPDA") is antenna
+
+    def kwargs_are_honoured():
+        provider = AntennaPatternProvider()
+        provider.load_antenna_pattern("analytic_LPDA")
+        antenna = provider.load_antenna_pattern("analytic_LPDA", max_VEL=1 * units.m)
+        assert antenna._max_VEL == 1 * units.m
+
+    # `__init__` resets the buffer on every instantiation, so the pattern is loaded again
+    expect_known_issue(buffer_survives_reinstantiation,
+                       "AntennaPatternProvider() empties the buffer of the singleton")
+    # kwargs are ignored as soon as the model is buffered
+    expect_known_issue(kwargs_are_honoured,
+                       "load_antenna_pattern ignores kwargs for an already buffered model")
+
+
+# --------------------------------------------------------------------------------------
+# AntennaPattern, these need the antenna model file
+# --------------------------------------------------------------------------------------
+
+def test_interpolation_at_nodes():
+    """At a grid node the interpolation has to return the tabulated value"""
+    antenna = AntennaPattern(TEST_MODEL)
+
+    for i_freq in [0, 100, antenna.n_freqs - 1]:
+        for i_theta in range(antenna.n_theta):
+            for i_phi in range(0, antenna.n_phi, 3):
+                index = antenna._get_index(i_freq, i_theta, i_phi)
+                vel = antenna._get_antenna_response_vectorized_raw(
+                    np.array([antenna.frequencies[i_freq]]),
+                    antenna.theta_angles[i_theta], antenna.phi_angles[i_phi])
+
+                assert np.allclose(vel[0], antenna.VEL_theta[index], atol=1e-15)
+                assert np.allclose(vel[1], antenna.VEL_phi[index], atol=1e-15)
+
+
+def test_magphase_agrees_at_nodes():
+    """Both interpolation methods are only allowed to differ in between the nodes"""
+    complex_ = AntennaPattern(TEST_MODEL, interpolation_method="complex")
+    magphase = AntennaPattern(TEST_MODEL, interpolation_method="magphase")
+    freqs = np.array([complex_.frequencies[100]])
+
+    for i_theta in range(complex_.n_theta):
+        for i_phi in range(0, complex_.n_phi, 3):
+            theta, phi = complex_.theta_angles[i_theta], complex_.phi_angles[i_phi]
+            assert np.allclose(
+                np.array(complex_._get_antenna_response_vectorized_raw(freqs, theta, phi)),
+                np.array(magphase._get_antenna_response_vectorized_raw(freqs, theta, phi)),
+                atol=1e-15)
+
+
+def test_phi_wrapping():
+    """Azimuth angles outside the tabulated range are wrapped, not clipped"""
+    antenna = AntennaPatternProvider().load_antenna_pattern(TEST_MODEL)
+    freqs = np.array([200., 300.]) * units.MHz
     orientation = [0, 0, np.pi / 2, np.pi / 2]
 
-    for azimuth in np.arange(0, 360, 20) * units.deg:
-        vel = np.array([np.abs(antenna.get_antenna_response_vectorized(
-            freq, zenith, azimuth, *orientation)["theta"]) for zenith in zeniths]).flatten()
+    for azimuth in [30, 100, 200]:
+        inside = antenna.get_antenna_response_vectorized(
+            freqs, 1., azimuth * units.deg, *orientation)
+        wrapped = antenna.get_antenna_response_vectorized(
+            freqs, 1., (azimuth - 360) * units.deg, *orientation)
 
-        steps = np.abs(np.diff(vel))
-        # a smooth curve on this fine a grid stays close to its typical step size
-        assert steps.max() < 10 * np.median(steps), \
-            "VEL jumps by {:.2e} at zenith = {:.1f} deg (azimuth = {:.0f} deg), " \
-            "typical step is {:.2e}".format(
-                steps.max(), zeniths[np.argmax(steps)] / units.deg,
-                azimuth / units.deg, np.median(steps))
+        for component in ["theta", "phi"]:
+            assert np.allclose(inside[component], wrapped[component]), \
+                "azimuth {} deg and {} deg give different responses".format(azimuth, azimuth - 360)
+
+
+def test_out_of_range():
+    """Directions outside the tabulated range return zeros"""
+    antenna = AntennaPattern(TEST_MODEL)
+    freqs = np.array([200., 300., 400.]) * units.MHz
+
+    vel = antenna._get_antenna_response_vectorized_raw(freqs, 200 * units.deg, 0.)
+    assert np.all(np.array(vel) == 0)
+
+    def shape_matches_frequencies():
+        vel = antenna._get_antenna_response_vectorized_raw(freqs, 200 * units.deg, 0.)
+        assert np.shape(vel)[1] == len(freqs)
+
+    # the in-range path returns one value per frequency, the out-of-range path a single one
+    expect_known_issue(shape_matches_frequencies,
+                       "out-of-range directions return shape (2, 1) instead of (2, n_freqs)")
+
+
+def test_vel_is_continuous():
+    """The interpolated VEL must not jump between two adjacent zenith angles"""
+    antenna = AntennaPatternProvider().load_antenna_pattern(TEST_MODEL)
+
+    # the theta/phi unit vectors are degenerate at the poles, stay away from them
+    zeniths = np.arange(1, 179, 0.1) * units.deg
+    orientation = [0, 0, np.pi / 2, np.pi / 2]
+
+    for freq in np.array([100., 200., 600.]) * units.MHz:
+        for azimuth in np.arange(0, 360, 45) * units.deg:
+            response = [antenna.get_antenna_response_vectorized(
+                np.array([freq]), zenith, azimuth, *orientation) for zenith in zeniths]
+
+            for component in ["theta", "phi"]:
+                vel = np.abs(np.array([r[component] for r in response])).flatten()
+                steps = np.abs(np.diff(vel))
+
+                # a smooth curve on this fine a grid stays close to its typical step size
+                assert steps.max() < 10 * np.median(steps), \
+                    "VEL_{} jumps by {:.2e} at zenith = {:.1f} deg (azimuth = {:.0f} deg, " \
+                    "{:.0f} MHz), typical step is {:.2e}".format(
+                        component, steps.max(), zeniths[np.argmax(steps)] / units.deg,
+                        azimuth / units.deg, freq / units.MHz, np.median(steps))
 
 
 if __name__ == "__main__":
-    test_get_bracketing_indices()
-    test_equidistant_shortcut()
-    test_vel_is_continuous()
-    print("Antenna pattern tests passed")
+    without_antenna_file = [
+        test_interpolate_linear, test_interpolate_linear_vectorized, test_get_bracketing_indices,
+        test_equidistant_shortcut, test_get_group_delay, test_antenna_rotation,
+        test_analytic_patterns, test_parametric_phase, test_provider_buffering]
+
+    with_antenna_file = [
+        test_interpolation_at_nodes, test_magphase_agrees_at_nodes, test_phi_wrapping,
+        test_out_of_range, test_vel_is_continuous]
+
+    for test in without_antenna_file + with_antenna_file:
+        print("{} ...".format(test.__name__))
+        test()
+
+    print("\nAntenna pattern tests passed")

--- a/NuRadioReco/detector/test/test_antennapattern.py
+++ b/NuRadioReco/detector/test/test_antennapattern.py
@@ -22,23 +22,6 @@ from NuRadioReco.utilities import units
 TEST_MODEL = "RNOG_vpol_4inch_center_n1.73"
 
 
-def expect_known_issue(func, description):
-    """
-    Run a check which documents a known defect, i.e. which is expected to fail
-
-    Raises if the check passes, which is the signal that the defect was fixed and that
-    the check should be turned into a regular assertion.
-    """
-    try:
-        func()
-    except AssertionError:
-        print("  known issue (still present): {}".format(description))
-        return
-
-    raise AssertionError(
-        "'{}' does not reproduce anymore, please turn it into a regular test".format(description))
-
-
 # --------------------------------------------------------------------------------------
 # interpolation helpers
 # --------------------------------------------------------------------------------------
@@ -225,24 +208,16 @@ def test_provider_buffering():
     # names starting with "analytic" are dispatched to the analytic implementation
     assert isinstance(antenna, AntennaPatternAnalytic)
 
-    def buffer_survives_reinstantiation():
-        provider = AntennaPatternProvider()
-        antenna = provider.load_antenna_pattern("analytic_LPDA")
-        AntennaPatternProvider()  # __init__ runs again on the singleton
-        assert provider.load_antenna_pattern("analytic_LPDA") is antenna
+    # instantiating the provider again must not throw away the buffered patterns
+    AntennaPatternProvider()
+    assert provider.load_antenna_pattern("analytic_LPDA") is antenna
 
-    def kwargs_are_honoured():
-        provider = AntennaPatternProvider()
-        provider.load_antenna_pattern("analytic_LPDA")
-        antenna = provider.load_antenna_pattern("analytic_LPDA", max_VEL=1 * units.m)
-        assert antenna._max_VEL == 1 * units.m
-
-    # `__init__` resets the buffer on every instantiation, so the pattern is loaded again
-    expect_known_issue(buffer_survives_reinstantiation,
-                       "AntennaPatternProvider() empties the buffer of the singleton")
-    # kwargs are ignored as soon as the model is buffered
-    expect_known_issue(kwargs_are_honoured,
-                       "load_antenna_pattern ignores kwargs for an already buffered model")
+    # kwargs are part of the identity of a pattern and must not be served from the buffer
+    configured = provider.load_antenna_pattern("analytic_LPDA", max_VEL=1 * units.m)
+    assert configured._max_VEL == 1 * units.m
+    assert configured is not antenna
+    assert provider.load_antenna_pattern("analytic_LPDA", max_VEL=1 * units.m) is configured
+    assert provider.load_antenna_pattern("analytic_LPDA") is antenna
 
 
 # --------------------------------------------------------------------------------------
@@ -305,13 +280,14 @@ def test_out_of_range():
     vel = antenna._get_antenna_response_vectorized_raw(freqs, 200 * units.deg, 0.)
     assert np.all(np.array(vel) == 0)
 
-    def shape_matches_frequencies():
-        vel = antenna._get_antenna_response_vectorized_raw(freqs, 200 * units.deg, 0.)
-        assert np.shape(vel)[1] == len(freqs)
+    # zeros still have to be returned per frequency, just like the in-range path
+    assert np.shape(vel) == (2, len(freqs))
 
-    # the in-range path returns one value per frequency, the out-of-range path a single one
-    expect_known_issue(shape_matches_frequencies,
-                       "out-of-range directions return shape (2, 1) instead of (2, n_freqs)")
+    # this model covers the full sphere, so the public method cannot reach the branch above
+    # (a zenith of 200 deg maps to theta = 160 deg, which is tabulated)
+    vel = antenna.get_antenna_response_vectorized(
+        freqs, 200 * units.deg, 0., 0, 0, np.pi / 2, np.pi / 2)
+    assert np.shape(vel["theta"]) == (len(freqs),)
 
 
 def test_vel_is_continuous():

--- a/NuRadioReco/detector/test/test_antennapattern.py
+++ b/NuRadioReco/detector/test/test_antennapattern.py
@@ -249,8 +249,8 @@ def test_interpolation_at_nodes():
                     np.array([antenna.frequencies[i_freq]]),
                     antenna.theta_angles[i_theta], antenna.phi_angles[i_phi])
 
-                assert np.allclose(vel[0], antenna.VEL_theta[i_freq, i_phi, i_theta], atol=1e-15)
-                assert np.allclose(vel[1], antenna.VEL_phi[i_freq, i_phi, i_theta], atol=1e-15)
+                assert np.allclose(vel[0], antenna._vel[0, i_freq, i_phi, i_theta], atol=1e-15)
+                assert np.allclose(vel[1], antenna._vel[1, i_freq, i_phi, i_theta], atol=1e-15)
 
 
 def test_magphase_agrees_at_nodes():

--- a/NuRadioReco/detector/test/test_antennapattern.py
+++ b/NuRadioReco/detector/test/test_antennapattern.py
@@ -225,23 +225,16 @@ def test_provider_buffering():
     # names starting with "analytic" are dispatched to the analytic implementation
     assert isinstance(antenna, AntennaPatternAnalytic)
 
-    def buffer_survives_reinstantiation():
-        provider = AntennaPatternProvider()
-        antenna = provider.load_antenna_pattern("analytic_LPDA")
-        AntennaPatternProvider()  # __init__ runs again on the singleton
-        assert provider.load_antenna_pattern("analytic_LPDA") is antenna
+    provider = AntennaPatternProvider()
+    antenna = provider.load_antenna_pattern("analytic_LPDA")
+    AntennaPatternProvider()  # __init__ runs again on the singleton
+    assert provider.load_antenna_pattern("analytic_LPDA") is antenna
 
-    def kwargs_are_honoured():
-        provider = AntennaPatternProvider()
-        provider.load_antenna_pattern("analytic_LPDA")
-        antenna = provider.load_antenna_pattern("analytic_LPDA", max_VEL=1 * units.m)
-        assert antenna._max_VEL == 1 * units.m
+    provider = AntennaPatternProvider()
+    provider.load_antenna_pattern("analytic_LPDA")
+    antenna = provider.load_antenna_pattern("analytic_LPDA", max_VEL=1 * units.m)
+    assert antenna._max_VEL == 1 * units.m
 
-    # `__init__` resets the buffer on every instantiation, so the pattern is loaded again
-    expect_known_issue(buffer_survives_reinstantiation,
-                       "AntennaPatternProvider() empties the buffer of the singleton")
-
-    kwargs_are_honoured()
 
 
 # --------------------------------------------------------------------------------------

--- a/NuRadioReco/modules/custom/deltaT/calculateAmplitudePerRaySolution.py
+++ b/NuRadioReco/modules/custom/deltaT/calculateAmplitudePerRaySolution.py
@@ -55,7 +55,7 @@ class calculateAmplitudePerRaySolution:
 
                 # get antenna pattern for current channel
                 antenna_model = det.get_antenna_model(sim_station_id, channel_id, zenith)
-                antenna_pattern = self.antenna_provider.load_antenna_pattern(antenna_model, interpolation_method='complex')
+                antenna_pattern = self.antenna_provider.load_antenna_pattern(antenna_model)
                 ori = det.get_antenna_orientation(sim_station_id, channel_id)
                 logger.debug("zen {:.0f}, az {:.0f}".format(zenith / units.deg, azimuth / units.deg))
                 VEL = antenna_pattern.get_antenna_response_vectorized(ff, zenith, azimuth, *ori)

--- a/changelog.txt
+++ b/changelog.txt
@@ -36,12 +36,12 @@ from the NOAA ETOPO1 dataset via www.opentopodata.org.
   stored in `AntennaPattern._vel`.
 
 bugfixes:
+- The orientation stored in an antenna model is corrected when it is not exactly perpendicular, i.e. when the two
+  directions are less than 0.1 deg off (RNOG_vpol_4inch_center_n1.73 and RNOG_vpol_v1_n1.73 store 89.9544 deg instead
+  of 90 deg, all other models are exact). Otherwise the transformation between the simulated and the deployed antenna
+  coordinate system is not a rotation and rescales the vector effective length, for the two models above by up to 8e-4.
 - Fixing bug in the simulation of non-trigger channels when an event is splitted into multiple events based on the signal arrival time.
   This is only relevant when simulating primaries and large detector arrays.
-- The basis defined by the antenna orientation is now orthonormalised. The two directions are only required to be almost
-  perpendicular, so the transformation between the simulated and the deployed antenna coordinate system was not a rotation
-  and rescaled the vector effective length slightly. The orientation stored in RNOG_vpol_4inch_center_n1.73 is 0.05 deg off
-  perpendicular, which changes its response by up to 8e-4 relative. All other antenna models are unaffected (< 1e-14).
 - `AntennaPatternProvider` no longer discards its buffer of loaded antenna models when it is instantiated a second time,
   which caused the (large) antenna model files to be read from disk again.
 - `AntennaPatternProvider.load_antenna_pattern` no longer ignores the keyword arguments (e.g. interpolation_method, max_VEL)

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,8 +22,9 @@ from the NOAA ETOPO1 dataset via www.opentopodata.org.
 - Improve time_logger functionality - yielding significant reduction in simulation time (25-40%). Smaller improvements to logging.
 - The antenna response interpolation collapses the two angular axes before the frequency axis and only over the frequency
   nodes that are actually requested. Theta and phi have a single pair of bracketing nodes while every requested frequency
-  has its own, so this interpolates a few hundred grid points instead of 8 per frequency bin: ~1.9x faster for a 2048
-  sample trace, results are unchanged (bit identical).
+  has its own, so this interpolates a few hundred grid points instead of 8 per frequency bin. The frequency axis is then
+  interpolated with np.interp (for the default 'complex' interpolation), which brackets the whole vector at once in C.
+  Together ~2.4x faster for a 2048 sample trace, results agree to 1e-15.
 - The rotation of the vector effective length into the NuRadio on-sky system is skipped when the antenna is only rolled
   about the polar axis (i.e. for vertically oriented Vpols/Hpols and upward facing LPDAs), where it is the identity for
   every direction. This is ~8-15% of the antenna response lookup and applies to 126 of the 168 channels of RNO_season_2023.

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,9 @@ from the NOAA ETOPO1 dataset via www.opentopodata.org.
 - Likelihood-based reconstruction modules, including minimization and matched filter classes. Specialized reconstruction modules for electric fields and
   in-ice neutrino showers are implemeted. See https://arxiv.org/abs/2510.21925 and documentation for details.
 - Improve time_logger functionality - yielding significant reduction in simulation time (25-40%). Smaller improvements to logging.
+- The rotation of the vector effective length into the NuRadio on-sky system is skipped when the antenna is only rolled
+  about the polar axis (i.e. for vertically oriented Vpols/Hpols and upward facing LPDAs), where it is the identity for
+  every direction. This is ~8-15% of the antenna response lookup and applies to 126 of the 168 channels of RNO_season_2023.
 - Refactored the antenna pattern classes: the vector effective length is now stored as a (frequency, phi, theta) cube and
   interpolated with array operations, and the coordinate transformations are reduced to the rotations actually needed and
   buffered. The antenna response lookup is 2-6x faster depending on the number of frequency bins, results are unchanged.
@@ -27,6 +30,10 @@ from the NOAA ETOPO1 dataset via www.opentopodata.org.
 bugfixes:
 - Fixing bug in the simulation of non-trigger channels when an event is splitted into multiple events based on the signal arrival time.
   This is only relevant when simulating primaries and large detector arrays.
+- The basis defined by the antenna orientation is now orthonormalised. The two directions are only required to be almost
+  perpendicular, so the transformation between the simulated and the deployed antenna coordinate system was not a rotation
+  and rescaled the vector effective length slightly. The orientation stored in RNOG_vpol_4inch_center_n1.73 is 0.05 deg off
+  perpendicular, which changes its response by up to 8e-4 relative. All other antenna models are unaffected (< 1e-14).
 - `AntennaPatternProvider` no longer discards its buffer of loaded antenna models when it is instantiated a second time,
   which caused the (large) antenna model files to be read from disk again.
 - `AntennaPatternProvider.load_antenna_pattern` no longer ignores the keyword arguments (e.g. interpolation_method, max_VEL)

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,10 +20,17 @@ from the NOAA ETOPO1 dataset via www.opentopodata.org.
 - Likelihood-based reconstruction modules, including minimization and matched filter classes. Specialized reconstruction modules for electric fields and
   in-ice neutrino showers are implemeted. See https://arxiv.org/abs/2510.21925 and documentation for details.
 - Improve time_logger functionality - yielding significant reduction in simulation time (25-40%). Smaller improvements to logging.
+- Refactored the antenna pattern classes: the vector effective length is now stored as a (frequency, phi, theta) cube and
+  interpolated with array operations, and the coordinate transformations are reduced to the rotations actually needed and
+  buffered. The antenna response lookup is 2-6x faster depending on the number of frequency bins, results are unchanged.
 
 bugfixes:
 - Fixing bug in the simulation of non-trigger channels when an event is splitted into multiple events based on the signal arrival time.
   This is only relevant when simulating primaries and large detector arrays.
+- `AntennaPatternProvider` no longer discards its buffer of loaded antenna models when it is instantiated a second time,
+  which caused the (large) antenna model files to be read from disk again.
+- Fixing the 'magphase' interpolation of the antenna response, which unwrapped the phase along the frequency axis instead
+  of between the two data points that are interpolated. The default 'complex' interpolation is unaffected.
 - Fixing the interpolation of antenna models which are not sampled on an equally spaced grid. The node indices were calculated
   from the grid boundaries, which silently picked the wrong nodes and extrapolated. Only RNOG_vpol_4inch_center_n1.73 (used in all
   RNO_G detector descriptions) is affected, where the vector effective length was off by up to 70% at some zenith angles.

--- a/changelog.txt
+++ b/changelog.txt
@@ -32,6 +32,8 @@ from the NOAA ETOPO1 dataset via www.opentopodata.org.
 - Refactored the antenna pattern classes: the vector effective length is now stored as a (frequency, phi, theta) cube and
   interpolated with array operations, and the coordinate transformations are reduced to the rotations actually needed and
   buffered. The antenna response lookup is 2-6x faster depending on the number of frequency bins, results are unchanged.
+  The `AntennaPattern.VEL`, `AntennaPattern.VEL_theta` and `AntennaPattern.VEL_phi` attributes are deprecated, the cube is
+  stored in `AntennaPattern._vel`.
 
 bugfixes:
 - Fixing bug in the simulation of non-trigger channels when an event is splitted into multiple events based on the signal arrival time.

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,10 @@ from the NOAA ETOPO1 dataset via www.opentopodata.org.
 - Likelihood-based reconstruction modules, including minimization and matched filter classes. Specialized reconstruction modules for electric fields and
   in-ice neutrino showers are implemeted. See https://arxiv.org/abs/2510.21925 and documentation for details.
 - Improve time_logger functionality - yielding significant reduction in simulation time (25-40%). Smaller improvements to logging.
+- The antenna response interpolation collapses the two angular axes before the frequency axis and only over the frequency
+  nodes that are actually requested. Theta and phi have a single pair of bracketing nodes while every requested frequency
+  has its own, so this interpolates a few hundred grid points instead of 8 per frequency bin: ~1.9x faster for a 2048
+  sample trace, results are unchanged (bit identical).
 - The rotation of the vector effective length into the NuRadio on-sky system is skipped when the antenna is only rolled
   about the polar axis (i.e. for vertically oriented Vpols/Hpols and upward facing LPDAs), where it is the identity for
   every direction. This is ~8-15% of the antenna response lookup and applies to 126 of the 168 channels of RNO_season_2023.

--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,9 @@ bugfixes:
   This is only relevant when simulating primaries and large detector arrays.
 - `AntennaPatternProvider` no longer discards its buffer of loaded antenna models when it is instantiated a second time,
   which caused the (large) antenna model files to be read from disk again.
+- `AntennaPatternProvider.load_antenna_pattern` no longer ignores the keyword arguments (e.g. interpolation_method, max_VEL)
+  when the antenna model is already buffered, i.e. it returned a pattern configured differently than requested. The arguments
+  are now part of the buffer key and loading a second variant of the same model is logged.
 - Fixing the 'magphase' interpolation of the antenna response, which unwrapped the phase along the frequency axis instead
   of between the two data points that are interpolated. The default 'complex' interpolation is unaffected.
 - Fixing the interpolation of antenna models which are not sampled on an equally spaced grid. The node indices were calculated

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,7 +24,8 @@ from the NOAA ETOPO1 dataset via www.opentopodata.org.
   nodes that are actually requested. Theta and phi have a single pair of bracketing nodes while every requested frequency
   has its own, so this interpolates a few hundred grid points instead of 8 per frequency bin. The frequency axis is then
   interpolated with np.interp (for the default 'complex' interpolation), which brackets the whole vector at once in C.
-  Together ~2.4x faster for a 2048 sample trace, results agree to 1e-15.
+  The bilinear interpolation of the two angular axes is written as a single weighted sum of the four corners. Together
+  ~3x faster for a 2048 sample trace, results agree to 1e-15.
 - The rotation of the vector effective length into the NuRadio on-sky system is skipped when the antenna is only rolled
   about the polar axis (i.e. for vertically oriented Vpols/Hpols and upward facing LPDAs), where it is the identity for
   every direction. This is ~8-15% of the antenna response lookup and applies to 126 of the 168 channels of RNO_season_2023.

--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,11 @@ bugfixes:
 - Fixing the interpolation of antenna models which are not sampled on an equally spaced grid. The node indices were calculated
   from the grid boundaries, which silently picked the wrong nodes and extrapolated. Only RNOG_vpol_4inch_center_n1.73 (used in all
   RNO_G detector descriptions) is affected, where the vector effective length was off by up to 70% at some zenith angles.
+- The AntennaPatternProvider buffer is no longer emptied every time the (singleton) provider is instantiated. Antenna models
+  were reloaded from disk whenever another module created its own provider.
+- The AntennaPatternProvider no longer ignores the keyword arguments (e.g. interpolation_method, max_VEL) when the antenna
+  model is already buffered. They are now part of the buffer key.
+- Antenna responses for directions outside the tabulated range return one value per frequency instead of a single value.
 
 deprecations:
 - Remove default values for `use_channels` and `bandpass` in voltageToAnalyticEfieldConverter.py and voltageToEfieldConverter.py which were suitable for ARIANNA.


### PR DESCRIPTION
This PR aims at make the class more readable and maintainable, faster, and more secure.

It fixes bugs on the way...

Based on PR #1148 

# Summary:

## Readability:

- store the VEL as a (n_freqs, n_phi, n_theta) cube instead of a flat array with a
  hand-rolled index formula, which replaces the 12 hand-written interpolate_linear
  calls by three collapses of the interpolation cell
- merge interpolate_linear and interpolate_linear_vectorized, they only differed in
  how they handled coincident data points (the latter name is kept as an alias)
- collapse the three identical orientation blocks of AntennaPatternAnalytic into a
  table of per-model defaults, and factor the shared gain -> VEL conversion out of
  its three model branches
- turn the 123k iteration python loop checking the ordering of the antenna file into
  three array comparisons, and document what it does (and does not) check
- fill in the empty docstrings, drop dead debug code

## Speed (antenna response lookup, 2 - 6x faster depending on the number of frequencies):

- build only the on-sky rotation instead of a full radiotools cstrafo, which
  constructs (and inverts) five transformation matrices of which one is used
- buffer the antenna rotation matrix and its inverse, they only depend on the
  orientation of the antenna, of which a detector has very few
- combine the three coordinate rotations into one and apply only the eTheta/ePhi
  block of it, the eR component of the VEL is zero

## Bugfixes:

- AntennaPatternProvider.__init__ reset the buffer of loaded antenna models on every
  instantiation, so a second AntennaPatternProvider() forced a reload from disk
- the 'magphase' interpolation unwrapped the phase along the frequency axis instead
  of between the two data points being interpolated
- an unknown analytic antenna model now raises instead of returning a half
  initialized object

Verified against the previous implementation for 7 antenna models, 3 orientations and
486 directions each (incl. out of band frequencies and out of range directions): the
response agrees to 1e-14 relative.